### PR TITLE
Add a shell script for running the tests

### DIFF
--- a/README
+++ b/README
@@ -10,3 +10,7 @@ home directory. For example, "~/src/switch_py" will not work, but
 "/home/username/src/switch_py" will work.
 
 export PYTHONPATH="${PYTHONPATH}:/absolute/path/to/switch_py"
+
+To run the tests, do:
+
+./run_tests.sh

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+
+set -o errexit -o nounset
+
+# Allow this script to be run from any directory for convenience.
+cd "$(dirname "$0")"
+
+# Add switch_mod to PYTHONPATH for convenience.
+export PYTHONPATH="$(pwd):${PYTHONPATH:-}"
+
+# The doctests expect to be run from the "switch_mod" directory in
+# order to find test_dat.
+cd switch_mod
+
+failed=0
+for module in $(find . -name "*.py" | sort); do
+  echo "$module"
+  if ! python -m doctest "$module"; then
+    failed=1
+  fi
+done
+
+if [ $failed = 0 ]; then
+  echo PASS
+else
+  echo FAIL
+fi
+exit $failed


### PR DESCRIPTION
Hi Josiah,

This is based on the shell script you sent me.  I added some error handling so that the script returns an error status if the tests fail.  For convenience I also made it set PYTHONPATH and the current directory.

There was a problem with running one of the tests you added in the last week (switch_mod/project/unitcommit/discrete.py).  It looks like there might be a discrepancy about which directory it expects to be run from?

Cheers,
Mark
