### PR TITLE
Fix NameError in a test in switch_mod.utilities

### DIFF
--- a/switch_mod/utilities.py
+++ b/switch_mod/utilities.py
@@ -244,7 +244,7 @@ def check_mandatory_components(model, *mandatory_model_components):
     This does not work with indexed sets.
 
     EXAMPLE:
-    >>> from switch_mod.utilities import define_AbstractModel
+    >>> import switch_mod.utilities as utilities
     >>> mod = ConcreteModel()
     >>> mod.set_A = Set(initialize=[1,2])
     >>> mod.paramA_full = Param(mod.set_A, initialize={1:'a',2:'b'})


### PR DESCRIPTION
Change 94e732c2528621649ff16c6e6eeb3325f69ad71c caused a doctest in
utilities.py to fail with:
  NameError: name 'utilities' is not defined
