### PR TITLE
Test runner: Add a "tests" subdir with an example unittest test case

### DIFF
--- a/run_tests.py
+++ b/run_tests.py
@@ -8,18 +8,37 @@ import sys
 import unittest
 
 
-# The unittest module does not have built-in support for finding
-# doctests.  In order to run the doctests, we need a custom TestLoader
-# that overrides loadTestsFromModule().
 class TestLoader(unittest.TestLoader):
 
+    # unittest.main does not allow multiple "--start-directory"
+    # options, but we can make it scan multiple separate directories
+    # by overriding discover().  This allows us to have a "tests"
+    # directory that's separate from "switch_mod".
+    #
+    # We don't want to scan for *.py files in the parent directory in
+    # case any of those are throwaway scripts that have unexpected
+    # effects when imported.
+    def discover(self, start_dir, pattern, top_level_dir):
+        test_suite = unittest.TestSuite()
+        for subdir in ('switch_mod', 'tests'):
+            test_suite.addTests(
+                super(TestLoader, self).discover(
+                    os.path.join(top_level_dir, subdir),
+                    pattern, top_level_dir))
+        return test_suite
+
+    # The unittest module does not have built-in support for finding
+    # doctests.  In order to run the doctests, we need a custom
+    # TestLoader that overrides loadTestsFromModule().
     def loadTestsFromModule(self, module):
+        test_suite = super(TestLoader, self).loadTestsFromModule(module)
+
         docstring = module.__doc__
         if not docstring:
             # Work around a misfeature whereby doctest complains if a
             # module contains no docstrings.
             module.__doc__ = 'Placeholder docstring'
-        test_suite = doctest.DocTestSuite(module)
+        test_suite.addTests(doctest.DocTestSuite(module))
         if not docstring:
             # Restore the original, in case this matters.
             module.__doc__ = docstring
@@ -35,7 +54,6 @@ def main():
 
     argv = [sys.argv[0],
             'discover',
-            '--start-directory', os.path.join(script_dir, 'switch_mod'),
             '--top-level-dir', script_dir,
             '--pattern', '*.py'] + sys.argv[1:]
     unittest.TestProgram(testLoader=TestLoader(), argv=argv)

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,2 @@
+# Copyright 2015 The Switch Authors. All rights reserved.
+# Licensed under the Apache License, Version 2, which is in the LICENSE file.

--- a/tests/utilities_test.py
+++ b/tests/utilities_test.py
@@ -1,0 +1,19 @@
+# Copyright 2015 The Switch Authors. All rights reserved.
+# Licensed under the Apache License, Version 2, which is in the LICENSE file.
+
+import unittest
+
+import switch_mod.utilities as utilities
+
+
+class UtilitiesTest(unittest.TestCase):
+
+    def test_approx_equal(self):
+        assert not utilities.approx_equal(1, 2)
+        assert not utilities.approx_equal(1, 1.02)
+        assert utilities.approx_equal(1, 1.01)
+        assert utilities.approx_equal(1, 1)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Change run_tests.py to look for tests in the "tests" subdir, and to
find unittests as well as doctests.