### PR TITLE
Change solve.py examples to use the GLPK solver instead of CPLEX

### DIFF
--- a/examples/3zone_toy/solve.py
+++ b/examples/3zone_toy/solve.py
@@ -16,15 +16,15 @@ directory is in your python search path. See the README for more info.
 """
 
 from pyomo.environ import *
-from pyomo.opt import SolverFactory
 from switch_mod.utilities import define_AbstractModel
+import switch_mod.utilities
 
 switch_model = define_AbstractModel(
     'switch_mod', 'local_td', 'project.no_commit', 'fuel_markets',
     'trans_build', 'trans_dispatch')
 switch_instance = switch_model.load_inputs(inputs_dir="inputs")
 
-opt = SolverFactory("cplex")
+opt = switch_mod.utilities.default_solver()
 results = opt.solve(switch_instance, keepfiles=False, tee=False)
 switch_model.save_results(results, switch_instance, "outputs")
 

--- a/examples/copperplate0/solve.py
+++ b/examples/copperplate0/solve.py
@@ -14,14 +14,14 @@ directory is in your python search path. See the README for more info.
 """
 
 from pyomo.environ import *
-from pyomo.opt import SolverFactory
 from switch_mod.utilities import define_AbstractModel
+import switch_mod.utilities
 
 switch_model = define_AbstractModel(
     'switch_mod', 'project.no_commit', 'fuel_cost')
 switch_instance = switch_model.load_inputs(inputs_dir="inputs")
 
-opt = SolverFactory("cplex")
+opt = switch_mod.utilities.default_solver()
 
 results = opt.solve(switch_instance, keepfiles=False, tee=False)
 switch_instance.load(results)

--- a/examples/copperplate1/solve.py
+++ b/examples/copperplate1/solve.py
@@ -15,14 +15,14 @@ directory is in your python search path. See the README for more info.
 """
 
 from pyomo.environ import *
-from pyomo.opt import SolverFactory
 from switch_mod.utilities import define_AbstractModel
+import switch_mod.utilities
 
 switch_model = define_AbstractModel(
     'switch_mod', 'local_td', 'project.no_commit', 'fuel_markets')
 switch_instance = switch_model.load_inputs(inputs_dir="inputs")
 
-opt = SolverFactory("cplex")
+opt = switch_mod.utilities.default_solver()
 results = opt.solve(switch_instance, keepfiles=False, tee=False)
 switch_instance.load(results)
 

--- a/examples/custom_extension/solve.py
+++ b/examples/custom_extension/solve.py
@@ -14,14 +14,14 @@ directory is in your python search path. See the README for more info.
 """
 
 from pyomo.environ import *
-from pyomo.opt import SolverFactory
 from switch_mod.utilities import define_AbstractModel
+import switch_mod.utilities
 
 switch_model = define_AbstractModel(
     'switch_mod', 'project.no_commit', 'fuel_cost', 'sunk_costs')
 switch_instance = switch_model.load_inputs(inputs_dir="inputs")
 
-opt = SolverFactory("cplex")
+opt = switch_mod.utilities.default_solver()
 
 results = opt.solve(switch_instance, keepfiles=False, tee=False)
 switch_instance.load(results)

--- a/examples/discrete_build/solve.py
+++ b/examples/discrete_build/solve.py
@@ -13,15 +13,15 @@ directory is in your python search path. See the README for more info.
 """
 
 from pyomo.environ import *
-from pyomo.opt import SolverFactory
 from switch_mod.utilities import define_AbstractModel
+import switch_mod.utilities
 
 switch_model = define_AbstractModel(
     'switch_mod', 'local_td', 'project.discrete_build',
     'project.no_commit', 'fuel_markets')
 switch_instance = switch_model.load_inputs(inputs_dir="inputs")
 
-opt = SolverFactory("cplex")
+opt = switch_mod.utilities.default_solver()
 results = opt.solve(switch_instance, keepfiles=False, tee=False)
 switch_instance.load(results)
 

--- a/examples/production_cost_models/1plant/solve.py
+++ b/examples/production_cost_models/1plant/solve.py
@@ -14,14 +14,14 @@ directory is in your python search path. See the README for more info.
 """
 
 from pyomo.environ import *
-from pyomo.opt import SolverFactory
 from switch_mod.utilities import define_AbstractModel
+import switch_mod.utilities
 
 switch_model = define_AbstractModel(
     'switch_mod', 'local_td', 'project.no_commit', 'fuel_cost')
 switch_instance = switch_model.load_inputs(inputs_dir="inputs")
 
-opt = SolverFactory("cplex")
+opt = switch_mod.utilities.default_solver()
 results = opt.solve(switch_instance, keepfiles=False, tee=False)
 switch_instance.load(results)
 

--- a/examples/production_cost_models/3plants/solve.py
+++ b/examples/production_cost_models/3plants/solve.py
@@ -14,14 +14,14 @@ directory is in your python search path. See the README for more info.
 """
 
 from pyomo.environ import *
-from pyomo.opt import SolverFactory
 from switch_mod.utilities import define_AbstractModel
+import switch_mod.utilities
 
 switch_model = define_AbstractModel(
     'switch_mod', 'local_td', 'project.no_commit', 'fuel_cost')
 switch_instance = switch_model.load_inputs(inputs_dir="inputs")
 
-opt = SolverFactory("cplex")
+opt = switch_mod.utilities.default_solver()
 results = opt.solve(switch_instance, keepfiles=False, tee=False)
 switch_instance.load(results)
 

--- a/examples/production_cost_models/4plants/solve.py
+++ b/examples/production_cost_models/4plants/solve.py
@@ -14,14 +14,14 @@ directory is in your python search path. See the README for more info.
 """
 
 from pyomo.environ import *
-from pyomo.opt import SolverFactory
 from switch_mod.utilities import define_AbstractModel
+import switch_mod.utilities
 
 switch_model = define_AbstractModel(
     'switch_mod', 'local_td', 'project.no_commit', 'fuel_cost')
 switch_instance = switch_model.load_inputs(inputs_dir="inputs")
 
-opt = SolverFactory("cplex")
+opt = switch_mod.utilities.default_solver()
 results = opt.solve(switch_instance, keepfiles=False, tee=False)
 switch_instance.load(results)
 

--- a/examples/production_cost_models/discrete_unit_commit/solve.py
+++ b/examples/production_cost_models/discrete_unit_commit/solve.py
@@ -14,15 +14,15 @@ directory is in your python search path. See the README for more info.
 """
 
 from pyomo.environ import *
-from pyomo.opt import SolverFactory
 from switch_mod.utilities import define_AbstractModel
+import switch_mod.utilities
 
 switch_model = define_AbstractModel(
     'switch_mod', 'local_td', 'project.unitcommit',
     'project.unitcommit.discrete', 'fuel_cost')
 switch_instance = switch_model.load_inputs(inputs_dir="inputs")
 
-opt = SolverFactory("cplex")
+opt = switch_mod.utilities.default_solver()
 results = opt.solve(switch_instance, keepfiles=False, tee=False)
 switch_instance.load(results)
 

--- a/examples/production_cost_models/unit_commit/solve.py
+++ b/examples/production_cost_models/unit_commit/solve.py
@@ -32,14 +32,14 @@ directory is in your python search path. See the README for more info.
 """
 
 from pyomo.environ import *
-from pyomo.opt import SolverFactory
 from switch_mod.utilities import define_AbstractModel
+import switch_mod.utilities
 
 switch_model = define_AbstractModel(
     'switch_mod', 'local_td', 'project.unitcommit', 'fuel_cost')
 switch_instance = switch_model.load_inputs(inputs_dir="inputs")
 
-opt = SolverFactory("cplex")
+opt = switch_mod.utilities.default_solver()
 
 results = opt.solve(switch_instance, keepfiles=False, tee=False)
 switch_model.save_results(results, switch_instance, "outputs")

--- a/switch_mod/utilities.py
+++ b/switch_mod/utilities.py
@@ -11,6 +11,7 @@ import importlib
 import sys
 import __main__ as main
 from pyomo.environ import *
+import pyomo.opt
 
 # This stores full names of modules that are dynamically loaded to
 # define a Switch model.
@@ -488,3 +489,7 @@ def load_aug(switch_data, optional=False, auto_select=False,
 
 def approx_equal(a, b, tolerance=0.01):
     return abs(a-b) <= (abs(a) + abs(b)) / 2.0 * tolerance
+
+
+def default_solver():
+    return pyomo.opt.SolverFactory('glpk')


### PR DESCRIPTION
This makes the examples runnable using only open source software --
since GLPK is open source (whereas CPLEX is proprietary).

Also move the choice of solver to one place in switch_mod, so that it
can be changed more easily.