### PR TITLE
Adding multi-fuel capability for power plants

### DIFF
--- a/switch_mod/fuel_cost.py
+++ b/switch_mod/fuel_cost.py
@@ -39,7 +39,7 @@ def define_components(mod):
     available.
 
     Enforce_Fuel_Availability[(proj, t) in
-    PROJ_FUEL_DISPATCH_POINTS_UNAVAILABLE] is a constrain that restricts
+    PROJ_FUEL_DISPATCH_POINTS_UNAVAILABLE] is a constraint that restricts
     ProjFuelUseRate to 0 for in load zones and periods where the
     projects' fuel is unavailable.
 
@@ -61,22 +61,22 @@ def define_components(mod):
 
     mod.PROJ_FUEL_DISPATCH_POINTS_UNAVAILABLE = Set(
         initialize=mod.PROJ_FUEL_DISPATCH_POINTS,
-        filter=lambda m, pr, t: (
-            (m.proj_load_zone[pr], m.proj_fuel[pr], m.tp_period[t])
+        filter=lambda m, pr, t, f: (
+            (m.proj_load_zone[pr], f, m.tp_period[t])
             not in m.FUEL_AVAILABILITY))
     mod.Enforce_Fuel_Availability = Constraint(
         mod.PROJ_FUEL_DISPATCH_POINTS_UNAVAILABLE,
-        rule=lambda m, pr, t: m.ProjFuelUseRate[pr, t] == 0)
+        rule=lambda m, pr, t, f: m.ProjFuelUseRate[pr, t, f] == 0)
 
     # Summarize total fuel costs in each timepoint for the objective function
     mod.Fuel_Costs_TP = Expression(
         mod.TIMEPOINTS,
         rule=lambda m, t: sum(
-            m.ProjFuelUseRate[proj, t] * m.fuel_cost[(
-                m.proj_load_zone[proj], m.proj_fuel[proj], m.tp_period[t])]
-            for (proj, t2) in m.PROJ_FUEL_DISPATCH_POINTS
+            m.ProjFuelUseRate[proj, t, f] 
+                * m.fuel_cost[(m.proj_load_zone[proj], f, m.tp_period[t])]
+            for (proj, t2, f) in m.PROJ_FUEL_DISPATCH_POINTS
             if((t2 == t) and (
-                (m.proj_load_zone[proj], m.proj_fuel[proj], m.tp_period[t]) in
+                (m.proj_load_zone[proj], f, m.tp_period[t]) in
                 m.FUEL_AVAILABILITY))))
     mod.cost_components_tp.append('Fuel_Costs_TP')
 

--- a/switch_mod/fuel_markets.py
+++ b/switch_mod/fuel_markets.py
@@ -295,17 +295,17 @@ def define_components(mod):
     mod.RFM_DISPATCH_POINTS = Set(
         mod.REGIONAL_FUEL_MARKET, mod.PERIODS,
         within=mod.PROJ_FUEL_DISPATCH_POINTS,
-        initialize=lambda m, rfm, p: 
-            (proj, t) for (proj, t, f) in m.PROJ_FUEL_DISPATCH_POINTS
+        initialize=lambda m, rfm, p: [
+            (proj, t, f) for (proj, t, f) in m.PROJ_FUEL_DISPATCH_POINTS
             if f == m.rfm_fuel[rfm] and
             m.proj_load_zone[proj] in m.RFM_LOAD_ZONES[rfm] and
-            m.tp_period[t] == p)
+            m.tp_period[t] == p])
 
     # could FuelConsumptionInMarket be an Expression instead of a constrained var?
     def Enforce_Fuel_Consumption_rule(m, rfm, p):
         return m.FuelConsumptionInMarket[rfm, p] == sum(
-            m.ProjFuelUseRate[proj, t, rfm_fuel[f]] * m.tp_weight_in_year[t]
-            for (proj, t) in m.RFM_DISPATCH_POINTS[rfm, p])
+            m.ProjFuelUseRate[proj, t, f] * m.tp_weight_in_year[t]
+            for (proj, t, f) in m.RFM_DISPATCH_POINTS[rfm, p])
     mod.Enforce_Fuel_Consumption = Constraint(
         mod.REGIONAL_FUEL_MARKET, mod.PERIODS,
         rule=Enforce_Fuel_Consumption_rule)
@@ -357,18 +357,18 @@ def load_inputs(mod, switch_data, inputs_dir):
     # column names, be indifferent to column order, and throw an error
     # message if some columns are not found.
 
-    switch_data.load(
+    switch_data.load_aug(
         filename=os.path.join(inputs_dir, 'regional_fuel_markets.tab'),
         select=('regional_fuel_market', 'fuel'),
         index=mod.REGIONAL_FUEL_MARKET,
         param=(mod.rfm_fuel))
-    switch_data.load(
+    switch_data.load_aug(
         filename=os.path.join(inputs_dir, 'fuel_supply_curves.tab'),
         select=('regional_fuel_market', 'period', 'tier', 'unit_cost',
                 'max_avail_at_cost'),
         index=mod.RFM_SUPPLY_TIERS,
         param=(mod.rfm_supply_tier_cost, mod.rfm_supply_tier_limit))
-    switch_data.load(
+    switch_data.load_aug(
         filename=os.path.join(inputs_dir, 'lz_to_regional_fuel_market.tab'),
         set=mod.LZ_RFM)
     # Load load zone fuel cost adder data if the file is available.

--- a/switch_mod/fuel_markets.py
+++ b/switch_mod/fuel_markets.py
@@ -295,15 +295,16 @@ def define_components(mod):
     mod.RFM_DISPATCH_POINTS = Set(
         mod.REGIONAL_FUEL_MARKET, mod.PERIODS,
         within=mod.PROJ_FUEL_DISPATCH_POINTS,
-        initialize=lambda m, rfm, p: set(
-            (proj, t) for (proj, t) in m.PROJ_FUEL_DISPATCH_POINTS
-            if m.proj_fuel[proj] == m.rfm_fuel[rfm] and
+        initialize=lambda m, rfm, p: 
+            (proj, t) for (proj, t, f) in m.PROJ_FUEL_DISPATCH_POINTS
+            if f == m.rfm_fuel[rfm] and
             m.proj_load_zone[proj] in m.RFM_LOAD_ZONES[rfm] and
-            m.tp_period[t] == p))
+            m.tp_period[t] == p)
 
+    # could FuelConsumptionInMarket be an Expression instead of a constrained var?
     def Enforce_Fuel_Consumption_rule(m, rfm, p):
         return m.FuelConsumptionInMarket[rfm, p] == sum(
-            m.ProjFuelUseRate[proj, t] * m.tp_weight_in_year[t]
+            m.ProjFuelUseRate[proj, t, rfm_fuel[f]] * m.tp_weight_in_year[t]
             for (proj, t) in m.RFM_DISPATCH_POINTS[rfm, p])
     mod.Enforce_Fuel_Consumption = Constraint(
         mod.REGIONAL_FUEL_MARKET, mod.PERIODS,

--- a/switch_mod/gen_tech.py
+++ b/switch_mod/gen_tech.py
@@ -303,7 +303,7 @@ def define_components(mod):
 
     mod.g_energy_source = Param(
         mod.GENERATION_TECHNOLOGIES,
-        within=mod.ENERGY_SOURCES)
+        validate=lambda m, val, g: val in m.ENERGY_SOURCES or val == "multiple")
     mod.g_uses_fuel = Param(
         mod.GENERATION_TECHNOLOGIES,
         initialize=lambda m, g: 
@@ -437,3 +437,8 @@ def load_inputs(mod, switch_data, inputs_dir):
         auto_select=True,
         index=mod.NEW_GENERATION_BUILDYEARS,
         param=[mod.g_overnight_cost, mod.g_fixed_o_m])
+
+    # read G_MULTI_FUELS from gen_multiple_fuels.dat if available
+    multi_fuels_path = os.path.join(inputs_dir, 'gen_multiple_fuels.dat')
+    if os.path.isfile(multi_fuels_path):
+        switch_data.load(filename=multi_fuels_path)

--- a/switch_mod/gen_tech.py
+++ b/switch_mod/gen_tech.py
@@ -66,8 +66,9 @@ def define_components(mod):
     GEN_TECH_WITH_MULTI_FUEL is a subset of GENERATION_TECHNOLOGIES for 
     which multiple allowed fuels have been specified.
     
-    G_FUELS is a list of all allowed combinations of generator technology
-    and fuel. It includes all single-fuel and multi-fuel technologies.
+    G_FUELS is a list of all allowed fuels for each fuel-consuming 
+    generator technology. It may contain one or more fuels for each
+    technology.
 
     g_max_age[g] is how many years a plant can remain operational once
     construction is complete.

--- a/switch_mod/project/build.py
+++ b/switch_mod/project/build.py
@@ -276,17 +276,9 @@ def define_components(mod):
     mod.FUEL_BASED_PROJECTS = Set(
         initialize=mod.PROJECTS,
         filter=lambda m, pr: m.g_uses_fuel[m.proj_gen_tech[pr]])
-    mod.proj_fuel = Param(
-        mod.FUEL_BASED_PROJECTS,
-        within=mod.FUELS,
-        initialize=lambda m, pr: m.g_energy_source[m.proj_gen_tech[pr]])
     mod.NON_FUEL_BASED_PROJECTS = Set(
         initialize=mod.PROJECTS,
         filter=lambda m, pr: not m.g_uses_fuel[m.proj_gen_tech[pr]])
-    mod.proj_non_fuel_energy_source = Param(
-        mod.NON_FUEL_BASED_PROJECTS,
-        within=mod.NON_FUEL_ENERGY_SOURCES,
-        initialize=lambda m, pr: m.g_energy_source[m.proj_gen_tech[pr]])
 
     def init_proj_buildyears(m):
         project_buildyears = set()

--- a/switch_mod/project/build.py
+++ b/switch_mod/project/build.py
@@ -67,12 +67,6 @@ def define_components(mod):
     describes the maximum possible capacity of a project in units of
     megawatts.
 
-    proj_energy_source[proj] is the primary energy source for a project.
-    This is derived from the generation technology description and
-    assumes one energy source per generation technology. This parameter
-    may be altered in the future to support generators that use multiple
-    energy sources.
-
     -- CONSTRUCTION --
 
     PROJECT_BUILDYEARS is a two-dimensional set of projects and the
@@ -278,24 +272,21 @@ def define_components(mod):
         mod.PROJECTS_CAP_LIMITED,
         within=PositiveReals)
     # Add PROJECTS_LOCATION_LIMITED & associated stuff later
-    mod.proj_energy_source = Param(
-        mod.PROJECTS,
-        within=mod.ENERGY_SOURCES,
-        initialize=lambda m, pr: m.g_energy_source[m.proj_gen_tech[pr]])
+
     mod.FUEL_BASED_PROJECTS = Set(
         initialize=mod.PROJECTS,
-        filter=lambda m, pr: m.proj_energy_source[pr] in m.FUELS)
+        filter=lambda m, pr: m.g_uses_fuel[m.proj_gen_tech[pr]])
     mod.proj_fuel = Param(
         mod.FUEL_BASED_PROJECTS,
         within=mod.FUELS,
-        initialize=lambda m, pr: m.proj_energy_source[pr])
+        initialize=lambda m, pr: m.g_energy_source[m.proj_gen_tech[pr]])
     mod.NON_FUEL_BASED_PROJECTS = Set(
         initialize=mod.PROJECTS,
-        filter=lambda m, pr: m.proj_energy_source[pr] not in m.FUELS)
+        filter=lambda m, pr: not m.g_uses_fuel[m.proj_gen_tech[pr]])
     mod.proj_non_fuel_energy_source = Param(
         mod.NON_FUEL_BASED_PROJECTS,
         within=mod.NON_FUEL_ENERGY_SOURCES,
-        initialize=lambda m, pr: m.proj_energy_source[pr])
+        initialize=lambda m, pr: m.g_energy_source[m.proj_gen_tech[pr]])
 
     def init_proj_buildyears(m):
         project_buildyears = set()

--- a/switch_mod/project/no_commit.py
+++ b/switch_mod/project/no_commit.py
@@ -88,7 +88,8 @@ def define_components(mod):
             m.DispatchProj[proj, t] <= m.DispatchUpperLimit[proj, t]))
 
     mod.ProjFuelUseRate_Calculate = Constraint(
-        mod.PROJ_FUEL_DISPATCH_POINTS,
+        mod.PROJ_WITH_FUEL_DISPATCH_POINTS,
         rule=lambda m, proj, t: (
-            m.ProjFuelUseRate[proj, t] ==
+            sum(m.ProjFuelUseRate[proj, t, f] for f in m.G_FUELS[m.proj_gen_tech[proj]])
+            ==
             m.DispatchProj[proj, t] * m.proj_full_load_heat_rate[proj]))

--- a/switch_mod/project/no_commit.py
+++ b/switch_mod/project/no_commit.py
@@ -89,8 +89,8 @@ def define_components(mod):
 
     mod.Enforce_Dispatch_Baseload_Flat = Constraint(
         mod.PROJ_DISPATCH_POINTS,
-        rule=lambda m, proj, t: (
-            (m.DispatchProj[proj, t] == BaseloadOperatingLevelForPeriod[proj, tp_period[t]])
+        rule=lambda m, proj, t: 
+            (m.DispatchProj[proj, t] == m.BaseloadOperatingLevelForPeriod[proj, m.tp_period[t]])
                 if proj in m.BASELOAD_PROJECTS
             else Constraint.Skip
     )

--- a/switch_mod/project/no_commit.py
+++ b/switch_mod/project/no_commit.py
@@ -56,6 +56,9 @@ def define_components(mod):
     DispatchProj * proj_full_load_heat_rate. The units become:
     MW * (MMBtu / MWh) = MMBTU / h
 
+    DispatchProjByFuel[(proj, t, f) in PROJ_FUEL_DISPATCH_POINTS]
+    calculates power production by each project from each fuel during
+    each timepoint.
 
     """
 
@@ -93,3 +96,13 @@ def define_components(mod):
             sum(m.ProjFuelUseRate[proj, t, f] for f in m.G_FUELS[m.proj_gen_tech[proj]])
             ==
             m.DispatchProj[proj, t] * m.proj_full_load_heat_rate[proj]))
+
+    # allocate the power produced during each timepoint among the fuels
+    # Here, we just calculate it from fuel usage and the full load heat rate,
+    # but it could be more complicated if we model the plant in more detail.
+    # note: this must be linear, because it may be used in RPS calculations
+    mod.DispatchProjByFuel = Expression(
+        mod.PROJ_FUEL_DISPATCH_POINTS,
+        rule=lambda m, proj, t, f:
+            m.ProjFuelUseRate[proj, t, f] / m.proj_full_load_heat_rate[proj]
+    )

--- a/switch_mod/project/unitcommit/fuel_use.py
+++ b/switch_mod/project/unitcommit/fuel_use.py
@@ -134,12 +134,12 @@ def define_components(mod):
         dimen=4,
         initialize=lambda m: set(
             (proj, t, intercept, slope)
-            for (proj, t) in m.PROJ_FUEL_DISPATCH_POINTS
+            for (proj, t) in m.PROJ_WITH_FUEL_DISPATCH_POINTS
             for (intercept, slope) in m.PROJ_FUEL_USE_SEGMENTS[proj]))
     mod.ProjFuelUseRate_Calculate = Constraint(
         mod.PROJ_DISP_FUEL_PIECEWISE_CONS_SET,
         rule=lambda m, pr, t, intercept, incremental_heat_rate: (
-            m.ProjFuelUseRate[pr, t] >=
+            sum(m.ProjFuelUseRate[pr, t, f] for f in m.G_FUELS[m.proj_gen_tech[pr]]) >=
             # Do the startup
             m.Startup[pr, t] * m.proj_startup_fuel[pr] / m.tp_duration_hrs[t] +
             intercept * m.CommitProject[pr, t] +

--- a/switch_mod/utilities.py
+++ b/switch_mod/utilities.py
@@ -420,6 +420,8 @@ def load_aug(switch_data, optional=False, auto_select=False,
     # Skip if the file is empty or has no data in the first row.
     if optional and (headers == [''] or dat1 == ['']):
         return
+    # copy the optional_params to avoid side-effects when the list is altered below
+    optional_params=list(optional_params)
     # Try to get a list of parameters. If param was given as a
     # singleton or a tuple, make it into a list that can be edited.
     params = []

--- a/switch_mod/utilities.py
+++ b/switch_mod/utilities.py
@@ -461,6 +461,11 @@ def load_aug(switch_data, optional=False, auto_select=False,
         num_indexes = 0
     # Make a select list if requested. Assume the left-most columns are
     # indexes and that other columns are named after their parameters.
+    # Maybe this could be extended to use a standard prefix for each data file?
+    # e.g., things related to regional fuel market supply tiers (indexed by RFM_SUPPLY_TIER)
+    # could all get the prefix "rfm_supply_tier_". Then they could get shorter names
+    # within the file (e.g., "cost" and "limit"). We could also require the data file
+    # to be called "rfm_supply_tier.tab" for greater consistency/predictability.
     if auto_select:
         if 'select' in kwds:
             raise InputError('You may not specify a select parameter if ' +


### PR DESCRIPTION
This adds elements to allow plants to switch freely among a list of fuels. If multi-fuel data are not provided, it runs the same as before. The main difference is that ProjFuelUseRate is now indexed over the available fuels (in addition to project and timepoint), and the Btu consumed by the plant during that timepoint must equal the sum of this variable across all fuels (instead of the single value of this variable).

There are also one or two other minor changes which could have been pushed separately but weren't.

This code has been used extensively in Switch-Hawaii and works well. I can submit some testing code if needed. I'd like to merge this to the master branch now to simplify life for our users (so they don't have to use the "multi-fuel" branch). But the changes are significant and it's possible they will break some existing code, so I wanted to have some discussion before merging it.