### PR TITLE
Advanced argument parsing and multi-scenario scripting

### DIFF
--- a/switch_mod/solve.py
+++ b/switch_mod/solve.py
@@ -1,62 +1,398 @@
-# Copyright 2015 The Switch Authors. All rights reserved.
-# Licensed under the Apache License, Version 2, which is in the LICENSE file.
+#!/usr/bin/env python
 
-"""
-Command line front-end for running the Switch model solver.
+import sys, os, time, traceback, shlex, re
 
-Usage:  python -m switch_mod.solve [ARGS]
-"""
+from pyomo.environ import *
+from pyomo.opt import SolverFactory, SolverStatus, TerminationCondition
 
-import argparse
-import os
-import sys
+def add_relative_path(*parts):
+    """ Adds a new path to sys.path.
+    The path should be specified relative to the current module,
+    and specified as a list of directories to traverse to reach the
+    final destination."""
+    sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), *parts)))
 
-import pyomo.opt
+add_relative_path('switch')   # standard switch model
+from switch_mod.utilities import create_model, _ArgumentParser
 
-import switch_mod.utilities
+add_relative_path('.') # components for this particular study
 
+def main(args=sys.argv[1:]):
+        
+    # build a module list based on configuration options passed in,
+    # and add the current module (to register define_arguments callback)
+    modules = get_module_list(args)
+    
+    # NOTE: we have (at least) two options for parsing model configuration arguments 
+    # (these may come from option files or the command line):
+    # 1. try to do all the parsing in solve.py and leave utilities.py ignorant of the argument framework
+    # 2. make command-line arguments a core part of the modeling framework in utilities.py
+    # I opted for option 1 because
+    # - each module may need to define its own arguments (e.g., EV scheduling rule or result storage request)
+    # - this means we need to call each module to define arguments and then parse the arguments
+    #   after creating the AbstractModel and before calling define_components. That can only be
+    #   done in utilities.py
+    # - parsing command line arguments in utilities.py allows us to define standard options
+    #   for the solver (and create a standard solve function in utilities.py) and for 
+    #   input/output directories (eliminating the need to pass variables around for these).
+    # - defining an options object (based on the arguments) in the utilities.py allows us to guarantee
+    #   that these elements will be available no matter what solution technique is used (standard
+    #   solve.py or runph or parallel solver)
 
-def main(argv):
-    parser = argparse.ArgumentParser(
-        prog='python -m switch_mod.solve',
-        description='Runs the Switch power grid model solver.')
-    parser.add_argument(
-        '--inputs-dir', type=str, default='inputs',
+    # Define the model
+    model = create_model(modules, args=args)
+
+    # Add any suffixes specified on the command line (usually only iis)
+    add_extra_suffixes(model)
+    
+    # get a list of modules to iterate through
+    iterate_modules = get_iteration_list(model)
+    
+    print "\n\n======================================================================="
+    print "arguments:"
+    print " ".join(k+"="+repr(v) for k, v in model.options.__dict__.items() if v)
+    print "modules:", modules
+    if iterate_modules:
+        print "iterate_modules", iterate_modules
+    print "======================================================================="
+
+    # create an instance
+    instance = model.load_inputs()
+
+    # make sure the outputs_dir exists (used by some modules during iterate)
+    if not os.path.exists(instance.options.outputs_dir):
+        os.makedirs(instance.options.outputs_dir)
+
+    # solve the model
+    if iterate_modules:
+        print "iterating model..."
+        iterate(instance, iterate_modules)
+    else:
+        print "solving model..."
+        solve(instance)
+        print "finished solving"
+    
+    # report/save results
+    instance.post_solve()
+
+def iterate(m, iterate_modules, depth=0):
+    """Iterate through all modules listed in the iterate_list (usually iterate.txt),
+    if any. If there is no iterate_list, then this will just solve the model once.
+    
+    If it exists, the iterate_list contains one row per level of iteration,
+    and each row contains a list of modules to test for iteration at that level
+    (these can be separated with commas, spaces or tabs).
+    The model will run through the levels like nested loops, running the lowest level 
+    till it converges, then iterating the next higher level by one step, then running the
+    lowest level to convergence again, repeating until all levels are converged.
+    During each iteration, the pre_iterate() and post_iterate() functions of each specified
+    module (if they exist) will be called before and after solving. When a module is 
+    converged, its post_iterate() function should return True. 
+    All modules specified in the iterate_list should also be loaded via the module_list
+    or include_module(s) arguments.
+    """
+    
+    # create or truncate the iteration tree
+    if depth == 0:
+        m.iteration_node = []
+
+    if depth == len(iterate_modules):
+        # asked to converge at the deepest level
+        # just preprocess to reflect all changes and then solve
+        m.preprocess()
+        solve(m)
+    else:
+        # iterate until converged at the current level
+
+        # note: the modules in iterate_modules were also specified in the model's 
+        # module list, and have already been loaded, so they are accessible via sys.modules
+        current_modules = [sys.modules[module_name] for module_name in iterate_modules[depth]]
+        # truncate the iteration tree at the current level
+        m.iteration_node = m.iteration_node[:depth] + [0]
+
+        j = 0
+        converged = False
+        while not converged:
+            # take one step at the current level
+            if m.options.max_iter is not None and j >= m.options.max_iter:
+                break
+
+            # record the current iteration number and node for use by modules 
+            # (e.g., to name files or reset/index params)
+            m.iteration_number = j
+            m.iteration_node[-1] = j
+
+            converged = True
+            # pre-iterate modules at this level
+            for module in current_modules:
+                if hasattr(module, 'pre_iterate'): 
+                    converged = module.pre_iterate(m) and converged
+
+            # converge the deeper-level modules, if any (inner loop)
+            iterate(m, iterate_modules, depth=depth+1)
+            
+            # post-iterate modules at this level
+            for module in current_modules:
+                if hasattr(module, 'post_iterate'):
+                    converged = module.post_iterate(m) and converged
+
+            j += 1
+        if converged:
+            print "Iteration of {ms} converged after {j} rounds.".format(ms=iterate_modules[depth], j=j)
+        else:
+            print "Iteration of {ms} was stopped after {j} iterations without convergence.".format(ms=iterate_modules[depth], j=j)
+    return
+
+def define_arguments(argparser):
+    # callback function to define model configuration arguments while the model is built
+
+    # add standard module arguments (not used later, but this adds them to the help)
+    add_module_args(argparser)
+
+    # iteration options
+    argparser.add_argument(
+        "--iterate_list", default=None,
+        help="Text file with a list of modules to iterate until converged (default is iterate.txt); "
+             "each row is one level of iteration, and there can be multiple modules on each row"
+    )
+    argparser.add_argument(
+        "--max_iter", type=int, default=None,
+        help="Maximum number of iterations to complete at each level for iterated models"
+    )
+
+    # scenario information
+    argparser.add_argument(
+        "--scenario_name", default="", help="Name of research scenario represented by this model"
+    )
+
+    # note: pyomo has a --solver-suffix option but it is not clear
+    # whether that does the same thing as --suffix defined here,
+    # so we don't reuse the same name.
+    argparser.add_argument("--suffixes", "--suffix", nargs="+", default=[],
+        help="Extra suffixes to add to the model and exchange with the solver (e.g., iis, rc, dual, or slack)")
+
+    # Define solver-related arguments
+    # These are a subset of the arguments offered by "pyomo solve --solver=cplex --help"
+    # Note: these use hyphens, even though we generally use underscores 
+    # for other SWITCH arguments. parse_args() will automatically convert the hyphens to 
+    # underscores when creating the attributes of the args object.
+    argparser.add_argument("--solver", default="glpk", 
+        help='Name of Pyomo solver to use for the model (default is "glpk")')
+    argparser.add_argument("--solver-io", default=None, help="Method for Pyomo to use to communicate with solver")
+    # note: pyomo has a --solver-options option but it is not clear
+    # whether that does the same thing as --solver-options-string so we don't reuse the same name.
+    argparser.add_argument("--solver-options-string", default=None, 
+        help='A quoted string of options to pass to the model solver. Each option must be of the form option=value. '
+            '(e.g., --solver-options-string "mipgap=0.001 primalopt advance=2 threads=1")')
+    argparser.add_argument("--keepfiles", action='store_true', default=None,
+        help="Keep temporary files produced by the solver (may be useful with --symbolic-solver-labels)")
+    argparser.add_argument(
+        "--stream-output", "--stream-solver", action='store_true', dest="tee", default=None,
+        help="Display information from the solver about its progress (usually combined with a suitable --solver-options string)")
+    argparser.add_argument(
+        "--symbolic-solver-labels", action='store_true', default=None, 
+        help='Use symbol names derived from the model when interfacing with the solver. '
+            'See "pyomo solve --solver=x --help" for more details.')
+
+    # NOTE: the following could potentially be made into standard arguments for all models,
+    # e.g. by defining them in a define_standard_arguments() function in switch.utilities.py
+
+    # Define input/output options
+    argparser.add_argument("--inputs", dest="inputs_dir", default="inputs", 
         help='Directory containing input files (default is "inputs")')
-    parser.add_argument(
-        '--outputs-dir', type=str, default='outputs',
+    argparser.add_argument("--outputs", dest="outputs_dir", default="outputs",
         help='Directory to write output files (default is "outputs")')
-    parser.add_argument(
-        '--solver', type=str, default='glpk',
-        help='Linear program solver to use (default is "glpk")')
-    parser.add_argument(
+
+    # General purpose arguments
+    argparser.add_argument(
         '--verbose', '-v', default=False, action='store_true',
-        help='Dump data about internal workings to stdout')
-    args = parser.parse_args(argv)
-
-    (switch_model, switch_instance) = load(args.inputs_dir)
-    opt = pyomo.opt.SolverFactory(args.solver)
-    results = opt.solve(switch_instance, keepfiles=False, tee=False)
-    switch_model.save_results(results, switch_instance, args.outputs_dir)
-
-    if args.verbose:
-        # Print a dump of the results and model instance to standard output.
-        results.write()
-        switch_instance.pprint()
+        help='Show information about model preparation and solution')
 
 
-def load(inputs_dir):
-    try:
-        module_fh = open(os.path.join(inputs_dir, 'modules'), 'r')
-    except IOError, exc:
-        sys.exit('Failed to open input file: {}'.format(exc))
-    module_list = [line.rstrip('\n') for line in module_fh]
+def add_module_args(parser):
+    parser.add_argument(
+        "--module_list", default=None, 
+        help='Text file with a list of modules to include in the model (default is "modules.txt")'
+    )
+    parser.add_argument(
+        "--include_modules", "--include_module", dest="include_modules", nargs='+', default=[],
+        help="Module(s) to add to the model in addition to any specified with --module_list"
+    )
+    parser.add_argument(
+        "--exclude_modules", "--exclude_module", dest="exclude_modules", nargs='+', default=[],
+        help="Module(s) to remove from the model after processing --module_list and --include_modules"
+    )
 
-    switch_model = switch_mod.utilities.define_AbstractModel(
-        'switch_mod', *module_list)
-    switch_instance = switch_model.load_inputs(inputs_dir=inputs_dir)
-    return (switch_model, switch_instance)
+def get_module_list(args):
+    # parse module options
+    parser = _ArgumentParser(allow_abbrev=False, add_help=False)
+    add_module_args(parser)
+    module_options = parser.parse_known_args(args=args)[0]
+
+    # identify modules to load
+    module_list_file = module_options.module_list
+    if module_list_file is None and os.path.exists("modules.txt"):
+        module_list_file = "modules.txt"
+    if module_list_file is None:
+        modules = []
+    else:
+        # if it exists, the module list contains one module name per row (no .py extension)
+        # we strip whitespace from either end (because those errors can be annoyingly hard to debug),
+        # but otherwise take the module names as given.
+        with open(module_list_file) as f:
+            modules = [r.strip() for r in f.read().splitlines()]
+
+    modules.extend(module_options.include_modules)
+    for module_name in module_options.exclude_modules:
+        modules.remove(module_name)
+    
+    # add the current module, since it has callbacks, e.g. define_arguments for iteration and suffixes
+    modules.append(__name__)
+
+    print "module list:", modules
+
+    return modules
+    
+def get_iteration_list(m):
+    # Identify modules to iterate until convergence (if any)
+    iterate_list_file = m.options.iterate_list
+    if iterate_list_file is None and os.path.exists("iterate.txt"):
+        iterate_list_file = "iterate.txt"
+    if iterate_list_file is None:
+        iterate_modules = []
+    else:
+        with open(iterate_list_file) as f:
+            iterate_rows = f.read().splitlines()
+        iterate_modules = [re.sub("[ \t,]+", " ", r).split(" ") for r in iterate_rows]
+    return iterate_modules
+
+def get_option_file_args():
+    args = []
+    # retrieve base arguments from options.txt (if present)
+    # note: these can be on multiple lines to ease editing,
+    # and lines can be commented out with #
+    if os.path.exists("options.txt"):
+        with open("options.txt") as f:
+            base_options = f.read().splitlines()
+        for r in base_options:
+            if not r.lstrip().startswith("#"):
+                args.extend(shlex.split(r))
+    return args
+
+# Generic argument-related code; could potentially be moved to utilities.py
+# if we want to make these standard parts of Switch.
+
+def add_extra_suffixes(model):
+    """
+    Add any suffix objects requested in the configuration options.
+    We assume they will be used for import or export of floating-point values
+    note: modules that need suffixes should normally just create them (possibly
+    checking whether they already exist first). Then solve() will automatically
+    pass them to the solver.
+    """
+    for suffix in model.options.suffixes:
+        setattr(model, suffix, Suffix(direction=Suffix.IMPORT_EXPORT))
 
 
-if __name__ == '__main__':
-    main(sys.argv[1:])
+def solve(model):
+    if not hasattr(model, "solver"):
+        # Create a solver object the first time in. We don't do this until a solve is
+        # requested, because sometimes a different solve function may be used,
+        # with its own solver object (e.g., with runph or a parallel solver server).
+        # In those cases, we don't want to go through the expense of creating an
+        # unused solver object, or get errors if the solver options are invalid.
+        model.solver = SolverFactory(model.options.solver, solver_io=model.options.solver_io)
+
+        # patch for Pyomo < 4.2
+        # note: Pyomo added an options_string argument to solver.solve() in Pyomo 4.2 rev 10587. 
+        # (See https://software.sandia.gov/trac/pyomo/browser/pyomo/trunk/pyomo/opt/base/solvers.py?rev=10587 )
+        # This is misreported in the documentation as options=, but options= actually accepts a dictionary.
+        if model.options.solver_options_string and not hasattr(model.solver, "_options_string_to_dict"):
+            for k, v in _options_string_to_dict(model.options.solver_options_string).items():
+                model.solver.options[k] = v
+    
+    # get solver arguments (if any)
+    if hasattr(model, "options"):
+        solver_args = dict(
+            options_string=model.options.solver_options_string,
+            keepfiles=model.options.keepfiles,
+            tee=model.options.tee,
+            symbolic_solver_labels=model.options.symbolic_solver_labels
+        )
+        # drop all the unspecified options
+        solver_args = {k: v for (k, v) in solver_args.items() if v is not None}
+    else:
+        solver_args={}
+
+    # Automatically send all defined suffixes to the solver
+    solver_args["suffixes"] = [c.cname() for c in model.component_objects() if isinstance(c, Suffix)]
+    # note: the next few lines are faster than the line above, but seem risky:
+    # i = m._ctypes.get(Suffix, [None])[0]
+    # solver_args["suffixes"] = []
+    # while i is not None:
+    #     c, i = m._decl_order[i]
+    #     solver_args[suffixes].append(c.cname())
+    
+    # patch for Pyomo < 4.2
+    if not hasattr(model.solver, "_options_string_to_dict"):
+        solver_args.pop("options_string", "")
+
+    # solve the model
+    if model.options.verbose:
+        print "solving model..."
+    start = time.time()
+    
+    results = model.solver.solve(model, **solver_args)
+
+    if model.options.verbose:
+        print "Total time in solver: {t}s".format(t=time.time()-start)
+    
+    # check for errors
+    model.solutions.load_from(results)
+    if results.solver.termination_condition == pyomo.opt.TerminationCondition.infeasible:
+        if hasattr(model, "iis"):
+            print "Model was infeasible; irreducible infeasible set (IIS) returned by solver:"
+            print "\n".join(c.cname() for c in m.iis)
+        else:
+            print "Model was infeasible; if the solver can generate an irreducible infeasible set,"
+            print "more information may be available by calling this script with --suffixes iis ..."
+        raise RuntimeError("Infeasible model")
+    
+    return results
+
+# taken from https://software.sandia.gov/trac/pyomo/browser/pyomo/trunk/pyomo/opt/base/solvers.py?rev=10784
+# This can be removed when all users are on Pyomo 4.2
+import pyutilib
+def _options_string_to_dict(istr):
+    ans = {}
+    istr = istr.strip()
+    if not istr:
+        return ans
+    if istr[0] == "'" or istr[0] == '"':
+        istr = eval(istr)
+    tokens = pyutilib.misc.quote_split('[ ]+',istr)
+    for token in tokens:
+        index = token.find('=')
+        if index is -1:
+            raise ValueError(
+                "Solver options must have the form option=value: '%s'" % istr)
+        try:
+            val = eval(token[(index+1):])
+        except:
+            val = token[(index+1):]
+        ans[token[:index]] = val
+    return ans
+
+
+
+        
+###############
+
+if __name__ == "__main__":
+    # combine default arguments read from options.txt file with 
+    # additional arguments specified on the command line
+    args = get_option_file_args()
+    # add any command-line arguments
+    args.extend(sys.argv[1:])
+    main(args)
+    

--- a/switch_mod/solve_scenarios.py
+++ b/switch_mod/solve_scenarios.py
@@ -1,0 +1,281 @@
+#!/usr/bin/env python
+
+"""Scenario management module. 
+Reads scenario-related arguments from the command line and uses them to
+setup scenarios_to_run(). For each scenario, this generator will yield a 
+tokenized list of arguments that define that scenario (similar to sys.argv, 
+but based on a line from a scenario definition file, followed by any options 
+specified on the command line). The arguments can be retrieved one-by-one 
+using parse_arg() or (once attached to a model as model.args) by using 
+get_arg(). These functions use the same syntax as the argparse module.
+A queueing system (based on lock files in a queue directory) is used to
+ensure that scenarios_to_run() will always return the next unsolved 
+scenario from the scenario list file, even if the file is edited while this
+script is running. This makes it possible to amend the scenario list while
+long solver jobs are running. Multiple solvers can also use scenarios_to_run()
+in separate processes to select the next job to do.
+"""
+
+from __future__ import print_function
+import sys, os, time
+import argparse, shlex, socket, io, glob
+from collections import OrderedDict
+
+def add_relative_path(*parts):
+    """ Adds a new path to sys.path.
+    The path should be specified relative to the current module, 
+    and specified as a list of directories to traverse to reach the
+    final destination."""
+    sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), *parts)))
+    
+add_relative_path('switch')   # standard switch model
+import switch_mod.utilities
+
+add_relative_path('.')   # same folder as this file
+
+
+# load the main model-solver module
+import solve
+
+# retrieve base options and command-line arguments
+option_file_args = solve.get_option_file_args()
+cmd_line_args = sys.argv[1:]
+
+# Parse scenario-manager-related command-line arguments.
+# Other command-line arguments will be passed through to solve.py via scenario_cmd_line_args
+parser = switch_mod.utilities._ArgumentParser(
+    allow_abbrev=False, description='Solve one or more SWITCH scenarios.'
+)
+parser.add_argument('--scenario', '--scenarios', nargs='+', dest='scenarios', default=[])
+#parser.add_argument('--scenarios', nargs='+', default=[])
+parser.add_argument("--scenario_list", default="scenarios.txt")
+parser.add_argument("--scenario_queue", default="scenario_queue")
+parser.add_argument("--job_id", default=None)
+
+#import pdb; pdb.set_trace()
+scenario_manager_args = parser.parse_known_args(args=option_file_args + cmd_line_args)[0]
+scenario_option_file_args = parser.parse_known_args(args=option_file_args)[1]
+scenario_cmd_line_args = parser.parse_known_args(args=cmd_line_args)[1]
+
+requested_scenarios = scenario_manager_args.scenarios
+scenario_list_file = scenario_manager_args.scenario_list
+scenario_queue_dir = scenario_manager_args.scenario_queue
+job_id = scenario_manager_args.job_id
+
+# Note: we could use code like below to collect arguments ad-hoc,
+# but then it is difficult to separate the scenario-related arguments from the
+# pass-through arguments for solve.py.
+# requested_scenarios = (
+#     parse_arg("--scenario", nargs='+', default=[])
+#     + parse_arg("--scenarios", nargs='+', default=[])
+# )
+# scenario_list_file = parse_arg("--scenario_list", default="scenarios.txt")
+# scenario_queue_dir = parse_arg("--scenario_queue", default="scenario_queue")
+#
+# job_id = parse_arg("--job_id", default=None)
+# scenario_cmd_line_args = sys.argv[1:] # note: this includes scenario-related args, which is bad
+
+# note: we make a best effort to get a unique, persistent job_id for each job.
+# this is used to clear the queue of running jobs if a job is stopped and
+# restarted. (would be better if other jobs could do this when this job dies
+# but it's hard to see how they can detect when this job fails.)
+if job_id is None:
+    job_id = os.environ.get('JOB_ID') # could be set by user
+if job_id is None:
+    job_id = os.environ.get('JOBID') # could be set by user
+if job_id is None:
+    job_id = os.environ.get('SLURM_JOBID')
+if job_id is None:
+    job_id = os.environ.get('OMPI_MCA_ess_base_jobid')
+if job_id is None:
+    # construct one
+    job_id = socket.gethostname() + '_' + str(os.getpid())
+
+running_scenarios_file = os.path.join(scenario_queue_dir, job_id+"_running.txt")
+
+# list of scenarios currently being run by this job (always just one with the current code)
+running_scenarios = []
+
+# make sure the scenario_queue_dir exists (marginally better to do this once
+# rather than every time we need to write a file there)
+try:
+    os.makedirs(scenario_queue_dir)
+except OSError:
+    pass    # directory probably exists already
+
+#import pdb; pdb.set_trace()
+
+def main():
+    # remove lock directories for any scenarios that were
+    # previously being solved by this job but were interrupted
+    unlock_running_scenarios()
+    
+    for (scenario_name, args) in scenarios_to_run():
+        print(
+            "\n\n=======================================================================\n"
+            + "running scenario {s}\n".format(s=scenario_name)
+            + "arguments: {}\n".format(args)
+            + "=======================================================================\n"
+        )
+
+        # call the standard solve module with the arguments for this particular scenario
+        solve.main(args=args)
+
+        # another option:
+        # subprocess.call(shlex.split("python -m solve") + args) <- omit args from options.txt
+        # it should also be possible to use a solver server, but that's not really needed
+        # since this script has built-in queue management.
+
+        mark_completed(scenario_name)
+
+def scenarios_to_run():
+    """Generator function which returns argument lists for each scenario that should be run.
+    
+    Note: each time a new scenario is required, this re-reads the scenario_list file
+    and then returns the first scenario that hasn't already started running.
+    This allows multiple copies of the script to be run and allocate scenarios among 
+    themselves."""
+    
+    skipped = []
+    ran = []
+    
+    if requested_scenarios:
+        # user requested one or more scenarios
+        # just run them in the order specified, with no queue-management
+        for scenario_name in requested_scenarios:
+            completed = False
+            scenario_args = scenario_option_file_args + get_scenario_dict()[scenario_name] + scenario_cmd_line_args
+            # flag the scenario as being run; then run it whether or not it was previously run
+            checkout(scenario_name, force=True)
+            yield (scenario_name, scenario_args)
+        # no more scenarios to run
+        return
+    else:   # no specific scenarios requested
+        # Run every scenario in the list, with queue management
+        # This is done by repeatedly scanning the scenario list and choosing
+        # the first scenario that hasn't been run. This way, users can edit the
+        # list and this script will adapt to the changes as soon as it finishes 
+        # the current scenario.
+        all_done = False
+        while not all_done:
+            all_done = True
+            # cache a list of scenarios that have been run, to avoid trying to checkout every one. 
+            # This list is found by retrieving the names of the lock-directories.
+            already_run = filter(os.path.isdir, os.listdir("."))
+            for scenario_name, base_args in get_scenario_dict().items():
+                if scenario_name not in already_run and checkout(scenario_name):
+                    # run this scenario, then start again at the top of the list
+                    ran.append(scenario_name)
+                    scenario_args = scenario_option_file_args + base_args + scenario_cmd_line_args
+                    yield (scenario_name, scenario_args)
+                    all_done = False
+                    break
+                else:
+                    if scenario_name not in skipped and scenario_name not in ran:
+                        skipped.append(scenario_name)
+                        print("Skipping {} because it was already run.".format(scenario_name))
+                # move on to the next candidate
+        # no more scenarios to run
+        if skipped and not ran:
+            print(
+                "Please remove the {sq} directory or its contents if you would like to "
+                "run these scenarios again. (rm -rf {sq})".format(sq=scenario_queue_dir)
+            )
+        return
+        
+
+def parse_arg(arg, args=sys.argv[1:], **parse_kw):
+    """Parse one argument from the argument list, using options as specified for argparse"""
+    parser = switch_mod.utilities._ArgumentParser(allow_abbrev=False)
+    # Set output destination to 'option', so we can retrieve the value predictably.
+    # This is done by updating parse_kw, so it can't be overridden by callers.
+    # (They have no reason to set the destination anyway.)
+    # note: we use the term "option" so that parsing errors will make a little more
+    # sense, e.g., if users call with "--suffixes <blank>" (instead of just omitting it)
+    parse_kw["dest"]="option"
+    parser.add_argument(arg, **parse_kw)
+    return parser.parse_known_args(args)[0].option
+
+def get_scenario_name(scenario_args):
+    # use ad-hoc parsing to extract the scenario name from a scenario-definition string
+    return parse_arg("--scenario_name", default="", args=scenario_args)
+
+def get_scenario_dict():
+    # note: we read the list from the disk each time so that we get a fresher version
+    # if the standard list is changed during a long solution effort.
+    with open(scenario_list_file, 'r') as f:
+        scenario_list_text = f.read()
+    # note: text.splitlines() omits newlines and ignores presence/absence of \n at end of the text
+    # shlex.split() breaks an command-line-style argument string into a list like sys.argv
+    scenario_list = [shlex.split(r) for r in scenario_list_text.splitlines()]
+    return OrderedDict((get_scenario_name(s), s) for s in scenario_list)
+
+def checkout(scenario_name, force=False):
+    # write a flag that we are solving this scenario, before actually trying to lock it
+    # this way, if the job gets interrupted in the middle of this function, the
+    # worst that can happen is the scenario will be restarted then next time the job restarts
+    # (if we locked the scenario and then got interrupted before setting the flag, then
+    # the scenario would not be restarted when the job restarts, which is worse.)
+    running_scenarios.append(scenario_name)
+    write_running_scenarios_file()
+    try:
+        # create a lock directory for this scenario
+        os.mkdir(os.path.join(scenario_queue_dir, scenario_name))
+        locked = True
+    except OSError as e:
+        if e.errno != 17:     # File exists
+            raise
+        locked = False
+    if locked or force:
+        return True
+    else:
+        # remove the flag that we're running this scenario
+        running_scenarios.remove(scenario_name)
+        write_running_scenarios_file()
+        return False
+
+def mark_completed(scenario_name):
+    # remove the scenario from the list of running scenarios (since it's been completed now)
+    running_scenarios.remove(scenario_name)
+    write_running_scenarios_file()
+    # note: the scenario lock directory is left in place so the scenario won't get checked 
+    # out again
+    
+def write_running_scenarios_file():
+    # write the list of scenarios currently being run by this job to disk
+    # so they can be released back to the queue if the job is interrupted and restarted
+    if running_scenarios:
+        # note: we use open("r+") and truncate() instead of open("w")
+        # to give a better chance of retaining the original file contents if this
+        # job is interrupted in the middle of writing the file. This is not an issue unless
+        # this job is running multiple scenarios at once
+        # (If the file is only partial, then the queue will just think some jobs have been
+        # done that actually haven't.)
+        flags = "r+" if os.path.exists(running_scenarios_file) else "w"
+        with open(running_scenarios_file, flags) as f:
+            f.write("\n".join(running_scenarios))
+            f.truncate()
+    else:
+        # remove the running_scenarios_file entirely if it would be empty
+        try: 
+            os.remove(running_scenarios_file)
+        except OSError as e:
+            if e.errno != 2:    # no such file
+                raise
+
+def unlock_running_scenarios():
+    # called during startup to remove lockfiles for any scenarios that were still running
+    # when this job was interrupted
+    if os.path.exists(running_scenarios_file):
+        with open(running_scenarios_file) as f:
+            interrupted = f.read().splitlines()
+        for scenario_name in interrupted:
+            try: 
+                os.rmdir(scenario_name)
+            except OSError as e:
+                if e.errno != 2:    # no such file
+                    raise
+
+# run the main function if called as a script
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
This commit includes a new version of solve.py and a new solve_scenarios.py. 

solve.py defines a number of solver-related command-line arguments, reads them from options.txt and/or the command line, creates a model instance, customizes a solver based on the command-line arguments, and solves the model. It can also solve models repeatedly in order to iterate to convergence or conduct sensitivity studies. Argument processing for solve.py is integrated with argument processing for add-on modules (e.g., switch_hawaii.demand_response.py in the hawaii_dr branch), so this provides a complete interface for customizing model runs.

solve_scenarios.py reads scenario definitions from scenarios.txt (or similar) and then sends the scenario definitions to solve.py. The scenario definitions are just lists of command-line arguments -- the same arguments can be used in options.txt, scenarios.txt or on the command line. Some of these affect the solver, and some of them are consumed by add-on modules. solve_scenarios.py also includes code to allow single or parallel instances to work their way through the scenario list without duplicating effort (and even to respond to changes in the scenario list while scenario_solve is running).

Some notes on solve.py:

- solve.py uses the new argument-parsing capabilities in utilities.py pretty extensively. 
- It reads any command-line arguments in options.txt and then appends any arguments specified on the actual command line.
- It reads a list of modules from modules.txt (or from a different file specified by `--module_list <listfile>`). It also appends any modules specified with `--include_module <mod>` or `--include_modules <mod1> <mod2> ...`, and then it excludes modules specified with `--exclude_module <mod>` or `--exclude_modules <mod1> <mod2> ...`. 
- Note that arguments specified on the command line will replace any specified earlier (e.g., in options.txt). So solve.py always starts with the list in modules.txt (or the file specified by the last --module_list command), then applies the _last_ --include_module(s) command, then the _last_ --exclude_module(s) command. This seems to give enough flexibility and predictability.
- It passes the module list to switch_mod.utilities.create_model() (similar to define_AbstractModel) to create a model.
- Note that code added to switch_mod.utilities.create_model() in a previous commit creates an argument parser and calls define_arguments(argparser) for all modules in the list. Any module can include this function to define command-line arguments that it wants to consume. Then switch_mod.utilities.create_model() parses all arguments and places the results in model.options (e.g., model.options.inputs_dir). This provides a flexible system for passing options into modules as needed.
- solve.py registers itself in the module list and uses the standard approach to define a number of solver-related arguments (see define_arguments())
- solve.py builds a customized solver based on options specified in options.txt and the command line. It adds this to the model as model.solver. This supports the possibility for creating a model.solve() method later or for defining two different models at the same time with different solver options. 
- The solve() function in solve.py calls solver.solve() with a customized list of arguments, including a list of suffixes created by other modules.
- solve.py also defines automatic iteration behavior. This is useful for models that must iterate to convergence (e.g., with nonlinear demand response functions and/or AC power flow). It could also potentially be used for sensitivity studies (e.g., carbon_costs=[10, 100, 1000]; model.carbon_cost=carbon_costs[model.iteration_number]). If modules are listed in iterate.txt, then solve.py will repeatedly call their pre_iterate() function, then solve(), then call their post_iterate() function to test for convergence/completion. If modules are listed on different lines in iterate.txt, then they define multi-level iteration loops. If they are listed on the same line, then they will all be tested for convergence at the same level.

Some notes on scenario_solve.py:

- scenario_solve.py reads a list of command line options for different scenarios from scenarios.txt or another file specified by `--scenario_list <scenario_file>`. It passes each of these lists of arguments in turn to the solve module. 
- one of the arguments passed to the solve module is scenario_name, which can be used by modules to give their output files unique names or store them in unique directories. 
- scenario_solve can be called with a `--scenario` or `--scenarios` option to choose one or more scenarios from the list; otherwise it will run all scenarios in the list.
- when running all scenarios in the list, scenario_solve will check whether each one has already been solved; if so, it will move onto the next scenario. After each solve, it will check the whole list again from the top. This allows users to add new scenarios to the list, and scenario_solve will solve them without being restarted.
- the code to check whether a scenario has run is designed to be multi-process safe on networked file systems. This means many copies of scenario_solve can be run simultaneously on the same computer or on different computers on a networked file system, and they will allocate the scenarios among themselves until all are completed. scenario_solve.py uses "lock directories" for each scenario, stored under scenario_queue/ (or another location specified by `--scenario_queue <dir>`). Scenarios can be re-queued by removing the empty directory with the same name. Or the whole queue can be restarted by executing `rm -rf scenario_queue`.
- when it starts, scenario_queue.py tries to create a unique, persistent job id. On HPC environments, this will be derived from the SLURM or MPI job ID. On ad hoc clusters, you may want to specify `--job_id <x>` for each separate worker. When it launches, if scenario_queue finds any scenarios that were previously being solved by the same job but got interrupted, it will requeue them. If you have a large sequence of scenarios to run, this allows you to interrupt and restart jobs without losing any scenarios. Scenarios that were previously being processed by this job are listed in scenario_queue/<job_id>_running.txt. I haven't found a way to re-queue the running jobs automatically when scenario_solve.py is interrupted. They will only be re-queued if you restart scenario_solve with the same job id or manually remove the lock directory for that scenario.

Take a look at the hawaii_dr branch (especially options.txt, iterate.txt, scenarios.txt and/or scenarios_tiny.txt, and switch_hawaii.demand_response) to see how these pieces work together. You can just run `python -m switch_mod.solve` to solve the default scenario defined in options.txt and iterate.txt, or run `python -m switch_mod.solve_scenarios --scenario_file scenarios_tiny.txt` to solve a small list of scenarios. You can also add command line arguments to either of these, e.g., `--biofuel_limit 0.05` or `--suffix iis`.

These scripts also provide help if called with `--help`. If a module list is defined, `python -m switch_mod.solve --help` will also give you help messages from all the modules that are loaded.