### PR TITLE
Fixing some things in the transmission modules

### DIFF
--- a/switch_mod/trans_build.py
+++ b/switch_mod/trans_build.py
@@ -236,7 +236,7 @@ def define_components(mod):
     mod.TransCapacityAvailable = Expression(
         mod.TRANSMISSION_LINES, mod.PERIODS,
         rule=lambda m, tx, period: (
-            m.TransCapacity[tx, period] * m.trans_derating_factor[tx]))
+            m.TransCapacity[tx, period] * (1 - m.trans_derating_factor[tx])))
     mod.trans_terrain_multiplier = Param(
         mod.TRANSMISSION_LINES,
         within=Reals,
@@ -318,7 +318,7 @@ def load_inputs(mod, switch_data, inputs_dir):
 
     trans_params.dat
         trans_capital_cost_per_mw_km, trans_lifetime_yrs,
-        trans_fixed_o_m_fraction, distribution_losses
+        trans_fixed_o_m_fraction, distribution_loss_rate
 
 
     """

--- a/switch_mod/trans_build.py
+++ b/switch_mod/trans_build.py
@@ -192,7 +192,7 @@ def define_components(mod):
             (tx, 'Legacy') for tx in m.TRANSMISSION_LINES))
     mod.existing_trans_cap = Param(
         mod.TRANSMISSION_LINES,
-        within=PositiveReals)
+        within=NonNegativeReals)
     mod.min_data_check(
         'trans_length_km', 'trans_efficiency', 'EXISTING_TRANS_BLD_YRS',
         'existing_trans_cap')
@@ -251,7 +251,7 @@ def define_components(mod):
     mod.trans_fixed_o_m_fraction = Param(
         within=PositiveReals,
         default=0.03)
-    # Total annaul fixed costs for building new transmission lines...
+    # Total annual fixed costs for building new transmission lines...
     # Multiply capital costs by capital recover factor to get annual
     # payments. Add annual fixed O&M that are expressed as a fraction of
     # overnight costs.
@@ -260,7 +260,7 @@ def define_components(mod):
         within=PositiveReals,
         initialize=lambda m, tx: (
             m.trans_capital_cost_per_mw_km * m.trans_terrain_multiplier[tx] *
-            (crf(m.interest_rate, m.trans_lifetime_yrs) +
+            m..trans_length_km[tx] * m.(crf(m.interest_rate, m.trans_lifetime_yrs) +
                 m.trans_fixed_o_m_fraction)))
     # An expression to summarize annual costs for the objective
     # function. Units should be total annual future costs in $base_year

--- a/switch_mod/trans_dispatch.py
+++ b/switch_mod/trans_dispatch.py
@@ -80,12 +80,12 @@ def define_components(mod):
 
     def LZ_TXNet_calculation(m, lz, tp):
         return (
-            sum(m.TxPowerReceived[lz_from, lz_to, tp]
-                for (lz_from, lz_to, tp) in m.TRANS_TIMEPOINTS
-                if lz_to == lz) -
-            sum(m.TxPowerSent[lz_from, lz_to, tp]
-                for (lz_from, lz_to, tp) in m.TRANS_TIMEPOINTS
-                if lz_from == lz))
+            sum(m.TxPowerReceived[lz_from, lz_to, t]
+                for (lz_from, lz_to, t) in m.TRANS_TIMEPOINTS
+                if lz_to == lz and t == tp) -
+            sum(m.TxPowerSent[lz_from, lz_to, t]
+                for (lz_from, lz_to, t) in m.TRANS_TIMEPOINTS
+                if lz_from == lz and t == tp))
     mod.LZ_TXNet = Expression(
         mod.LOAD_ZONES, mod.TIMEPOINTS,
         rule=LZ_TXNet_calculation)


### PR DESCRIPTION
There was a conflict in the calculation of the LZ_TXNet expression between the arguments of the function and the indexes of the for loop.
Transmission capacity was calculated using the derating factor as the availability, when the availability is actually (1 - derating factor).

Also changed the name of a parameter in the trans_params.dat documentation to match the name of the Pyomo parameter.