### PR TITLE
Skip example directories that lack an expectation file

### DIFF
--- a/tests/examples_test.py
+++ b/tests/examples_test.py
@@ -38,6 +38,15 @@ def find_example_dirs():
                 yield path
 
 
+def get_expectation_path(example_dir):
+    expectation_file = os.path.join(example_dir, 'outputs',
+                                        'total_cost.txt')
+    if not os.path.isfile( expectation_file ):
+        return False
+    else:
+        return expectation_file
+
+
 def make_test(example_dir):
     def test_example():
         temp_dir = tempfile.mkdtemp(prefix='switch_test_')
@@ -48,8 +57,7 @@ def make_test(example_dir):
             total_cost = read_file(os.path.join(temp_dir, 'total_cost.txt'))
         finally:
             shutil.rmtree(temp_dir)
-        expectation_file = os.path.join(example_dir, 'outputs',
-                                        'total_cost.txt')
+        expectation_file = get_expectation_path(example_dir)
         if UPDATE_EXPECTATIONS:
             write_file(expectation_file, total_cost)
         else:
@@ -73,7 +81,8 @@ def make_test(example_dir):
 def load_tests(loader, tests, pattern):
     suite = unittest.TestSuite()
     for example_dir in find_example_dirs():
-        suite.addTest(make_test(example_dir))
+        if get_expectation_path(example_dir):
+            suite.addTest(make_test(example_dir))
     return suite
 
 


### PR DESCRIPTION
Skip example directories that lack an expectation file. This deals with the tricky issue of providing example usage of PySP, which has poor integration with python scripting (i.e. PySP lacks a python API, and instead directs you to command line tools). As we develop better integration with PySP, we will need to integrate it with automated testing, but that is too tricky to deal with for now.

For a quick fix, adding this behavior seemed less kludgy than writing phony output files that match a deterministic problem since this example is actually demonstrating how to specify and solve a stochastic problem.