### PR TITLE
Speeding up transmission expression construction. Also allowing new lines to have 0 initial capacity.

### DIFF
--- a/switch_mod/trans_build.py
+++ b/switch_mod/trans_build.py
@@ -194,7 +194,7 @@ def define_components(mod):
             (tx, 'Legacy') for tx in m.TRANSMISSION_LINES))
     mod.existing_trans_cap = Param(
         mod.TRANSMISSION_LINES,
-        within=PositiveReals)
+        within=NonNegativeReals)
     mod.min_data_check(
         'trans_length_km', 'trans_efficiency', 'EXISTING_TRANS_BLD_YRS',
         'existing_trans_cap')
@@ -284,6 +284,10 @@ def define_components(mod):
     mod.TRANS_DIRECTIONAL = Set(
         dimen=2,
         initialize=init_TRANS_DIRECTIONAL)
+    mod.CONNECTED_LOAD_ZONES = Set(
+        mod.LOAD_ZONES,
+        initialize=lambda m, lz: set(
+            z for z in m.LOAD_ZONES if (lz,z) in m.TRANS_DIRECTIONAL))
 
     def init_trans_d_line(m, lz_from, lz_to):
         for tx in m.TRANSMISSION_LINES:

--- a/switch_mod/trans_dispatch.py
+++ b/switch_mod/trans_dispatch.py
@@ -80,12 +80,10 @@ def define_components(mod):
 
     def LZ_TXNet_calculation(m, lz, tp):
         return (
-            sum(m.TxPowerReceived[lz_from, lz_to, t]
-                for (lz_from, lz_to, t) in m.TRANS_TIMEPOINTS
-                if lz_to == lz and t == tp) -
-            sum(m.TxPowerSent[lz_from, lz_to, t]
-                for (lz_from, lz_to, t) in m.TRANS_TIMEPOINTS
-                if lz_from == lz and t == tp))
+            sum(m.TxPowerReceived[lz_from, lz, tp] 
+                for lz_from in m.CONNECTED_LOAD_ZONES[lz]) -
+            sum(m.TxPowerSent[lz, lz_to, tp] 
+                for lz_to in m.CONNECTED_LOAD_ZONES[lz]))
     mod.LZ_TXNet = Expression(
         mod.LOAD_ZONES, mod.TIMEPOINTS,
         rule=LZ_TXNet_calculation)


### PR DESCRIPTION
-Generation of the LZ_TXNet Pyomo Expression was taking a long time, so it is replaced with a simpler expression that requires the construction of an additional Set in the trans_build module. Overall, expression construction time is reduced dramatically.
-Allowed existing Tx capacity to take a value of 0, since proposed lines do not yet exist and the model may choose or not to build them in the future. Since SWITCH takes a linear (and not binary) approach to Tx line building, then initial values of 0 are required for new lines.

I was experimenting with an input set of 1 day with hourly operations each year, for 6 periods of 5 years each (720 tps), with 190 projects, 5 possible projects, 23 load zones and 32 transmission lines. The whole solve was taking 395 s on my machine with Gurobi. By profiling it, it popped out that a surprising 230 s were being taken by the sum expressions in the LZ_TXNet_calculation Pyomo Expression construction. It seems the sum expression generator takes a lot of processing power to run through the for loop and to evaluate the if statements. So, I rewrote the expression to use a new Set so no if statements are needed. Solving time came down to 190 s with only 1.56 s being taken by the LZ_TXNet_calculation expression.

I ran another comparison with the 3_zone_toy example set and expression construction time came down from 0.00112 s to 0.00105 s, so the speedup seems to hold for smaller input sets. Also, solver time came down from 0.931 s to 0.172 s, which was interesting. Maybe this new way of building the expressions makes it easier for the solver to read them?