### PR TITLE
Make the dependency on sympy be a version-pinned dependency

### DIFF
--- a/pip_requirements.txt
+++ b/pip_requirements.txt
@@ -4,4 +4,4 @@ nose==1.3.7
 ply==3.8
 six==1.10.0
 testfixtures==4.8.0
-sympy
+sympy==1.0


### PR DESCRIPTION
All the other existing dependencies are version-pinned to ensure
reproducibility, so make the recently-added dependency on sympy be
version-pinned too for the same reason and for consistency.