### PR TITLE
Use load_aug() from switch_mod.utilities to deal with optional files

### DIFF
--- a/switch_mod/balancing_areas.py
+++ b/switch_mod/balancing_areas.py
@@ -105,20 +105,18 @@ def load_inputs(mod, switch_data, inputs_dir):
     # Include select in each load() function so that it will check out
     # column names, be indifferent to column order, and throw an error
     # message if some columns are not found.
-    switch_data.load(
+    switch_data.load_aug(
         filename=os.path.join(inputs_dir, 'lz_balancing_areas.tab'),
         select=('LOAD_ZONE', 'balancing_area'),
         param=(mod.lz_balancing_area))
-    path = os.path.join(inputs_dir, 'balancing_areas.tab')
-    if os.path.isfile(path):
-        # Load balancing area data from a file if it exists.
-        switch_data.load(
-            filename=path,
-            select=(
-                'BALANCING_AREAS', 'quickstart_res_load_frac',
-                'quickstart_res_wind_frac', 'quickstart_res_solar_frac',
-                'spinning_res_load_frac', 'spinning_res_wind_frac',
-                'spinning_res_solar_frac'),
-            param=(mod.quickstart_res_load_frac, mod.quickstart_res_wind_frac,
-                   mod.quickstart_res_solar_frac, mod.spinning_res_load_frac,
-                   mod.spinning_res_wind_frac, mod.spinning_res_solar_frac))
+    switch_data.load_aug(
+        filename=os.path.join(inputs_dir, 'balancing_areas.tab'),
+        optional=True,
+        select=(
+            'BALANCING_AREAS', 'quickstart_res_load_frac',
+            'quickstart_res_wind_frac', 'quickstart_res_solar_frac',
+            'spinning_res_load_frac', 'spinning_res_wind_frac',
+            'spinning_res_solar_frac'),
+        param=(mod.quickstart_res_load_frac, mod.quickstart_res_wind_frac,
+               mod.quickstart_res_solar_frac, mod.spinning_res_load_frac,
+               mod.spinning_res_wind_frac, mod.spinning_res_solar_frac))

--- a/switch_mod/fuel_cost.py
+++ b/switch_mod/fuel_cost.py
@@ -92,7 +92,7 @@ def load_inputs(mod, switch_data, inputs_dir):
 
     """
 
-    switch_data.load(
+    switch_data.load_aug(
         filename=os.path.join(inputs_dir, 'fuel_cost.tab'),
         select=('load_zone', 'fuel', 'period', 'fuel_cost'),
         index=mod.FUEL_AVAILABILITY,

--- a/switch_mod/fuel_markets.py
+++ b/switch_mod/fuel_markets.py
@@ -371,13 +371,11 @@ def load_inputs(mod, switch_data, inputs_dir):
     switch_data.load_aug(
         filename=os.path.join(inputs_dir, 'lz_to_regional_fuel_market.tab'),
         set=mod.LZ_RFM)
-    # Load load zone fuel cost adder data if the file is available.
-    path = os.path.join(inputs_dir, 'lz_fuel_cost_diff.tab')
-    if os.path.isfile(path):
-        switch_data.load(
-            filename=path,
-            select=('load_zone', 'fuel', 'period', 'fuel_cost_adder'),
-            param=(mod.lz_fuel_cost_adder))
+    switch_data.load_aug(
+        filename=os.path.join(inputs_dir, 'lz_fuel_cost_diff.tab'),
+        optional=True,
+        select=('load_zone', 'fuel', 'period', 'fuel_cost_adder'),
+        param=(mod.lz_fuel_cost_adder))
 
     # Load a simple specifications of costs if the file exists. The
     # actual loading, error checking, and casting into a supply curve is

--- a/switch_mod/trans_build.py
+++ b/switch_mod/trans_build.py
@@ -333,22 +333,20 @@ def load_inputs(mod, switch_data, inputs_dir):
 
     """
 
-    switch_data.load(
+    switch_data.load_aug(
         filename=os.path.join(inputs_dir, 'transmission_lines.tab'),
         select=('TRANSMISSION_LINE', 'trans_lz1', 'trans_lz2',
                 'trans_length_km', 'trans_efficiency', 'existing_trans_cap'),
         index=mod.TRANSMISSION_LINES,
         param=(mod.trans_lz1, mod.trans_lz2, mod.trans_length_km,
                mod.trans_efficiency, mod.existing_trans_cap))
-    trans_optional_params_path = os.path.join(
-        inputs_dir, 'trans_optional_params.tab')
-    if os.path.isfile(trans_optional_params_path):
-        switch_data.load(
-            filename=trans_optional_params_path,
-            select=('TRANSMISSION_LINE', 'trans_dbid', 'trans_derating_factor',
-                    'trans_terrain_multiplier', 'trans_new_build_allowed'),
-            param=(mod.trans_dbid, mod.trans_derating_factor,
-                   mod.trans_terrain_multiplier, mod.trans_new_build_allowed))
+    switch_data.load_aug(
+        filename=os.path.join(inputs_dir, 'trans_optional_params.tab'),
+        optional=True,
+        select=('TRANSMISSION_LINE', 'trans_dbid', 'trans_derating_factor',
+                'trans_terrain_multiplier', 'trans_new_build_allowed'),
+        param=(mod.trans_dbid, mod.trans_derating_factor,
+               mod.trans_terrain_multiplier, mod.trans_new_build_allowed))
     trans_params_path = os.path.join(inputs_dir, 'trans_params.dat')
     if os.path.isfile(trans_params_path):
         switch_data.load(filename=trans_params_path)


### PR DESCRIPTION
Use load_aug() from switch_mod.utilities to deal with optional files instead of wrapping the standard DataPortal load() function with a "if os.path.isfile(): ..."

Really, just avoid using load() for any .tab file.