### PR TITLE
Fuel_Costs_TP Expression speedup

### DIFF
--- a/switch_mod/fuel_cost.py
+++ b/switch_mod/fuel_cost.py
@@ -70,17 +70,17 @@ def define_components(mod):
 
     # Summarize total fuel costs in each timepoint for the objective function
     def Fuel_Costs_TP_rule(m, t):
-    if not hasattr(m, 'Fuel_Costs_TP_dict'):
-        # cache all Fuel_Cost_TP values in a dictionary (created in one pass)
-        m.Fuel_Costs_TP_dict = {t2: 0.0 for t2 in m.TIMEPOINTS}
-        for (proj, t2, f) in m.PROJ_FUEL_DISPATCH_POINTS:
-            if (m.proj_load_zone[proj], f, m.tp_period[t2]) in m.FUEL_AVAILABILITY:
-                m.Fuel_Costs_TP_dict[t2] += (
-                    m.ProjFuelUseRate[proj, t2, f] 
-                    * m.fuel_cost[m.proj_load_zone[proj], f, m.tp_period[t2]])
-    # return a result from the dictionary and pop the element each time 
-    # to release memory
-    return m.Fuel_Costs_TP_dict.pop(t)
+        if not hasattr(m, 'Fuel_Costs_TP_dict'):
+            # cache all Fuel_Cost_TP values in a dictionary (created in one pass)
+            m.Fuel_Costs_TP_dict = {t2: 0.0 for t2 in m.TIMEPOINTS}
+            for (proj, t2, f) in m.PROJ_FUEL_DISPATCH_POINTS:
+                if (m.proj_load_zone[proj], f, m.tp_period[t2]) in m.FUEL_AVAILABILITY:
+                    m.Fuel_Costs_TP_dict[t2] += (
+                        m.ProjFuelUseRate[proj, t2, f] 
+                        * m.fuel_cost[m.proj_load_zone[proj], f, m.tp_period[t2]])
+        # return a result from the dictionary and pop the element each time 
+        # to release memory
+        return m.Fuel_Costs_TP_dict.pop(t)
     mod.Fuel_Costs_TP = Expression(mod.TIMEPOINTS, rule=Fuel_Costs_TP_rule)
     mod.cost_components_tp.append('Fuel_Costs_TP')
 

--- a/switch_mod/fuel_cost.py
+++ b/switch_mod/fuel_cost.py
@@ -74,10 +74,9 @@ def define_components(mod):
         rule=lambda m, t: sum(
             m.ProjFuelUseRate[proj, t, f] 
                 * m.fuel_cost[(m.proj_load_zone[proj], f, m.tp_period[t])]
-            for (proj, t2, f) in m.PROJ_FUEL_DISPATCH_POINTS
-            if((t2 == t) and (
-                (m.proj_load_zone[proj], f, m.tp_period[t]) in
-                m.FUEL_AVAILABILITY))))
+            for (proj, f) in m.DISPATCHED_PROJECTS_FUEL_IN_TP[t]
+            if (m.proj_load_zone[proj], f, m.tp_period[t]) in
+                m.FUEL_AVAILABILITY))
     mod.cost_components_tp.append('Fuel_Costs_TP')
 
 

--- a/switch_mod/fuel_cost.py
+++ b/switch_mod/fuel_cost.py
@@ -69,14 +69,19 @@ def define_components(mod):
         rule=lambda m, pr, t, f: m.ProjFuelUseRate[pr, t, f] == 0)
 
     # Summarize total fuel costs in each timepoint for the objective function
-    mod.Fuel_Costs_TP = Expression(
-        mod.TIMEPOINTS,
-        rule=lambda m, t: sum(
-            m.ProjFuelUseRate[proj, t, f] 
-                * m.fuel_cost[(m.proj_load_zone[proj], f, m.tp_period[t])]
-            for (proj, f) in m.DISPATCHED_PROJECTS_FUEL_IN_TP[t]
-            if (m.proj_load_zone[proj], f, m.tp_period[t]) in
-                m.FUEL_AVAILABILITY))
+    def Fuel_Costs_TP_rule(m, t):
+    if not hasattr(m, 'Fuel_Costs_TP_dict'):
+        # cache all Fuel_Cost_TP values in a dictionary (created in one pass)
+        m.Fuel_Costs_TP_dict = {t2: 0.0 for t2 in m.TIMEPOINTS}
+        for (proj, t2, f) in m.PROJ_FUEL_DISPATCH_POINTS:
+            if (m.proj_load_zone[proj], f, m.tp_period[t2]) in m.FUEL_AVAILABILITY:
+                m.Fuel_Costs_TP_dict[t2] += (
+                    m.ProjFuelUseRate[proj, t2, f] 
+                    * m.fuel_cost[m.proj_load_zone[proj], f, m.tp_period[t2]])
+    # return a result from the dictionary and pop the element each time 
+    # to release memory
+    return m.Fuel_Costs_TP_dict.pop(t)
+    mod.Fuel_Costs_TP = Expression(mod.TIMEPOINTS, rule=Fuel_Costs_TP_rule)
     mod.cost_components_tp.append('Fuel_Costs_TP')
 
 

--- a/switch_mod/project/dispatch.py
+++ b/switch_mod/project/dispatch.py
@@ -260,13 +260,6 @@ def define_components(mod):
     # mod.PROJ_WITH_FUEL_DISPATCH_POINTS = Set(
     #     initialize=mod.PROJ_DISPATCH_POINTS,
     #     filter=lambda m, p, t: m.g_uses_fuel[m.proj_gen_tech[p]])
-    mod.DISPATCHED_PROJECTS_FUEL_IN_TP = Set(
-        mod.TIMEPOINTS,
-        dimen=2,
-        initialize=lambda m, t: (
-            (p, f) for p in m.PROJECTS 
-            if (p, t) in m.PROJ_WITH_FUEL_DISPATCH_POINTS 
-                for f in m.G_FUELS[m.proj_gen_tech[p]]))
     mod.PROJ_FUEL_DISPATCH_POINTS = Set(
         dimen=3,
         initialize=lambda m: (

--- a/switch_mod/project/dispatch.py
+++ b/switch_mod/project/dispatch.py
@@ -260,6 +260,13 @@ def define_components(mod):
     # mod.PROJ_WITH_FUEL_DISPATCH_POINTS = Set(
     #     initialize=mod.PROJ_DISPATCH_POINTS,
     #     filter=lambda m, p, t: m.g_uses_fuel[m.proj_gen_tech[p]])
+    mod.DISPATCHED_PROJECTS_FUEL_IN_TP = Set(
+        mod.TIMEPOINTS,
+        dimen=2,
+        initialize=lambda m, t: (
+            (p, f) for p in m.PROJECTS 
+            if (p, t) in m.PROJ_WITH_FUEL_DISPATCH_POINTS 
+                for f in m.G_FUELS[m.proj_gen_tech[p]]))
     mod.PROJ_FUEL_DISPATCH_POINTS = Set(
         dimen=3,
         initialize=lambda m: (


### PR DESCRIPTION
The Fuel_Costs_TP Expression in the fuel_cost module is taking significant time to be constructed. By building and using a new Set, this process can be sped up.

For the same input set used in my last commit (23 lz, 720 tp, 190 proj, 32 tx lines) building the Fuel_Costs_TP Expression was taking 7,76 s and the whole load_inputs function was at 71,04 s.
With these changes, the Expression construction takes 1,64 s and the load_inputs function takes 68,63 s.
Model instantiation is sped up only slightly (because the Expression akes less time to build, but a new Set has to be constructed), but I believe it may become more significant in larger models, specially with more timepoints.