### PR TITLE
Standarizing the way Switch writes output.

### DIFF
--- a/examples/custom_extension/sunk_costs.py
+++ b/examples/custom_extension/sunk_costs.py
@@ -9,8 +9,10 @@ mimics the convention of switch modules that can include the following
 functions:
 
 define_components(model)
-load_data(model, data_portal, inputs_dir)
-save_results(model, instance, outdir)
+define_dynamic_components(model)
+load_inputs(model, data_portal, inputs_dir)
+pre_solve(instance, outdir)
+post_solve(instance, outdir)
 
 In this example, I have only implemented define_components() which adds
 a administration_fees parameter to the model that specifies a fixed

--- a/switch_mod/__init__.py
+++ b/switch_mod/__init__.py
@@ -41,4 +41,5 @@ core_modules = [
     'switch_mod.load_zones',
     'switch_mod.fuels',
     'switch_mod.gen_tech',
-    'switch_mod.project']
+    'switch_mod.project',
+    'switch_mod.export']

--- a/switch_mod/export/__init__.py
+++ b/switch_mod/export/__init__.py
@@ -19,9 +19,10 @@ dependency on load_zones.
 
 """
 
+import os
 import csv
 import itertools
-from pyomo.environ import value
+from pyomo.environ import value, Var
 
 csv.register_dialect(
     "ampl-tab",
@@ -52,3 +53,54 @@ def write_table(instance, *indexes, **kwargs):
             tuple(value(v) for v in values(instance, *x))
             for x in idx
         )
+
+
+def make_iterable(item):
+    """Return an iterable for the one or more items passed."""
+    if isinstance(item, basestring):
+        i = iter([item])
+    else:
+        try:
+            # check if it's iterable
+            i = iter(item)
+        except TypeError:
+            i = iter([item])
+    return i
+
+
+def _save_generic_results(instance, outdir, deterministic_order=False):
+    for var in instance.component_objects():
+        if not isinstance(var, Var):
+            continue
+
+        index_name = var.index_set().name
+        output_file = os.path.join(outdir, '%s.tab' % var.name)
+        with open(output_file, 'wb') as fh:
+            writer = csv.writer(fh, dialect='ampl-tab')
+            # Write column headings
+            writer.writerow(['%s_%d' % (index_name, i + 1)
+                             for i in xrange(var.index_set().dimen)] +
+                            [var.name])
+            # Results are saved in a random order by default for
+            # increased speed. Sorting is available if wanted.
+            for key, obj in (sorted(var.items())
+                            if deterministic_order
+                            else var.items()):
+                writer.writerow(tuple(make_iterable(key)) + (obj.value,))
+
+
+def _save_total_cost_value(instance, outdir):
+    values = instance.Minimize_System_Cost.values()
+    assert len(values) == 1
+    total_cost = values[0].expr()
+    with open(os.path.join(outdir, 'total_cost.txt'), 'w') as fh:
+        fh.write('%s\n' % total_cost)
+
+
+def post_solve(instance, outdir):
+    """
+    Minimum output generation for all model runs.
+    
+    """
+    _save_generic_results(instance, outdir)
+    _save_total_cost_value(instance, outdir)

--- a/switch_mod/export/dump.py
+++ b/switch_mod/export/dump.py
@@ -27,7 +27,7 @@ def _print_output(instance):
         raise RuntimeError("Invalid value for command line param --dump-level") 
 
 
-def save_results(model, instance, outdir):
+def post_solve(instance, outdir):
     """
     Dump the model & solution to model_dump.txt using either instance.display()
     or instance.pprint(), depending on the value of dump-level. Default is pprint().

--- a/switch_mod/export/example_export.py
+++ b/switch_mod/export/example_export.py
@@ -10,7 +10,7 @@ This module has prerequisites of timescales and load_zones.
 """
 import os
 
-def save_results(model, instance, outdir):
+def post_solve(instance, outdir):
     """
     Export results to standard files.
 

--- a/switch_mod/generators/storage.py
+++ b/switch_mod/generators/storage.py
@@ -308,7 +308,7 @@ def load_inputs(mod, switch_data, inputs_dir):
         param=(mod.proj_storage_energy_overnight_cost))
 
 
-def save_results(model, instance, outdir):
+def post_solve(instance, outdir):
     """
     Export storage build information to storage_builds.txt, and storage
     dispatch info to storage_dispatch.txt

--- a/switch_mod/load_zones.py
+++ b/switch_mod/load_zones.py
@@ -163,12 +163,9 @@ def load_inputs(mod, switch_data, inputs_dir):
         param=(mod.lz_demand_mw))
 
 
-def save_results(model, instance, outdir):
+def post_solve(instance, outdir):
     """
-    Export results to standard files.
-
-    This initial placeholder version is integrating snippets of
-    some of Matthias's code into the main codebase.
+    Default export of energy balance per node and timepoint in tabular format.
 
     """
     import switch_mod.export as export

--- a/switch_mod/project/dispatch.py
+++ b/switch_mod/project/dispatch.py
@@ -340,12 +340,9 @@ def load_inputs(mod, switch_data, inputs_dir):
                mod.proj_forced_outage_rate, mod.proj_scheduled_outage_rate))
 
 
-def save_results(model, instance, outdir):
+def post_solve(instance, outdir):
     """
-    Export results to standard files.
-
-    This initial placeholder version is integrating snippets of
-    some of Matthias's code into the main codebase.
+    Default export of project dispatch per timepoint in tabular format.
 
     """
     import switch_mod.export as export

--- a/switch_mod/solve.py
+++ b/switch_mod/solve.py
@@ -49,13 +49,13 @@ def main(args=None, return_model=False, return_instance=False):
     iterate_modules = get_iteration_list(model)
     
     if model.options.verbose:
-        print "\n\n======================================================================="
+        print "\n======================================================================="
         print "arguments:"
         print " ".join(k+"="+repr(v) for k, v in model.options.__dict__.items() if v)
         print "modules:", modules
         if iterate_modules:
             print "iterate_modules", iterate_modules
-        print "======================================================================="
+        print "=======================================================================\n"
 
     # create an instance
     instance = model.load_inputs()
@@ -84,7 +84,9 @@ def main(args=None, return_model=False, return_instance=False):
         iterate(instance, iterate_modules)
     else:
         results = solve(instance)
-        instance.save_results(results, instance, instance.options.outputs_dir)
+        if instance.options.verbose:
+            print ("Optimization termination condition was %s." 
+                    % results.solver.termination_condition)
     
     # report/save results
     instance.post_solve()
@@ -262,6 +264,10 @@ def define_arguments(argparser):
     #     help='Directory containing input files (default is "inputs")')
     argparser.add_argument("--outputs-dir", default="outputs",
         help='Directory to write output files (default is "outputs")')
+    argparser.add_argument(
+        "--sorted-output", default=False, action='store_true', 
+        dest='deterministic_order',
+        help='Write generic variable result values in sorted order')
 
     # General purpose arguments
     argparser.add_argument(

--- a/switch_mod/solve.py
+++ b/switch_mod/solve.py
@@ -264,10 +264,6 @@ def define_arguments(argparser):
     #     help='Directory containing input files (default is "inputs")')
     argparser.add_argument("--outputs-dir", default="outputs",
         help='Directory to write output files (default is "outputs")')
-    argparser.add_argument(
-        "--sorted-output", default=False, action='store_true', 
-        dest='deterministic_order',
-        help='Write generic variable result values in sorted order')
 
     # General purpose arguments
     argparser.add_argument(

--- a/switch_mod/utilities.py
+++ b/switch_mod/utilities.py
@@ -5,7 +5,6 @@
 Utility functions for SWITCH-pyomo.
 """
 
-import csv
 import os
 import types
 import importlib
@@ -14,7 +13,6 @@ import argparse
 import __main__ as main
 from pyomo.environ import *
 import pyomo.opt
-import switch_mod.export # For ampl-tab dialect
 import datetime
 
 # This stores full names of modules that are dynamically loaded to
@@ -37,7 +35,7 @@ def create_model(module_list, args=sys.argv[1:]):
     Construct a Pyomo AbstractModel using the Switch modules or packages
     in the given list and return the model. The following utility methods
     are attached to the model as class methods to simplify their use:
-    min_data_check(), load_inputs(), save_results().
+    min_data_check(), load_inputs(), pre_solve(), post_solve().
 
     This is implemented as calling define_components() for each module
     that has that function defined, then calling
@@ -199,22 +197,22 @@ def save_inputs_as_dat(model, instance, save_path="inputs/complete_inputs.dat",
                     "Error! Component type {} not recognized for model element '{}'.".
                     format(comp_class, component_name))
 
-def pre_solve(model, outputs_dir=None):
+def pre_solve(instance, outputs_dir=None):
     """
     Call pre-solve function (if present) in all modules used to compose this model.
     This function can be used to adjust the instance after it is created and before it is solved.
     """
-    for module in get_module_list(model):
+    for module in get_module_list(instance):
         if hasattr(module, 'pre_solve'):
-            module.pre_solve(model)
+            module.pre_solve(instance)
 
-def post_solve(model, outputs_dir=None):
+def post_solve(instance, outputs_dir=None):
     """
     Call post-solve function (if present) in all modules used to compose this model. 
     This function can be used to report or save results from the solved model.
     """
     if outputs_dir is None:
-        outputs_dir = getattr(model.options, "outputs_dir", "outputs")
+        outputs_dir = getattr(instance.options, "outputs_dir", "outputs")
     if not os.path.exists(outputs_dir):
         os.makedirs(outputs_dir)
         
@@ -223,11 +221,9 @@ def post_solve(model, outputs_dir=None):
     # (the latter occurs when there are problems with licenses, etc)
     
     # replace the old _save_results function
-    for module in get_module_list(model):
+    for module in get_module_list(instance):
         if hasattr(module, 'post_solve'):
-            module.post_solve(model, outputs_dir)
-    _save_generic_results(model, outputs_dir)
-    _save_total_cost_value(model, outputs_dir)
+            module.post_solve(instance, outputs_dir)
 
 
 def min_data_check(model, *mandatory_model_components):
@@ -515,35 +511,6 @@ def _load_inputs(model, inputs_dir, module_list, data):
             _load_inputs(model, inputs_dir, module.core_modules, data)
 
 
-def _save_generic_results(instance, outdir):
-    for var in instance.component_objects():
-        if not isinstance(var, Var):
-            continue
-
-        index_name = var.index_set().name
-        output_file = os.path.join(outdir, '%s.tab' % var.name)
-        with open(output_file, 'wb') as fh:
-            writer = csv.writer(fh, dialect='ampl-tab')
-            # Write column headings
-            writer.writerow(['%s_%d' % (index_name, i + 1)
-                             for i in xrange(var.index_set().dimen)] +
-                            [var.name])
-            # Results are saved in a random order by default for
-            # increased speed. Sorting is available if wanted.
-            for key, obj in (sorted(var.items())
-                            if instance.options.deterministic_order
-                            else var.items()):
-                writer.writerow(tuple(make_iterable(key)) + (obj.value,))
-
-
-def _save_total_cost_value(instance, outdir):
-    values = instance.Minimize_System_Cost.values()
-    assert len(values) == 1
-    total_cost = values[0].expr()
-    with open(os.path.join(outdir, 'total_cost.txt'), 'w') as fh:
-        fh.write('%s\n' % total_cost)
-
-
 class InputError(Exception):
     """Exception raised for errors in the input.
 
@@ -707,18 +674,6 @@ def approx_equal(a, b, tolerance=0.01):
 
 def default_solver():
     return pyomo.opt.SolverFactory('glpk')
-
-def make_iterable(item):
-    """Return an iterable for the one or more items passed."""
-    if isinstance(item, basestring):
-        i = iter([item])
-    else:
-        try:
-            # check if it's iterable
-            i = iter(item)
-        except TypeError:
-            i = iter([item])
-    return i
 
 
 class Logging:

--- a/switch_mod/utilities.py
+++ b/switch_mod/utilities.py
@@ -217,10 +217,9 @@ def post_solve(instance, outputs_dir=None):
         os.makedirs(outputs_dir)
         
     # TODO: implement a check to call post solve functions only if
-    # solver termination condition was not infeasible or unknown
-    # (the latter occurs when there are problems with licenses, etc)
+    # solver termination condition is not 'infeasible' or 'unknown'
+    # (the latter may occur when there are problems with licenses, etc)
     
-    # replace the old _save_results function
     for module in get_module_list(instance):
         if hasattr(module, 'post_solve'):
             module.post_solve(instance, outputs_dir)


### PR DESCRIPTION
- Removed the save_results and _save_results functions for exclusive
use of the post_solve function. Replaced the latter in all modules
which were still using save_results. This eliminates several redundancies.
- Since most new Switch users are also new Pyomo users, there is a very
slim chance that they will be using old Pyomo versions, so I didn't import some snippet of code from save_results into post_solve which was supporting them.
Since there were no checks for solver termination conditions and only
a print statement, I put a generic printing of the condition on the
solve module, if verbose option is on.
- Added an option for sorted output of generic variables. The capacity
was already written, but no command line option was available.

Passes the tests and gives me the same output as in the examples folders. Code should be compatible with Hawaii modules, since its own save_results module has a post_solve function which will be called upon solver termination.