### PR TITLE
Make the rhosetter's regular expression capable of dealing with exponents in the cost coefficients

### DIFF
--- a/examples/3zone_toy_stochastic_PySP/rhosetter.py
+++ b/examples/3zone_toy_stochastic_PySP/rhosetter.py
@@ -52,7 +52,7 @@ def ph_rhosetter_callback(ph, scenario_tree, scenario):
     # parts because I used two sets of parenthesis. I don't care about the
     # second parenthesis that returns the indexed bits, just the larger part
 
-    pattern = "(?<=[^a-zA-Z])([a-zA-Z][a-zA-Z_0-9]*(\[[^]]*\])?)"
+    pattern = "(?<=[^a-zA-Z])([a-zA-Z][a-zA-Z_0-9]+(\[[^]]*\])?)"
     component_by_alias = {}
     variable_list = findall(pattern, objective_as_str)
     for (cname, index_as_str) in variable_list:


### PR DESCRIPTION
Tweak the rhosetter string matching pattern in so it isn't confused by cost coefficients that include exponents (like 2e-7, for example). This could make it break with single-letter decision variable names, but we never use those, so that shouldn't be an issue.

I tested this with the 3zone stochastic example and it works identically as before.