### PR TITLE
Add command line option to allow sorted output printing.

### DIFF
--- a/examples/3zone_toy_stochastic_PySP/PySPInputGenerator.py
+++ b/examples/3zone_toy_stochastic_PySP/PySPInputGenerator.py
@@ -72,14 +72,14 @@ from pyomo.environ import *
 print "creating model for scenario input generation..."
 
 try:
-    module_fh = open(os.path.join(inputs_dir, 'modules'), 'r')
+    module_fh = open(os.path.join(inputs_dir, 'modules.txt'), 'r')
 except IOError, exc:
     sys.exit('Failed to open input file: {}'.format(exc))
 
 module_list = [line.rstrip('\n') for line in module_fh]
 module_list.insert(0,'switch_mod')
 
-model = utilities.define_AbstractModel(*module_list)
+model = utilities.create_model(module_list)
 
 print "model successfully created..."
 

--- a/examples/3zone_toy_stochastic_PySP/PySPInputGenerator.py
+++ b/examples/3zone_toy_stochastic_PySP/PySPInputGenerator.py
@@ -97,8 +97,8 @@ def save_dat_files():
 
     dat_file = os.path.join(inputs_dir, pysp_subdir, "RootNode.dat")
     print "creating and saving {}...".format(dat_file)
-    utilities.save_inputs_as_dat(
-        model, instance, save_path=dat_file, determistic_order=True)
+    utilities.save_inputs_as_dat(model, instance, save_path=dat_file,
+        sorted_output=model.options.sorted_output)
     
     #######################
     # ScenarioStructure.dat

--- a/examples/3zone_toy_stochastic_PySP/README.md
+++ b/examples/3zone_toy_stochastic_PySP/README.md
@@ -48,6 +48,8 @@ PySPInputGenerator.py
     problem. Further documentation on the construction of these files is located
     inside this script. Note: branch and leaf node .dat files are not generated
     by this file, they must be built by the user.
+    You may execute this script with the SWITCH command line option
+    "--sorted-output" (without quotes) to get a sorted .dat file.
 
 rhosetter.py
     When using the progressive hedging algorithm a value for the Rho parameter

--- a/switch_mod/export/__init__.py
+++ b/switch_mod/export/__init__.py
@@ -33,6 +33,11 @@ csv.register_dialect(
     skipinitialspace=False
 )
 
+def define_arguments(argparser):
+    argparser.add_argument(
+        "--sorted-output", default=False, action='store_true',
+        dest='sorted_output',
+        help='Write generic variable result values in sorted order')
 
 def write_table(instance, *indexes, **kwargs):
     # there must be a way to accept specific named keyword arguments and
@@ -68,7 +73,7 @@ def make_iterable(item):
     return i
 
 
-def _save_generic_results(instance, outdir, deterministic_order=False):
+def _save_generic_results(instance, outdir, sorted_output):
     for var in instance.component_objects():
         if not isinstance(var, Var):
             continue
@@ -84,7 +89,7 @@ def _save_generic_results(instance, outdir, deterministic_order=False):
             # Results are saved in a random order by default for
             # increased speed. Sorting is available if wanted.
             for key, obj in (sorted(var.items())
-                            if deterministic_order
+                            if sorted_output
                             else var.items()):
                 writer.writerow(tuple(make_iterable(key)) + (obj.value,))
 
@@ -102,5 +107,5 @@ def post_solve(instance, outdir):
     Minimum output generation for all model runs.
     
     """
-    _save_generic_results(instance, outdir)
+    _save_generic_results(instance, outdir, instance.options.sorted_output)
     _save_total_cost_value(instance, outdir)

--- a/switch_mod/utilities.py
+++ b/switch_mod/utilities.py
@@ -127,7 +127,8 @@ def load_inputs(model, inputs_dir=None, attachDataPortal=True):
     return instance
 
 
-def save_inputs_as_dat(model, instance, save_path="inputs/complete_inputs.dat", exclude=[], sorted_output=False):
+def save_inputs_as_dat(model, instance, save_path="inputs/complete_inputs.dat",
+    exclude=[], sorted_output=False):
     """
     Save input data to a .dat file for use with PySP or other command line
     tools that have not been fully integrated with DataPortal.

--- a/switch_mod/utilities.py
+++ b/switch_mod/utilities.py
@@ -127,8 +127,7 @@ def load_inputs(model, inputs_dir=None, attachDataPortal=True):
     return instance
 
 
-def save_inputs_as_dat(model, instance, save_path="inputs/complete_inputs.dat",
-                       exclude=[], deterministic_order=False):
+def save_inputs_as_dat(model, instance, save_path="inputs/complete_inputs.dat", exclude=[], sorted_output=False):
     """
     Save input data to a .dat file for use with PySP or other command line
     tools that have not been fully integrated with DataPortal.
@@ -174,7 +173,7 @@ def save_inputs_as_dat(model, instance, save_path="inputs/complete_inputs.dat",
                     else:
                         f.write("\n")
                         for key,value in (sorted(component_data.iteritems()) 
-                                          if deterministic_order 
+                                          if sorted_output
                                           else component_data.iteritems()):
                             f.write(" " + 
                                     ' '.join(map(str, key)) + " " +


### PR DESCRIPTION
Default behavior is to print without sorting, to prioritize speed.

This option is extremely useful for visual inspection when developing new code or testing datasets, specially when combined with a nice diff tool.