### PR TITLE
Fix to the min-build bugs from pull request #63.

### DIFF
--- a/examples/discrete_and_min_build/inputs/modules.txt
+++ b/examples/discrete_and_min_build/inputs/modules.txt
@@ -1,5 +1,4 @@
 local_td
 project.discrete_build
-project.min_build
 project.no_commit
 fuel_markets

--- a/switch_mod/local_td.py
+++ b/switch_mod/local_td.py
@@ -44,11 +44,6 @@ def define_components(mod):
     transmission and distribution capacity in MW that has already been
     built.
 
-    lz_peak_demand_mw[z,p] describes the peak demand in each load zone z
-    and each investment period p. This optional parameter defaults to
-    the highest load in the lz_demand_mw timeseries for the given load
-    zone & period.
-
     BuildLocalTD[(lz, bld_yr) in LOCAL_TD_BUILD_YEARS] is a decision
     variable describing how much local transmission and distribution to
     build in a load zone. For existing builds, this variable is locked
@@ -139,11 +134,6 @@ def define_components(mod):
         dimen=2,
         initialize=lambda m: set((lz, 'Legacy') for lz in m.LOAD_ZONES))
     mod.existing_local_td = Param(mod.LOAD_ZONES, within=NonNegativeReals)
-    mod.lz_peak_demand_mw = Param(
-        mod.LOAD_ZONES, mod.PERIODS,
-        within=NonNegativeReals,
-        default=lambda m, lz, p: max(
-            m.lz_demand_mw[lz, t] for t in m.PERIOD_TPS[p]))
     mod.min_data_check('existing_local_td')
     mod.LOCAL_TD_BUILD_YEARS = Set(
         dimen=2,
@@ -203,14 +193,11 @@ def load_inputs(mod, switch_data, inputs_dir):
     """
 
     Import local transmission & distribution data. The following files
-    are expected in the input directory. load_zones.tab will likely
+    are expected in the input directory. load_zones.tab will
     contain additional columns that are used by the load_zones module.
 
     load_zones.tab
         load_zone, existing_local_td, local_td_annual_cost_per_mw
-
-    lz_peak_loads.tab is optional.
-        LOAD_ZONE, PERIOD, peak_demand_mw
 
     """
 
@@ -218,8 +205,3 @@ def load_inputs(mod, switch_data, inputs_dir):
         filename=os.path.join(inputs_dir, 'load_zones.tab'),
         auto_select=True,
         param=(mod.existing_local_td, mod.local_td_annual_cost_per_mw))
-    switch_data.load_aug(
-        optional=True,
-        filename=os.path.join(inputs_dir, 'lz_peak_loads.tab'),
-        select=('LOAD_ZONE', 'PERIOD', 'peak_demand_mw'),
-        param=(mod.lz_peak_demand_mw))

--- a/switch_mod/project/build.py
+++ b/switch_mod/project/build.py
@@ -130,9 +130,8 @@ def define_components(mod):
     generation technologies that have those requirements. They force BuildProj
     to be 0 when ProjCommitToMinBuild is 0, and to be greater than
     g_min_build_capacity when ProjCommitToMinBuild is 1. In the latter case,
-    the upper constraint should be non-binding. The total demand over all
-    periods and load zones is used as  a limit, as in the extreme case where
-    all energy should have to be served in one hour.
+    the upper constraint should be non-binding; the upper limit is set to 10
+    times the peak non-conincident demand of the entire system.
 
     --- OPERATIONS ---
 
@@ -389,10 +388,9 @@ def define_components(mod):
         mod.NEW_PROJ_WITH_MIN_BUILD_YEARS,
         rule=lambda m, proj, p: (
             m.BuildProj[proj, p] <=
-            m.ProjCommitToMinBuild[proj, p] *
-            sum(m.lz_total_demand_in_period_mwh[lz, p2]
-                for lz in m.LOAD_ZONES
-                for p2 in m.PERIODS)))
+            m.ProjCommitToMinBuild[proj, p] * 10 * 
+            sum(m.lz_peak_demand_mw[lz, p]
+                for lz in m.LOAD_ZONES)))
 
     # Costs
     mod.proj_connect_cost_per_mw = Param(mod.PROJECTS, within=NonNegativeReals)


### PR DESCRIPTION
* Removed dangling reference to project.min_build
* Moved peak coincident load from local_td to load_zones so it could be available to more modules.
* Use system-wide non-coincident peak load as a basis for binary constraints on capacity. Using an overly large number like cumulative system-wide energy from the entire study horizon was producing errors in how glpk handled the constraint that enforces a binary decision.