### PR TITLE
More minor fixes

### DIFF
--- a/switch_mod/generators/storage.py
+++ b/switch_mod/generators/storage.py
@@ -164,7 +164,7 @@ def define_components(mod):
                 m.Storage_Build_Summation_dict[p2] = set(
                     (proj, bld_yr)
                     for bld_yr in m.G_NEW_BUILD_YEARS[m.proj_gen_tech[proj]]
-                    if bld_yr <= p2 <= m.proj_end_year[proj, bld_yr])
+                    if bld_yr <= p2 <= m.proj_final_period[proj, bld_yr])
         # Use pop to free memory
         relevant_proj_build_years = m.Storage_Build_Summation_dict.pop(p)
         return sum(m.BuildStorageEnergyMWh[proj, bld_yr] *

--- a/switch_mod/project/build.py
+++ b/switch_mod/project/build.py
@@ -112,7 +112,7 @@ def define_components(mod):
 
         ProjCapacity <= proj_capacity_limit_mw
 
-    proj_end_year[(proj, build_year) in PROJECT_BUILDYEARS] is the last
+    proj_final_period[(proj, build_year) in PROJECT_BUILDYEARS] is the last
     investment period in the simulation that a given project build will
     be operated. It can either indicate retirement or the end of the
     simulation. This is derived from g_max_age.
@@ -301,20 +301,20 @@ def define_components(mod):
         initialize=lambda m: set(
             m.EXISTING_PROJ_BUILDYEARS | m.NEW_PROJ_BUILDYEARS))
 
-    def init_proj_end_year(m, proj, build_year):
+    def init_proj_final_period(m, proj, build_year):
         g = m.proj_gen_tech[proj]
         max_age = m.g_max_age[g]
         earliest_study_year = m.period_start[m.PERIODS.first()]
         if build_year + max_age < earliest_study_year:
             return build_year + max_age
         for p in m.PERIODS:
-            if build_year + max_age < m.period_end[p]:
+            if build_year + max_age <= m.period_start[p] + m.period_length_years[p]:
                 break
         return p
-    mod.proj_end_year = Param(
+    mod.proj_final_period = Param(
         mod.PROJECT_BUILDYEARS,
-        initialize=init_proj_end_year)
-    mod.min_data_check('proj_end_year')
+        initialize=init_proj_final_period)
+    mod.min_data_check('proj_final_period')
 
     mod.PROJECT_BUILDS_OPERATIONAL_PERIODS = Set(
         mod.PROJECT_BUILDYEARS,
@@ -322,14 +322,14 @@ def define_components(mod):
         ordered=True,
         initialize=lambda m, proj, bld_yr: set(
             p for p in m.PERIODS
-            if bld_yr <= p <= m.proj_end_year[proj, bld_yr]))
+            if bld_yr <= p <= m.proj_final_period[proj, bld_yr]))
     # The set of build years that could be online in the given period
     # for the given project.
     mod.PROJECT_PERIOD_ONLINE_BUILD_YRS = Set(
         mod.PROJECTS, mod.PERIODS,
         initialize=lambda m, proj, p: set(
             bld_yr for (prj, bld_yr) in m.PROJECT_BUILDYEARS
-            if prj == proj and bld_yr <= p <= m.proj_end_year[proj, bld_yr]))
+            if prj == proj and bld_yr <= p <= m.proj_final_period[proj, bld_yr]))
 
     def bounds_BuildProj(model, proj, bld_yr):
         if((proj, bld_yr) in model.EXISTING_PROJ_BUILDYEARS):

--- a/switch_mod/project/no_commit.py
+++ b/switch_mod/project/no_commit.py
@@ -106,13 +106,3 @@ def define_components(mod):
             sum(m.ProjFuelUseRate[proj, t, f] for f in m.G_FUELS[m.proj_gen_tech[proj]])
             ==
             m.DispatchProj[proj, t] * m.proj_full_load_heat_rate[proj]))
-
-    # allocate the power produced during each timepoint among the fuels
-    # Here, we just calculate it from fuel usage and the full load heat rate,
-    # but it could be more complicated if we model the plant in more detail.
-    # note: this must be linear, because it may be used in RPS calculations
-    mod.DispatchProjByFuel = Expression(
-        mod.PROJ_FUEL_DISPATCH_POINTS,
-        rule=lambda m, proj, t, f:
-            m.ProjFuelUseRate[proj, t, f] / m.proj_full_load_heat_rate[proj]
-    )

--- a/switch_mod/project/unitcommit/fuel_use.py
+++ b/switch_mod/project/unitcommit/fuel_use.py
@@ -145,28 +145,6 @@ def define_components(mod):
             intercept * m.CommitProject[pr, t] +
             incremental_heat_rate * m.DispatchProj[pr, t]))
 
-    # Allocate the power produced during each timepoint among the fuels.
-    # This can be written as a non-linear expression, but that can't be
-    # added to a model, since it will produce division-by-zero errors at 
-    # times and Pyomo Expressions can't use if functions to work around
-    # this. The quadratic version below can be used in a model (e.g.,
-    # for RPS calculations.) However, it would force all users to use a
-    # quadratic solver, so we haven't activated it. Eventually we may need
-    # a way for users to turn this on (e.g., to run an RPS with unit 
-    # commitment). (Also note: this could be replaced with 
-    # m.DispatchProjByFuel[proj, t, f] == DispatchProj[proj, t]
-    # for projects that only use one fuel, but we'd need extra code to take 
-    # advantage of that.)
-    # mod.DispatchProjByFuel = Var(mod.PROJ_FUEL_DISPATCH_POINTS)
-    # mod.DispatchProjByFuel_Allocate = Constraint(
-    #     mod.PROJ_FUEL_DISPATCH_POINTS,
-    #     rule = lambda m, proj, t, f:
-    #         m.DispatchProjByFuel[proj, t, f]
-    #         * sum(m.ProjFuelUseRate[proj, t, _f] for _f in m.G_FUELS[m.proj_gen_tech[proj]])
-    #         ==
-    #         DispatchProj[proj, t]
-    #         * m.ProjFuelUseRate[proj, t, f]
-    # )
 
 def load_inputs(mod, switch_data, inputs_dir):
     """

--- a/switch_mod/solve.py
+++ b/switch_mod/solve.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 
-import sys, os, time, traceback, shlex, re
+import sys, os, time, traceback, shlex, re, pdb, traceback
 
 from pyomo.environ import *
 from pyomo.opt import SolverFactory, SolverStatus, TerminationCondition
@@ -21,6 +21,14 @@ def main(args=None, return_model=False, return_instance=False):
 
     # Get options needed before any modules are loaded
     pre_module_options = parse_pre_module_options(args)
+    
+    # turn on post-mortem debugging mode if requested
+    # (from http://stackoverflow.com/a/1237407 ; more options available there)
+    if pre_module_options.debug:
+        def info(type, value, tb):
+            traceback.print_exception(type, value, tb)
+            pdb.pm()
+        sys.excepthook = info
 
     # Write output to a log file if logging option is specified
     stdout_copy = sys.stdout  # make a copy of current sys.stdout to return to eventually
@@ -321,7 +329,8 @@ def add_pre_module_args(parser):
                         help="Log output to a file.")
     parser.add_argument("--logs-dir", dest="logs_dir", default="logs",
                         help='Directory containing log files (default is "logs"')
-
+    parser.add_argument("--debug", action="store_true", default=False,
+                        help='Automatically start pdb debugger on exceptions')
 
 def parse_pre_module_options(args):
     """

--- a/switch_mod/timescales.py
+++ b/switch_mod/timescales.py
@@ -276,6 +276,12 @@ def define_components(mod):
         mod.TIMEPOINTS,
         within=mod.PERIODS,
         initialize=lambda m, t: m.ts_period[m.tp_ts[t]])
+    mod.PERIOD_TS = Set(
+        mod.PERIODS,
+        ordered=True,
+        within=mod.TIMESERIES,
+        initialize=lambda m, p: [
+            ts for ts in m.TIMESERIES if m.ts_period[ts] == p])
     mod.PERIOD_TPS = Set(
         mod.PERIODS,
         ordered=True,
@@ -352,6 +358,24 @@ def define_components(mod):
     mod.validate_time_weights = BuildCheck(
         mod.PERIODS,
         rule=validate_time_weights_rule)
+
+    def validate_period_lengths_rule(m, p):
+        tol = 0.01
+        if p != m.PERIODS.last():
+            p_end = m.period_start[p] + m.period_length_years[p]
+            p_next = m.period_start[m.PERIODS.next(p)]
+            if abs(p_next - p_end) > tol:
+                print (
+                    "validate_period_lengths_rule failed for period"
+                    + "'{p:.0f}'. Period ends at {p_end}, but next period"
+                    + "begins at {p_next}."
+                ).format(p=p, p_end=p_end, p_next=p_next)
+                return False
+        return True
+    mod.validate_period_lengths = BuildCheck(
+        mod.PERIODS, 
+        rule=validate_period_lengths_rule)
+
 
 def load_inputs(mod, switch_data, inputs_dir):
     """


### PR DESCRIPTION
These commits do the following:

- rename `m.proj_end_year` to `m.proj_final_period` to clarify which year it refers to (also slightly improve the calculation, e.g., using `m.period_start + m.period_length_years` instead of `m.period_end`, because `m.period_end` could refer either to the last full year of the period or the moment when the period ends (the start of the next period)
- provide post-mortem debugging, activated via a `--debug` flag
- allow single-point heat rate curves  in `project.unitcommit.fuel_use` (e.g., a plant that always produces exactly 8 MW if it is committed); a few minor bug fixes and refactorings in this code
- remove `m.DispatchProjByFuel` from `project.no_commit` module because it cannot be generalized neatly for models that use `project.unitcommit`. Note: this term has been replaced by code in the `hawaii.rps` module that uses binary variables to distinguish between RPS-eligible and RPS-ineligible fuels (and artificially prevents use of multiple fuels in the same project in the same period). That code could eventually be generalized to allocate production to individual fuels and moved back into the core code. However, doing that would introduce more binary variables than the RPS-oriented code, and would artificially limit fuel-mixing. This term is only useful when there's an RPS in place, so I'm leaving it in `hawaii.rps` for now.

These changes should not interfere with any existing code (all tests pass).