### PR TITLE
Use setuptools and switch command line tool

### DIFF
--- a/INSTALL
+++ b/INSTALL
@@ -5,19 +5,7 @@ Python v2.7
     to do so. We have verified our code works with v2.7.9 and 2.7.10. We
     had some difficulties with our testing framework on v2.7.3.
 
-Pyomo
-    To install Pyomo, you can run this command:
-
-        pip install --user -r pip_requirements.txt
-
-    The pip_requirements.txt file records the versions of Pyomo and other
-    Python libraries that Switch is tested against.
-
-    Alternatively, you can see Pyomo's instructions for installing Pyomo
-    and its dependencies at:
-    https://software.sandia.gov/downloads/pub/pyomo/PyomoInstallGuide.html#_installing_pyomo
-
-A solver such as GLPK, Cbc https://projects.coin-or.org/Cbc or cplex.
+A solver such as GLPK, Cbc [https://projects.coin-or.org/Cbc] or cplex.
     GLPK is an established open source solver that is easy to install 
     on most platforms. We have andecdotal reports that Cbc tends to
     be significantly faster, but have had difficulties installing it
@@ -25,74 +13,13 @@ A solver such as GLPK, Cbc https://projects.coin-or.org/Cbc or cplex.
     expensive for non-academics. It is free for registered academics who
     use it for teaching or research.
 
-To use this model, either install this to a standard python library
-location or set the environment variable PYTHONPATH to include this
-directory. The latter option is probably more useful for developers. On
-mac or linux systems, you can do this by adding the following line to
-your login script ~/.profile and updating it to the actual path to your
-switch_py directory. This won't work if you use a relative path to
-specify your home directory. For example, "~/src/switch_py" will not
-work, but "/home/username/src/switch_py" will work.
+After installing prerequisites, you may install Switch by running the
+following command from the switch directory:
+	pip install --upgrade .
 
-export PYTHONPATH="${PYTHONPATH}:/absolute/path/to/switch_py"
+To install Switch in developer mode, run this command:
+	pip install --editable .
 
----------------------------------
-Instructions on CentOS on version 7.1.1503
-
-# Check python version is higher than 2.7.3. Update python version if
-# needed. 
-python --version
-
-# Install pip.
-sudo yum install -y python-pip
-
-# Install Pyomo
-pip install --user -r pip_requirements.txt
-
-# Install glpk & glpsol
-sudo yum install -y glpk glpk-utils
-
---------------------------------
-Instructions on ArchLinux
-
-# Check python version is set to 2.7.x. If you are currently using Python 3 or higher you can set a virtual environment using virtualenv
-python --version
-
-# Install pip through AUR.
-yaourt pip
-
-# Only if you're currently using Python 3:
-pip install virtualenv
-cd <switch folder>
-virtualenv -p  /usr/bin/python2.7 <virtual environment name>
-export VIRTUALENV_PYTHON=/usr/bin/python2.7
-source <virtual environment name>/bin/activate
-
-# Install the required packages
-pip install -r pip_requirements.txt
-
-# Install GLPK v4.55: https://ftp.gnu.org/gnu/glpk/ follow the instructions in the 'INSTALL' file inside the tar.
-
----------------------------------
-Instructions for Mac OS X 10.11 (El Capitan)
-
-Install Xcode via the App Store. Open it, accept the license agreement, and say yes if it asks about installing additional required components. Close it when finished.
-
-Install Homebrew, a package manager that ports open source projects to mac os x. For full instructions see http://brew.sh/ The quick instructions are to copy and paste the following command in a terminal.
-  ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)"
-
-Use brew to install python and glpk
-  brew install python
-  brew install homebrew/science/glpk
-
-Install pip:
-  sudo easy_install pip
-
-Download Switch:
-  mkdir -p ~/src
-  cd ~/src
-  git clone https://github.com/switch-model/switch.git
-
-Install Pyomo and other python libraries that Switch depends on
-  cd ~/src/switch
-  pip install --user -r pip_requirements.txt
+To install "extras", optional modules that interfaces with R or psql, run these commands:
+	sudo pip install --upgrade .[r]
+	sudo pip install --upgrade .[psql]

--- a/INSTALL
+++ b/INSTALL
@@ -1,25 +1,146 @@
-Software prerequisites for this project are:
+INTRODUCTION
+
+This repository contains code and example files for the SWITCH power system
+planning model. To use this model, you will need to install several things:
 
 Python v2.7
     We have not tested this on version 3, and do not have immediate plans
     to do so. We have verified our code works with v2.7.9 and 2.7.10. We
     had some difficulties with our testing framework on v2.7.3.
 
-A solver such as GLPK, Cbc [https://projects.coin-or.org/Cbc] or cplex.
-    GLPK is an established open source solver that is easy to install 
+A solver such as GLPK, Cbc [https://projects.coin-or.org/Cbc], cplex or gurobi.
+    The solver performs the raw numerical computations needed to solve each
+    model. GLPK is an established open source solver that is easy to install 
     on most platforms. We have andecdotal reports that Cbc tends to
     be significantly faster, but have had difficulties installing it
     on some platforms. Cplex tends to be fast, but is proprietary and
     expensive for non-academics. It is free for registered academics who
     use it for teaching or research.
 
-After installing prerequisites, you may install Switch by running the
-following command from the switch directory:
-	pip install --upgrade .
+git software (optional)
+    This is useful for downloading SWITCH, upgrading to the latest version, 
+    or contributing your changes back to the main project.
+    
+Python code for SWITCH and its dependencies
 
-To install Switch in developer mode, run this command:
-	pip install --editable .
+The instructions below show you how to install these components on a Linux, Mac
+or Windows computer. We recommend that you use the Anaconda scientific
+computing environment to install and run SWITCH. This provides an easy,
+cross-platform way to install most of the resources that SWITCH needs, and it
+avoids interfering with your system's built-in Python installation (if
+present). The instructions below assume you wiil use the Anaconda distribution.
+If you prefer to use a different distribution, you will need to adjust the
+instructions accordingly.
 
-To install "extras", optional modules that interfaces with R or psql, run these commands:
-	sudo pip install --upgrade .[r]
-	sudo pip install --upgrade .[psql]
+
+INSTALL CONDA AND PYTHON
+
+Download and install Anaconda from https://www.continuum.io/downloads or 
+Miniconda from http://conda.pydata.org/miniconda.html . Make sure to select the
+option to install Python 2.7. (SWITCH is not yet compatible with Python 3.x.).
+These install a similar environment, but Anaconda installs more packages by 
+default and Miniconda installs them as needed.
+
+Note that you do not need administrator privileges to install the Conda 
+environment or add packages to it. However, your firewall will need to allow 
+external network access to add packages as described below.
+
+
+INSTALL AN OPEN-SOURCE SOLVER
+
+You can solve small models, including the SWITCH examples, using the open-source 
+glpk solver. This can be installed as follows:
+
+1. Open Terminal.app (OS X) or an Anaconda command prompt (Start -> Anaconda -> 
+Anaconda Prompt)
+
+2. Type this command and then press Enter or return:
+
+conda install -c conda-forge glpk
+
+Follow the prompts to install glpk.
+
+In some cases, you may find the open-source coincbc solver is a little faster 
+than glpk. You can install coincbc via the following command (currently only
+provides packages for Linux and Mac OS X):
+
+conda install -c conda-forge coincbc
+
+
+INSTALL A PROPRIETARY SOLVER (OPTIONAL)
+
+To solve larger models, you will need to install the cplex or gurobi solvers,
+which are an order of magnitude faster than glpk or coincbc. Both of these have
+free trials available, and are free long-term for academics. You can install
+one of these now or after you install SWITCH. More information on these solvers
+can be found at the following links:
+
+cplex: 
+https://www.ibm.com/developerworks/community/blogs/jfp/entry/free_cplex_trials?lang=en
+
+gurobi: 
+http://www.gurobi.com/downloads/download-center
+
+INSTALL GIT SOFTWARE (OPTIONAL)
+
+Open a Terminal window or Anaconda command prompt, as discussed earlier, then
+run this command and follow the prompts:
+
+conda install git
+
+
+INSTALL SWITCH MODEL CODE AND DEPENDENCIES
+
+Open a Terminal window or Anaconda command prompt. Then use the 'cd' and
+'mkdir' commands to create and/or enter the directory where you would like to
+store the SWITCH model code and examples. Once you are in that directory, run
+the following commands (don't type the comments that start with '#'):
+
+# download SWITCH
+git clone https://github.com/switch-model/switch.git
+
+# (If you didn't install git, just download a .zip file from 
+# https://github.com/switch-model/switch, then unzip it to a folder called
+# switch in the appropriate location.)
+
+# install the SWITCH model code that you downloaded, and any required Python packages
+cd switch
+pip install --upgrade --editable .
+
+The 'pip install command' adds the switch_mod package to your Python
+installation. It also installs the Pyomo Python package, which SWITCH uses to
+define and solve optimization models. (SWITCH uses Pyomo to define a model,
+then Pyomo passes the model to the solver and receives the solution, then
+SWITCH retrieves the solution from Pyomo.)
+
+If you want to use certain advanced features of SWITCH, you should install the
+"advanced" dependencies. These extra packages are used by the advanced demand
+response system (in the hawaii package) and the progressive hedging examples.
+You can install the advanced dependencies via the command below (you can use
+this instead of the command above, or run it later to add these packages):
+
+pip install --upgrade --editable .[advanced]
+
+
+RUN TESTS
+
+To test your installation, you can run "python run_tests.py".
+
+
+SOLVE MODELS
+
+At this point, you can solve example models or your own power system models.
+See README for more information.
+
+
+UPDATE TO LATEST VERSION OF SWITCH
+
+You can pull the latest version of the SWITCH code and examples from github.com
+at any time by launching a Terminal window or Anaconda prompt, then cd'ing into
+the 'switch' directory and running this command:
+
+git pull
+
+This will attempt to merge your local changes with changes in the main
+repository. If there are any conflicts, you should follow the instructions given
+by the git command to resolve them.

--- a/README
+++ b/README
@@ -14,14 +14,8 @@ components they define, and what input files they expect.
 
 TESTING
 To test the entire codebase, run this command from the root directory:
-
-./run_tests.py
-
+	./run_tests.py
 
 EXAMPLES
-To run an example, first update the python path to include the source directory.
-If you downloaded the project to ~/src/switch, the commands are:
-    cd ~/src/switch
-    export PYTHONPATH=$(pwd)":"$PYTHONPATH
-    cd examples/copperplate0
-    python -m switch_mod.solve --verbose
+To run an example, navigate to an example directory and run the command:
+	switch solve --verbose --log-run

--- a/README
+++ b/README
@@ -14,8 +14,62 @@ components they define, and what input files they expect.
 
 TESTING
 To test the entire codebase, run this command from the root directory:
-	./run_tests.py
+	python run_tests.py
 
 EXAMPLES
 To run an example, navigate to an example directory and run the command:
 	switch solve --verbose --log-run
+
+CONFIGURING YOUR OWN MODELS
+
+At a minimum, each model requires a list of SWITCH modules to define the model
+and a set of input files to provide the data. The SWITCH framework and
+individual modules also accept command-line arguments to change their behavior.
+
+Each SWITCH model or collection of models is defined in a specific directory
+(e.g., examples/3zone_toy). This directory contains one or more subdirectories
+that hold input data and results (e.g., "inputs" and "outputs"). The models in
+the examples directory show the type of text files used to provide inputs for a
+model. You can change any of the model's input data by editing the *.tab files
+in the input directory.
+
+SWITCH contains a number of different modules, which can be selected and
+combined to create models with different capabilities and amounts of detail.
+You can look through the *.py files within switch_mod and its subdirectories to
+see the standard modules that are available and the columns that each one will
+read from the input files. You can also add modules of your own by creating
+Python files in the main model directory and adding their name (without the
+".py") to the module list, discussed below. These should define the same
+functions as the standard modules (e.g., define_components()).
+
+Each model has a text file which lists the modules that will be used for that
+model. Normally this file is called "modules.txt" and is stored in the main
+model directory or in an inputs subdirectory. SWITCH will automatically look in
+those locations for this list; alternatively, you can specify a different file
+with the "--module-list" argument.
+
+Use "switch --help", "switch solve --help" or "switch solve-scenarios --help"
+to see a list of command-line arguments that are available.
+
+You can specify these arguments on the command line when you solve the model
+(e.g., "switch solve --solver cplex"). You can also place frequently used
+arguments in a file called "options.txt" in the main model directory. These can
+all be on one line, or they can be placed on multiple lines for easier
+readability (be sure to include the "--" part in all the argument names in
+options.txt). The "switch solve" command first reads all the arguments from
+options.txt, and then applies any arguments you specified on the command line.
+If the same argument is specified multiple times, the last one takes priority.
+
+You can also define scenarios, which are sets of command-line arguments to
+define different models. These additional arguments can be placed in a scenario
+list file, usually called "scenarios.txt" in the main model directory (or you
+can use a different file specified by "--scenario-list"). Each scenario should
+be defined on a single line, which includes a "--scenario-name" argument and
+any other arguments needed to define the scenario. "switch solve-scenarios"
+will solve all the scenarios listed in this file. For each scenario, it will
+first apply all arguments from options.txt, then arguments from the relevant
+line of scenarios.txt, then any arguments specified on the command line.
+
+After the model runs, results will be written in tab-separated text files (with
+extension .tsv or .tab) in the "outputs" directory (or some other directory
+specified via the "--outputs-dir" argument).

--- a/examples/3zone_toy/README.md
+++ b/examples/3zone_toy/README.md
@@ -1,5 +1,5 @@
 SYNOPSIS
-    python -m switch_mod.solve
+	switch solve --verbose --log-run
 
 This example illustrates the use of Switch to construct and run a toy
 model with three load zones and two investment periods where the first

--- a/examples/copperplate0/README.md
+++ b/examples/copperplate0/README.md
@@ -1,5 +1,5 @@
 SYNOPSIS
-    python -m switch_mod.solve
+	switch solve --verbose --log-run
 
 This example illustrates the use of Switch to construct and run a very
 simple model with a single load zone, one investment period, and two

--- a/examples/copperplate1/README.md
+++ b/examples/copperplate1/README.md
@@ -1,5 +1,5 @@
 SYNOPSIS
-    python -m switch_mod.solve
+	switch solve --verbose --log-run
 
 This example illustrates the use of Switch to construct and run a very
 simple model with a single load zone, one investment period, and two

--- a/examples/discrete_and_min_build/README.md
+++ b/examples/discrete_and_min_build/README.md
@@ -1,5 +1,5 @@
 SYNOPSIS
-    python -m switch_mod.solve
+	switch solve --verbose --log-run
 
 This example illustrates the use of Switch to construct and run a very
 simple model with a single load zone, one investment period, and two

--- a/examples/discrete_build/README.md
+++ b/examples/discrete_build/README.md
@@ -1,5 +1,5 @@
 SYNOPSIS
-    python -m switch_mod.solve
+	switch solve --verbose --log-run
 
 This example illustrates the use of Switch to construct and run a very
 simple model with a single load zone, one investment period, and two

--- a/examples/hydro_simple/README.md
+++ b/examples/hydro_simple/README.md
@@ -1,5 +1,5 @@
 SYNOPSIS
-    python -m switch_mod.solve
+	switch solve --verbose --log-run
 
 This example illustrates the use of using the hydro_simple module. 
 

--- a/examples/hydro_system/README.md
+++ b/examples/hydro_system/README.md
@@ -1,5 +1,5 @@
 SYNOPSIS
-    python -m switch_mod.solve
+	switch solve --verbose --log-run
 
 This example illustrates the use of the hydro_system module. The input set does not consider new investments; this is only a production costing example.
 

--- a/examples/new_builds_only/README.md
+++ b/examples/new_builds_only/README.md
@@ -1,5 +1,5 @@
 SYNOPSIS
-    python -m switch_mod.solve
+	switch solve --verbose --log-run
 
 This example is the same as "copperplate0" but with no existing builds
 -- without proj_existing_builds.tab or proj_build_costs.tab.  This is

--- a/examples/production_cost_models/1plant/README.md
+++ b/examples/production_cost_models/1plant/README.md
@@ -1,5 +1,5 @@
 SYNOPSIS
-    python -m switch_mod.solve
+	switch solve --verbose --log-run
 
 This example illustrates the use of Switch to construct and run a very
 simple production-cost model with a single load zone, one investment

--- a/examples/production_cost_models/3plants/README.md
+++ b/examples/production_cost_models/3plants/README.md
@@ -1,5 +1,5 @@
 SYNOPSIS
-    python -m switch_mod.solve
+	switch solve --verbose --log-run
 
 This example illustrates the use of Switch to construct and run a very
 simple production-cost model with a single load zone, one investment

--- a/examples/production_cost_models/4plants/README.md
+++ b/examples/production_cost_models/4plants/README.md
@@ -1,5 +1,5 @@
 SYNOPSIS
-    python -m switch_mod.solve
+	switch solve --verbose --log-run
 
 This example illustrates the use of Switch to construct and run a very
 simple production-cost model with a single load zone, one investment

--- a/examples/production_cost_models/discrete_unit_commit/README.md
+++ b/examples/production_cost_models/discrete_unit_commit/README.md
@@ -1,5 +1,5 @@
 SYNOPSIS
-    python -m switch_mod.solve
+	switch solve --verbose --log-run
 
 This example illustrates the use of Switch to construct and run a very
 simple production-cost model with a single load zone, one investment

--- a/examples/production_cost_models/unit_commit/README.md
+++ b/examples/production_cost_models/unit_commit/README.md
@@ -1,5 +1,5 @@
 SYNOPSIS
-    python -m switch_mod.solve
+	switch solve --verbose --log-run
 
 This example illustrates the use of Switch to construct and run a very
 simple production-cost model with a single load zone, one investment

--- a/examples/storage/README.md
+++ b/examples/storage/README.md
@@ -1,5 +1,5 @@
 SYNOPSIS
-    python -m switch_mod.solve
+	switch solve --verbose --log-run
 
 This example illustrates the use of storage. It is very similar to the
 copperplate0 example.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
-PyUtilib==5.2.3601
-Pyomo==4.2.10784
+PyUtilib==5.4.1
+Pyomo==5.1.1
 nose==1.3.7
 ply==3.8
 six==1.10.0

--- a/setup.py
+++ b/setup.py
@@ -5,14 +5,11 @@ Use "pip install --upgrade ." to install a copy in the site packages directory.
 Use "pip install --upgrade --editable ." to install SWITCH to be run from its 
 current location.
 
-Optional dependencies can be added during the initial install by running a 
-command like this: 
-pip install --upgrade .[advanced,database_access]
+Optional dependencies can be added during the initial install or later by 
+running a command like this: 
+pip install --upgrade --editable .[advanced,database_access]
 
-Optional dependencies can be installed later by running a command like this:
-pip install switch[advanced]
-
-Use "pip uninstall switch" to uninstall the package.
+Use "pip uninstall switch" to uninstall switch from your system.
 """
 
 import os

--- a/setup.py
+++ b/setup.py
@@ -12,8 +12,6 @@ pip install --upgrade .[advanced,database_access]
 Optional dependencies can be installed later by running a command like this:
 pip install switch[advanced]
 
-Use "python setup.py test" to test the package before installing.
-
 Use "pip uninstall switch" to uninstall the package.
 """
 

--- a/setup.py
+++ b/setup.py
@@ -21,24 +21,6 @@ from setuptools import setup
 def read(*rnames):
     return open(os.path.join(os.path.dirname(__file__), *rnames)).read()
 
-required = [
-    'Pyomo>=4.4.1', # We need a version that works with glpk 4.60+
-    'testfixtures'  # used for standard tests
-]
- 
-extras = {
-    # packages used for advanced demand response and progressive hedging
-    'advanced': ['numpy', 'scipy', 'rpy2', 'sympy'],
-    'database_access': ['psycopg2']
-}
-
-packages = ['switch_mod']
-
-entry_points = """
-    [console_scripts]
-    switch=switch_mod.main:main
-"""
-
 setup(
     name='SWITCH',
     version='2.0.0b0',
@@ -65,13 +47,22 @@ setup(
     'Topic :: Scientific/Engineering',
     'Topic :: Software Development :: Libraries :: Python Modules'
     ],
-    packages=packages,
+    packages=['switch_mod'],
     keywords=[
         'renewable', 'power', 'energy', 'electricity', 
         'production cost', 'capacity expansion', 
         'planning', 'optimization'
     ],
-    install_requires=required,
-    extras_require=extras,
-    entry_points=entry_points,
+    install_requires=[
+        'Pyomo>=4.4.1', # We need a version that works with glpk 4.60+
+        'testfixtures'  # used for standard tests
+    ],
+    extras_require={
+        # packages used for advanced demand response and progressive hedging
+        'advanced': ['numpy', 'scipy', 'rpy2', 'sympy'],
+        'database_access': ['psycopg2']
+    },
+    entry_points={
+        'console_scripts': ['switch = switch_mod.main:main']
+    },
 )

--- a/setup.py
+++ b/setup.py
@@ -9,44 +9,53 @@ from setuptools import setup
 def read(*rnames):
     return open(os.path.join(os.path.dirname(__file__), *rnames)).read()
 
-requires = [
-    "Pyomo"
-]
-
-packages = ['switch_mod']
-
 setup(
     name='SWITCH',
-    version='2.0b0',
+    version='2.0.0b0',
     maintainer='Matthias Fripp',
     maintainer_email='mfripp@hawaii.edu',
     url='http://switch-model.org',
-    license='Apache',
+    license='Apache v2',
     platforms=["any"],
     description='SWITCH Power System Planning Model',
     long_description=read('README'),
     classifiers=[
     'Development Status :: 4 - Beta',
+    'Environment :: Console',
+    'Intended Audience :: Education',
     'Intended Audience :: End Users/Desktop',
     'Intended Audience :: Science/Research',
     'License :: OSI Approved :: Apache Software License',
     'Natural Language :: English',
     'Operating System :: Microsoft :: Windows',
+    'Operating System :: MacOS :: MacOS X',
     'Operating System :: Unix',
     'Programming Language :: Python',
     'Programming Language :: Unix Shell',
     'Topic :: Scientific/Engineering',
     'Topic :: Software Development :: Libraries :: Python Modules'
     ],
-    packages=packages,
+    packages=['switch_mod'],
     keywords=[
         'renewable', 'power', 'energy', 'electricity', 
         'production cost', 'capacity expansion', 
         'planning', 'optimization'
     ],
-    install_requires=requires,
-    entry_points="""
-    [console_scripts]
-    switch=switch_mod.main:main
-    """
-    )
+    install_requires=[
+        'PyUtilib',
+        'Pyomo>=4.3.11377', # We minimally need the glpk bugfix version
+        'nose',
+        'ply',
+        'six',
+        'testfixtures',
+        'sympy',
+        'numpy'
+    ],
+    extras_require={
+        'r': ['rpy2'],
+        'psql': ['psycopg2']
+    },
+    entry_points={
+        'console_scripts': ['switch = switch_mod.main:main']
+    }
+)

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,20 @@
 """Setup script for SWITCH. 
-Use "python setup.py install" to install a copy in the site packages directory.
-Use "python setup.py develop" to activate SWITCH while preserving its current location.
+
+Use "pip install --upgrade ." to install a copy in the site packages directory.
+
+Use "pip install --upgrade --editable ." to install SWITCH to be run from its 
+current location.
+
+Optional dependencies can be added during the initial install by running a 
+command like this: 
+pip install --upgrade .[advanced,database_access]
+
+Optional dependencies can be installed later by running a command like this:
+pip install switch[advanced]
+
+Use "python setup.py test" to test the package before installing.
+
+Use "pip uninstall switch" to uninstall the package.
 """
 
 import os
@@ -8,6 +22,24 @@ from setuptools import setup
 
 def read(*rnames):
     return open(os.path.join(os.path.dirname(__file__), *rnames)).read()
+
+required = [
+    'Pyomo>=4.4.1', # We need a version that works with glpk 4.60+
+    'testfixtures'  # used for standard tests
+]
+ 
+extras = {
+    # packages used for advanced demand response and progressive hedging
+    'advanced': ['numpy', 'scipy', 'rpy2', 'sympy'],
+    'database_access': ['psycopg2']
+}
+
+packages = ['switch_mod']
+
+entry_points = """
+    [console_scripts]
+    switch=switch_mod.main:main
+"""
 
 setup(
     name='SWITCH',
@@ -35,27 +67,13 @@ setup(
     'Topic :: Scientific/Engineering',
     'Topic :: Software Development :: Libraries :: Python Modules'
     ],
-    packages=['switch_mod'],
+    packages=packages,
     keywords=[
         'renewable', 'power', 'energy', 'electricity', 
         'production cost', 'capacity expansion', 
         'planning', 'optimization'
     ],
-    install_requires=[
-        'PyUtilib',
-        'Pyomo>=4.3.11377', # We minimally need the glpk bugfix version
-        'nose',
-        'ply',
-        'six',
-        'testfixtures',
-        'sympy',
-        'numpy'
-    ],
-    extras_require={
-        'r': ['rpy2'],
-        'psql': ['psycopg2']
-    },
-    entry_points={
-        'console_scripts': ['switch = switch_mod.main:main']
-    }
+    install_requires=required,
+    extras_require=extras,
+    entry_points=entry_points,
 )

--- a/switch_mod/hawaii/constant_elasticity_demand_system.py
+++ b/switch_mod/hawaii/constant_elasticity_demand_system.py
@@ -1,13 +1,11 @@
-import numpy as np
-
-base_load_dict = None
-base_price_dict = None
-elasticity_scenario = None
-
 def calibrate(base_data, dr_elasticity_scenario=3):
     """Accept a list of tuples showing [base hourly loads], and [base hourly prices] for each 
     location (load_zone) and date (time_series). Store these for later reference by bid().
     """
+    # import numpy; we delay till here to avoid interfering with unit tests 
+    global np
+    import numpy as np
+
     global base_load_dict, base_price_dict, elasticity_scenario
     # build dictionaries (indexed lists) of base loads and prices
     # store the load and price vectors as numpy arrays (vectors) for faste calculation later

--- a/switch_mod/hawaii/demand_response.py
+++ b/switch_mod/hawaii/demand_response.py
@@ -24,7 +24,6 @@ from pprint import pprint
 from pyomo.environ import *
 import pyomo.repn.canonical_repn
 
-import scipy.optimize
 import switch_mod.utilities as utilities
 from save_results import DispatchProjByFuel
 
@@ -87,6 +86,17 @@ def define_components(m):
             .format(mod=m.options.dr_demand_module)
         )
     demand_module = sys.modules[m.options.dr_demand_module]
+    
+    # load scipy.optimize for use later
+    try:
+        global scipy
+        import scipy.optimize
+    except ImportError:
+        print "="*80
+        print "Unable to load scipy package, which is used by the demand response system."
+        print "Please install this via 'conda install scipy' or 'pip install scipy'."
+        print "="*80
+        raise
     
     # Make sure the model has dual and rc suffixes
     if not hasattr(m, "dual"):

--- a/switch_mod/hawaii/scenario_data.py
+++ b/switch_mod/hawaii/scenario_data.py
@@ -1,6 +1,5 @@
 import time, sys, collections, os
 from textwrap import dedent
-import psycopg2
 
 # NOTE: instead of using the python csv writer, this directly writes tables to 
 # file in the pyomo .tab format. This uses tabs between columns and the standard
@@ -747,6 +746,19 @@ con = None
 def db_cursor():
     global con
     if con is None:
+        try:
+            # note: we don't import until here to avoid interfering with unit tests on systems that don't have
+            # (or need) psycopg2
+            global psycopg2
+            import psycopg2
+        except ImportError:
+            print dedent("""
+                ############################################################################################
+                Unable to import psycopg2 module to access database server.
+                Please install this module via 'conda install psycopg2' or 'pip install psycopg2'.
+                ############################################################################################
+                """)
+            raise
         try:
             pghost='redr.eng.hawaii.edu'
             # note: the connection gets created when the module loads and never gets closed (until presumably python exits)

--- a/switch_mod/solve_scenarios.py
+++ b/switch_mod/solve_scenarios.py
@@ -51,10 +51,17 @@ scenario_list_file = scenario_manager_args.scenario_list
 scenario_queue_dir = scenario_manager_args.scenario_queue
 job_id = scenario_manager_args.job_id
 
-# note: we make a best effort to get a unique, persistent job_id for each job.
-# this is used to clear the queue of running jobs if a job is stopped and
+# Make a best effort to get a unique, persistent job_id for each job.
+# This is used to clear the queue of running tasks if a task is stopped and
 # restarted. (would be better if other jobs could do this when this job dies
 # but it's hard to see how they can detect when this job fails.)
+# (The idea is that the user will run multiple jobs in parallel, with one 
+# thread per job, to process all the scenarios. These might be run in separate
+# terminal windows, or in separate instances of gnu screen, or as numbered
+# jobs on an HPC system. Sometimes a job will get interrupted, e.g., if the
+# user presses ctrl-c in a terminal window or if the job is launched on an 
+# interruptible queue. This script attempts to detect when that job gets 
+# relaunched, and re-run the interrupted scenario.)
 if job_id is None:
     job_id = os.environ.get('JOB_ID') # could be set by user
 if job_id is None:
@@ -72,7 +79,11 @@ if job_id is None:
     # when running multiple jobs in parallel. Without that, all 
     # jobs will think they have the same ID, and at startup they will 
     # try to re-run the scenario currently being run by some other job.)
-    job_id = socket.gethostname() + '_' + str(os.getppid())
+    if hasattr(os, 'getppid'):
+        job_id = socket.gethostname() + '_' + str(os.getppid())
+    else:
+        # won't be able to automatically clear previously interrupted job
+        job_id = socket.gethostname() + '_' + str(os.getpid())
 
 running_scenarios_file = os.path.join(scenario_queue_dir, job_id+"_running.txt")
 


### PR DESCRIPTION
Updated installation instructions to use setuptools, and usage instructions to use the switch command line script.
Added dependencies and extras to setup.py, set minimal Pyomo version to the glpk bugfix, updated entry_points syntax, implemented pointers from https://packaging.python.org/distributing/
Renamed pip_requirements.txt to requirements.txt to reflect standard python naming conventions.