### PR TITLE
Streamline dispatch sets

### DIFF
--- a/switch_mod/generators/core/dispatch.py
+++ b/switch_mod/generators/core/dispatch.py
@@ -141,15 +141,10 @@ def define_components(mod):
 
     """
 
-    def _ACTIVE_PROJ_PERIODS(m):
-        return set((proj, period)
-            for proj, bld_yr in m.PROJECT_BUILDYEARS
-                for period in m.PROJECT_BUILDS_OPERATIONAL_PERIODS[proj, bld_yr])
-
     def period_active_proj_rule(m, period):
         if not hasattr(m, 'period_active_proj_dict'):
             m.period_active_proj_dict = collections.defaultdict(set)
-            for (_proj, _period) in _ACTIVE_PROJ_PERIODS(m):
+            for (_proj, _period) in m.PROJECT_OPERATIONAL_PERIODS:
                 m.period_active_proj_dict[_period].add(_proj)
         result = m.period_active_proj_dict.pop(period)
         if len(m.period_active_proj_dict) == 0:
@@ -161,7 +156,7 @@ def define_components(mod):
     def PROJ_ACTIVE_TIMEPOINTS_rule(m, gen):
         if not hasattr(m, '_PROJ_ACTIVE_TIMEPOINTS_dict'):
             m._PROJ_ACTIVE_TIMEPOINTS_dict = collections.defaultdict(set)
-            for (_gen, period) in _ACTIVE_PROJ_PERIODS(m):
+            for (_gen, period) in m.PROJECT_OPERATIONAL_PERIODS:
                 for t in m.PERIOD_TPS[period]:
                     m._PROJ_ACTIVE_TIMEPOINTS_dict[_gen].add(t)
         result = m._PROJ_ACTIVE_TIMEPOINTS_dict.pop(gen)

--- a/switch_mod/policies/rps_simple.py
+++ b/switch_mod/policies/rps_simple.py
@@ -84,16 +84,14 @@ def define_components(mod):
 
     mod.RPSFuelEnergy = Expression(
         mod.RPS_PERIODS,
-        rule=lambda m, p: sum(m.RPSProjFuelPower[proj, t] * m.tp_weight[t]
-            for proj in m.FUEL_BASED_PROJECTS 
-                if (proj, p) in m.ACTIVE_PROJ_PERIODS
-                    for t in m.PERIOD_TPS[p]))
+        rule=lambda m, p: sum(m.RPSProjFuelPower[g, t] * m.tp_weight[t]
+            for g in m.FUEL_BASED_PROJECTS 
+                for t in m.PROJ_ACTIVE_TIMEPOINTS_IN_PERIOD[g, p]))
     mod.RPSNonFuelEnergy = Expression(
         mod.RPS_PERIODS,
-        rule=lambda m, p: sum(m.DispatchProj[proj, t] * m.tp_weight[t]
-            for proj in m.NON_FUEL_BASED_PROJECTS 
-                if (proj, p) in m.ACTIVE_PROJ_PERIODS
-                    for t in m.PERIOD_TPS[p]))
+        rule=lambda m, p: sum(m.DispatchProj[g, t] * m.tp_weight[t]
+            for g in m.NON_FUEL_BASED_PROJECTS 
+                for t in m.PROJ_ACTIVE_TIMEPOINTS_IN_PERIOD[g, p]))
 
     mod.RPS_Enforce_Target = Constraint(
         mod.RPS_PERIODS,
@@ -104,8 +102,8 @@ def define_components(mod):
 def total_generation_in_period(model, period):
     return sum(
         model.DispatchProj[g, t] * model.tp_weight[t]
-        for g in model.PROJECTS if (g, period) in model.ACTIVE_PROJ_PERIODS
-        for t in model.PERIOD_TPS[period])
+        for g in model.PROJECTS 
+            for t in model.PROJ_ACTIVE_TIMEPOINTS_IN_PERIOD[g, period])
 
 
 def total_demand_in_period(model, period):


### PR DESCRIPTION
Replaced PROJ_ACTIVE_PERIODS with PROJ_ACTIVE_TIMEPOINTS_IN_PERIOD to simplify end-uses in rps_simple. Replaced the internal ACTIVE_PROJ_PERIODS set with a private function.