### PR TITLE
Migrate code style to Black

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,2 @@
+# Migrate code style to Black
+b7131aa93b27e18236880a65f29e36631bb7fb5d

--- a/examples/3zone_toy_stochastic_PySP/PySPInputGenerator.py
+++ b/examples/3zone_toy_stochastic_PySP/PySPInputGenerator.py
@@ -48,6 +48,7 @@ scenario_list should be modified to reflect those changes.
 
 """
 from __future__ import print_function
+
 # Inputs directory relative to the location of this script.
 inputs_dir = "inputs"
 # ScenarioStructure.dat and RootNode.dat will be saved to a
@@ -58,11 +59,10 @@ pysp_subdir = "pysp_inputs"
 stage_list = ["Investment", "Operation"]
 stage_vars = {
     "Investment": ["BuildGen", "BuildLocalTD", "BuildTx"],
-    "Operation": ["DispatchGen", "GenFuelUseRate"]
+    "Operation": ["DispatchGen", "GenFuelUseRate"],
 }
 # List of scenario names
-scenario_list = [
-    "LowFuelCosts", "MediumFuelCosts", "HighFuelCosts"]
+scenario_list = ["LowFuelCosts", "MediumFuelCosts", "HighFuelCosts"]
 
 ###########################################################
 
@@ -82,6 +82,7 @@ print("loading inputs into model...")
 instance = model.load_inputs(inputs_dir=inputs_dir)
 print("inputs successfully loaded...")
 
+
 def save_dat_files():
 
     if not os.path.exists(os.path.join(inputs_dir, pysp_subdir)):
@@ -92,8 +93,9 @@ def save_dat_files():
 
     dat_file = os.path.join(inputs_dir, pysp_subdir, "RootNode.dat")
     print("creating and saving {}...".format(dat_file))
-    utilities.save_inputs_as_dat(model, instance, save_path=dat_file,
-        sorted_output=model.options.sorted_output)
+    utilities.save_inputs_as_dat(
+        model, instance, save_path=dat_file, sorted_output=model.options.sorted_output
+    )
 
     #######################
     # ScenarioStructure.dat
@@ -117,7 +119,7 @@ def save_dat_files():
 
         f.write("param NodeStage := RootNode {}\n".format(stage_list[0]))
         for s in scenario_list:
-            f.write("    {scen} {st}\n".format(scen=s,st=stage_list[1]))
+            f.write("    {scen} {st}\n".format(scen=s, st=stage_list[1]))
         f.write(";\n\n")
 
         f.write("set Children[RootNode] := ")
@@ -127,7 +129,7 @@ def save_dat_files():
 
         f.write("param ConditionalProbability := RootNode 1.0")
         # All scenarios have the same probability in this example
-        probs = [1.0/len(scenario_list)] * (len(scenario_list) - 1)
+        probs = [1.0 / len(scenario_list)] * (len(scenario_list) - 1)
         # The remaining probability is lumped in the last scenario to avoid rounding issues
         probs.append(1.0 - sum(probs))
         for (s, p) in zip(scenario_list, probs):
@@ -150,14 +152,16 @@ def save_dat_files():
             if hasattr(instance, cname):
                 dimen = getattr(instance, cname).index_set().dimen
                 if dimen == 0:
-                   f.write("    {cn}\n".format(cn=cname))
+                    f.write("    {cn}\n".format(cn=cname))
                 else:
-                    indexing = (",".join(["*"]*dimen))
+                    indexing = ",".join(["*"] * dimen)
                     f.write("    {cn}[{dim}]\n".format(cn=cname, dim=indexing))
             else:
                 raise ValueError(
-                    "Variable '{}' is not a component of the model. Did you make a typo?".
-                    format(cname))
+                    "Variable '{}' is not a component of the model. Did you make a typo?".format(
+                        cname
+                    )
+                )
 
         for st in stage_list:
             f.write("set StageVariables[{}] := \n".format(st))
@@ -171,8 +175,9 @@ def save_dat_files():
         f.write("    Operation OperationCost\n")
         f.write(";")
 
+
 ####################
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     # If the script is executed on the command line, then the .dat files are created.
     save_dat_files()

--- a/examples/3zone_toy_stochastic_PySP/ReferenceModel.py
+++ b/examples/3zone_toy_stochastic_PySP/ReferenceModel.py
@@ -37,7 +37,7 @@ print("loading model...")
 
 # Ideally, we would use the main codebase to generate the model, but the
 # mandatory switch argument parser is interferring with pysp's command line tools
-#model = switch_model.solve.main(return_model=True)
+# model = switch_model.solve.main(return_model=True)
 
 module_list = switch_model.solve.get_module_list(args=None)
 model = utilities.create_model(module_list, args=[])
@@ -53,14 +53,19 @@ model = utilities.create_model(module_list, args=[])
 # are nested inside another function in the financials module, they can't
 # be called from this script.
 
+
 def calc_tp_costs_in_period(m, t):
-	return sum(
-		getattr(m, tp_cost)[t] * m.tp_weight_in_year[t]
-		for tp_cost in m.Cost_Components_Per_TP)
+    return sum(
+        getattr(m, tp_cost)[t] * m.tp_weight_in_year[t]
+        for tp_cost in m.Cost_Components_Per_TP
+    )
+
+
 def calc_annual_costs_in_period(m, p):
-	return sum(
-		getattr(m, annual_cost)[p]
-		for annual_cost in m.Cost_Components_Per_Period)
+    return sum(
+        getattr(m, annual_cost)[p] for annual_cost in m.Cost_Components_Per_Period
+    )
+
 
 # In the current version of Switch, all annual costs are defined
 # by First Stage decision variables, such as fixed O&M and capital
@@ -73,14 +78,19 @@ def calc_annual_costs_in_period(m, p):
 # decisions in this example.
 # Further comments on this are written in the Readme file.
 
-model.InvestmentCost = Expression(rule=lambda m: sum(
-                calc_annual_costs_in_period(m, p) * m.bring_annual_costs_to_base_year[p]
-                for p in m.PERIODS))
+model.InvestmentCost = Expression(
+    rule=lambda m: sum(
+        calc_annual_costs_in_period(m, p) * m.bring_annual_costs_to_base_year[p]
+        for p in m.PERIODS
+    )
+)
 
-model.OperationCost = Expression(rule=lambda m:
-	sum(
-		sum(calc_tp_costs_in_period(m, t) for t in m.TPS_IN_PERIOD[p]
-		   ) * m.bring_annual_costs_to_base_year[p]
-	for p in m.PERIODS))
+model.OperationCost = Expression(
+    rule=lambda m: sum(
+        sum(calc_tp_costs_in_period(m, t) for t in m.TPS_IN_PERIOD[p])
+        * m.bring_annual_costs_to_base_year[p]
+        for p in m.PERIODS
+    )
+)
 
 print("model successfully loaded...")

--- a/examples/3zone_toy_stochastic_PySP/pha_bounds_cfg.py
+++ b/examples/3zone_toy_stochastic_PySP/pha_bounds_cfg.py
@@ -4,20 +4,24 @@
 # Use this by adding terms like the following to the runph command:
 # --linearize-nonbinary-penalty-terms=5 --bounds-cfgfile=pha_bounds_cfg.py
 
+
 def pysp_boundsetter_callback(self, scenario_tree, scenario):
-    m = scenario._instance 	# see pyomo/pysp/scenariotree/tree_structure.py
+    m = scenario._instance  # see pyomo/pysp/scenariotree/tree_structure.py
 
     # BuildLocalTD
     for p in m.PERIODS:
         for lz in m.LOAD_ZONES:
-            m.BuildLocalTD[lz, p].setub(2 * m.zone_expected_coincident_peak_demand[lz, p])
+            m.BuildLocalTD[lz, p].setub(
+                2 * m.zone_expected_coincident_peak_demand[lz, p]
+            )
 
     # Estimate an upper bound of system peak demand for limiting generation unit
     # & transmission line builds
     system_wide_peak = {}
     for p in m.PERIODS:
         system_wide_peak[p] = sum(
-            m.zone_expected_coincident_peak_demand[lz, p] for lz in m.LOAD_ZONES)
+            m.zone_expected_coincident_peak_demand[lz, p] for lz in m.LOAD_ZONES
+        )
 
     # BuildGen
     for g, bld_yr in m.NEW_GEN_BLD_YRS:
@@ -26,6 +30,7 @@ def pysp_boundsetter_callback(self, scenario_tree, scenario):
     # BuildTx
     for tx, bld_yr in m.TRANS_BLD_YRS:
         m.BuildTx[tx, bld_yr].setub(5 * system_wide_peak[bld_yr])
+
 
 # For some reason runph looks for pysp_boundsetter_callback when run in
 # single-thread mode and ph_boundsetter_callback when called from mpirun with

--- a/examples/3zone_toy_stochastic_PySP/rhosetter.py
+++ b/examples/3zone_toy_stochastic_PySP/rhosetter.py
@@ -18,17 +18,22 @@ from pyomo.environ import Objective
 from switch_model.utilities import iteritems
 
 try:
-    from pyomo.repn import generate_standard_repn    # Pyomo >=5.6
+    from pyomo.repn import generate_standard_repn  # Pyomo >=5.6
+
     newPyomo = True
 except ImportError:
-    from pyomo.repn import generate_canonical_repn   # Pyomo <=5.6
+    from pyomo.repn import generate_canonical_repn  # Pyomo <=5.6
+
     newPyomo = False
 
+
 def ph_rhosetter_callback(ph, scenario_tree, scenario):
-    # Derive coefficients from active objective    
-    cost_expr = next(scenario._instance.component_data_objects(
-        Objective, active=True, descend_into=True
-    ))
+    # Derive coefficients from active objective
+    cost_expr = next(
+        scenario._instance.component_data_objects(
+            Objective, active=True, descend_into=True
+        )
+    )
     set_rho_values(ph, scenario_tree, scenario, cost_expr)
 
 
@@ -57,8 +62,7 @@ def set_rho_values(ph, scenario_tree, scenario, cost_expr):
 
     cost_coefficients = {}
     var_names = {}
-    for (variable, coef) in \
-            zip(standard_repn.linear_vars, standard_repn.linear_coefs):
+    for (variable, coef) in zip(standard_repn.linear_vars, standard_repn.linear_coefs):
         variable_id = symbol_map.getSymbol(variable)
         cost_coefficients[variable_id] = coef
         var_names[variable_id] = variable.name
@@ -72,11 +76,13 @@ def set_rho_values(ph, scenario_tree, scenario, cost_expr):
                     tree_node,
                     scenario,
                     variable_id,
-                    cost_coefficients[variable_id] * rho_coefficient)
+                    cost_coefficients[variable_id] * rho_coefficient,
+                )
                 set_rho = True
                 break
         if not set_rho:
             print(
-                "Warning! Could not find tree node for variable {}; rho not set."
-                .format(var_names[variable_id])
+                "Warning! Could not find tree node for variable {}; rho not set.".format(
+                    var_names[variable_id]
+                )
             )

--- a/examples/3zone_toy_stochastic_PySP/rhosetter_FS_only.py
+++ b/examples/3zone_toy_stochastic_PySP/rhosetter_FS_only.py
@@ -25,6 +25,7 @@ optimizations.
 # The rhosetter module should be in the same directory as this file.
 from rhosetter import set_rho_values
 
+
 def ph_rhosetter_callback(ph, scenario_tree, scenario):
     # This component name must match the expression used for first stage
     # costs defined in the ReferenceModel.

--- a/examples/custom_extension/sunk_costs.py
+++ b/examples/custom_extension/sunk_costs.py
@@ -27,7 +27,5 @@ from pyomo.environ import *
 
 
 def define_components(mod):
-    mod.administration_fees = Param(
-        mod.PERIODS,
-        initialize=lambda m, p: 1000000)
-    mod.Cost_Components_Per_Period.append('administration_fees')
+    mod.administration_fees = Param(mod.PERIODS, initialize=lambda m, p: 1000000)
+    mod.Cost_Components_Per_Period.append("administration_fees")

--- a/run_tests.py
+++ b/run_tests.py
@@ -20,11 +20,12 @@ class TestLoader(unittest.TestLoader):
     # effects when imported.
     def discover(self, start_dir, pattern, top_level_dir):
         test_suite = unittest.TestSuite()
-        for subdir in ('switch_model', 'tests'):
+        for subdir in ("switch_model", "tests"):
             test_suite.addTests(
                 super(TestLoader, self).discover(
-                    os.path.join(top_level_dir, subdir),
-                    pattern, top_level_dir))
+                    os.path.join(top_level_dir, subdir), pattern, top_level_dir
+                )
+            )
         return test_suite
 
     # The unittest module does not have built-in support for finding
@@ -37,7 +38,7 @@ class TestLoader(unittest.TestLoader):
         if not docstring:
             # Work around a misfeature whereby doctest complains if a
             # module contains no docstrings.
-            module.__doc__ = 'Placeholder docstring'
+            module.__doc__ = "Placeholder docstring"
         test_suite.addTests(doctest.DocTestSuite(module))
         if not docstring:
             # Restore the original, in case this matters.
@@ -48,12 +49,16 @@ class TestLoader(unittest.TestLoader):
 def main():
     script_dir = os.path.join(os.getcwd(), os.path.dirname(__file__))
     # print('old argv: {}'.format(sys.argv))
-    argv = [sys.argv[0],
-            'discover',
-            '--top-level-directory', script_dir,
-            '--pattern', '*.py'] + sys.argv[1:]
+    argv = [
+        sys.argv[0],
+        "discover",
+        "--top-level-directory",
+        script_dir,
+        "--pattern",
+        "*.py",
+    ] + sys.argv[1:]
     unittest.TestProgram(testLoader=TestLoader(), argv=argv, module=None)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     main()

--- a/setup.py
+++ b/setup.py
@@ -76,7 +76,10 @@ setup(
             'rpy2;python_version>="3.0"',
             'sympy'
         ],
-        'dev': ['ipdb'],
+        'dev': [
+            'ipdb',
+            'black'
+        ],
         'plotting': ['plotnine'],
         'database_access': ['psycopg2-binary']
     },

--- a/setup.py
+++ b/setup.py
@@ -16,74 +16,77 @@ import os
 from setuptools import setup, find_packages
 
 # Get the version number. Strategy #3 from https://packaging.python.org/single_source_version/
-version_path = os.path.join(os.path.dirname(__file__), 'switch_model', 'version.py')
+version_path = os.path.join(os.path.dirname(__file__), "switch_model", "version.py")
 version = {}
 with open(version_path) as f:
     exec(f.read(), version)
-__version__ = version['__version__']
+__version__ = version["__version__"]
+
 
 def read(*rnames):
     return open(os.path.join(os.path.dirname(__file__), *rnames)).read()
 
+
 setup(
-    name='switch_model',
+    name="switch_model",
     version=__version__,
-    maintainer='Switch Authors',
-    maintainer_email='authors@switch-model.org',
-    url='http://switch-model.org',
-    license='Apache License 2.0',
+    maintainer="Switch Authors",
+    maintainer_email="authors@switch-model.org",
+    url="http://switch-model.org",
+    license="Apache License 2.0",
     platforms=["any"],
-    description='Switch Power System Planning Model',
-    long_description=read('README'),
+    description="Switch Power System Planning Model",
+    long_description=read("README"),
     long_description_content_type="text/markdown",
     classifiers=[
         # from https://pypi.org/classifiers/
-        'Development Status :: 5 - Production/Stable',
-        'Environment :: Console',
-        'Intended Audience :: Education',
-        'Intended Audience :: End Users/Desktop',
-        'Intended Audience :: Science/Research',
-        'License :: OSI Approved :: Apache Software License',
-        'Natural Language :: English',
-        'Operating System :: Microsoft :: Windows',
-        'Operating System :: MacOS :: MacOS X',
-        'Operating System :: POSIX :: Linux',
-        'Operating System :: Unix',
-        'Programming Language :: Python :: 2.7',
-        'Programming Language :: Python :: 3',
-        'Topic :: Scientific/Engineering',
-        'Topic :: Software Development :: Libraries :: Python Modules'
+        "Development Status :: 5 - Production/Stable",
+        "Environment :: Console",
+        "Intended Audience :: Education",
+        "Intended Audience :: End Users/Desktop",
+        "Intended Audience :: Science/Research",
+        "License :: OSI Approved :: Apache Software License",
+        "Natural Language :: English",
+        "Operating System :: Microsoft :: Windows",
+        "Operating System :: MacOS :: MacOS X",
+        "Operating System :: POSIX :: Linux",
+        "Operating System :: Unix",
+        "Programming Language :: Python :: 2.7",
+        "Programming Language :: Python :: 3",
+        "Topic :: Scientific/Engineering",
+        "Topic :: Software Development :: Libraries :: Python Modules",
     ],
-    packages=find_packages(include=['switch_model', 'switch_model.*']),
+    packages=find_packages(include=["switch_model", "switch_model.*"]),
     keywords=[
-        'renewable', 'power', 'energy', 'electricity',
-        'production cost', 'capacity expansion',
-        'planning', 'optimization'
+        "renewable",
+        "power",
+        "energy",
+        "electricity",
+        "production cost",
+        "capacity expansion",
+        "planning",
+        "optimization",
     ],
     install_requires=[
-        'Pyomo >=4.4.1, <5.6.9a0', # 4.4.1+ works with glpk 4.60+; 5.6.9 gives warning and 5.7 gives error
-        'pyutilib <6.0a0', # by default, incompatible 6.0 gets installed with Pyomo 5.6.*
-        'pint',          # needed by Pyomo when we run our tests, but not included
-        'testfixtures',  # used for standard tests
-        'pandas',        # used for input upgrades and some outputs
+        "Pyomo >=4.4.1, <5.6.9a0",  # 4.4.1+ works with glpk 4.60+; 5.6.9 gives warning and 5.7 gives error
+        "pyutilib <6.0a0",  # by default, incompatible 6.0 gets installed with Pyomo 5.6.*
+        "pint",  # needed by Pyomo when we run our tests, but not included
+        "testfixtures",  # used for standard tests
+        "pandas",  # used for input upgrades and some outputs
     ],
     extras_require={
         # packages used for advanced demand response, progressive hedging
         # note: rpy2 discontinued support for Python 2 as of rpy2 2.9.0
-        'advanced': [
-            'numpy', 'scipy',
+        "advanced": [
+            "numpy",
+            "scipy",
             'rpy2<2.9.0;python_version<"3.0"',
             'rpy2;python_version>="3.0"',
-            'sympy'
+            "sympy",
         ],
-        'dev': [
-            'ipdb',
-            'black'
-        ],
-        'plotting': ['plotnine'],
-        'database_access': ['psycopg2-binary']
+        "dev": ["ipdb", "black"],
+        "plotting": ["plotnine"],
+        "database_access": ["psycopg2-binary"],
     },
-    entry_points={
-        'console_scripts': ['switch = switch_model.main:main']
-    },
+    entry_points={"console_scripts": ["switch = switch_model.main:main"]},
 )

--- a/switch_model/__init__.py
+++ b/switch_model/__init__.py
@@ -18,10 +18,12 @@ Most applications of Switch will also benefit from optional modules such as
 transmission, local_td, reserves, etc.
 """
 from .version import __version__
+
 core_modules = [
-    'switch_model.timescales',
-    'switch_model.financials',
-    'switch_model.balancing.load_zones',
-    'switch_model.energy_sources.properties',
-    'switch_model.generators.core',
-    'switch_model.reporting']
+    "switch_model.timescales",
+    "switch_model.financials",
+    "switch_model.balancing.load_zones",
+    "switch_model.energy_sources.properties",
+    "switch_model.generators.core",
+    "switch_model.reporting",
+]

--- a/switch_model/balancing/demand_response/iterative/__init__.py
+++ b/switch_model/balancing/demand_response/iterative/__init__.py
@@ -24,6 +24,7 @@ from __future__ import division
 import os, sys, time
 from pprint import pprint
 from pyomo.environ import *
+
 try:
     from pyomo.repn import generate_standard_repn
 except ImportError:
@@ -31,26 +32,38 @@ except ImportError:
     from pyomo.repn import generate_canonical_repn as generate_standard_repn
 
 import switch_model.utilities as utilities
+
 # TODO: move part of the reporting back into Hawaii module and eliminate these dependencies
 from switch_model.hawaii.save_results import DispatchGenByFuel
 import switch_model.hawaii.util as util
 
-demand_module = None    # will be set via command-line options
+demand_module = None  # will be set via command-line options
+
 
 def define_arguments(argparser):
-    argparser.add_argument("--dr-flat-pricing", action='store_true', default=False,
-        help="Charge a constant (average) price for electricity, rather than varying hour by hour")
-    argparser.add_argument("--dr-demand-module", default=None,
+    argparser.add_argument(
+        "--dr-flat-pricing",
+        action="store_true",
+        default=False,
+        help="Charge a constant (average) price for electricity, rather than varying hour by hour",
+    )
+    argparser.add_argument(
+        "--dr-demand-module",
+        default=None,
         help="Name of module to use for demand-response bids. This should also be "
         "specified in the modules list, and should provide calibrate() and bid() functions. "
         "Pre-written options include constant_elasticity_demand_system or r_demand_system. "
-        "Specify one of these in the modules list and use --help again to see module-specific options.")
-    argparser.add_argument('--demand-response-reserve-types', nargs='+', default=[],
-        help=
-            "Type(s) of reserves to provide from demand response (e.g., 'contingency' or 'regulation'). "
-            "Specify 'none' to disable. Default is 'spinning' if an operating reserve module is used, "
-            "otherwise it is 'none'."
+        "Specify one of these in the modules list and use --help again to see module-specific options.",
     )
+    argparser.add_argument(
+        "--demand-response-reserve-types",
+        nargs="+",
+        default=[],
+        help="Type(s) of reserves to provide from demand response (e.g., 'contingency' or 'regulation'). "
+        "Specify 'none' to disable. Default is 'spinning' if an operating reserve module is used, "
+        "otherwise it is 'none'.",
+    )
+
 
 def define_components(m):
 
@@ -59,10 +72,12 @@ def define_components(m):
         global scipy
         import scipy.optimize
     except ImportError:
-        print("="*80)
-        print("Unable to load scipy package, which is used by the demand response system.")
+        print("=" * 80)
+        print(
+            "Unable to load scipy package, which is used by the demand response system."
+        )
         print("Please install this via 'conda install scipy' or 'pip install scipy'.")
-        print("="*80)
+        print("=" * 80)
         raise
 
     ###################
@@ -85,8 +100,7 @@ def define_components(m):
             "Demand module {mod} cannot be used because it has not been loaded. "
             "Please add this module to the modules list (usually modules.txt) "
             "or specify --include-module {mod} in options.txt, scenarios.txt or "
-            "on the command line."
-            .format(mod=m.options.dr_demand_module)
+            "on the command line.".format(mod=m.options.dr_demand_module)
         )
     demand_module = sys.modules[m.options.dr_demand_module]
 
@@ -106,23 +120,27 @@ def define_components(m):
     # amount of unserved load during each timepoint
     m.DRUnservedLoad = Var(m.LOAD_ZONES, m.TIMEPOINTS, within=NonNegativeReals)
     # total cost for unserved load
-    m.DR_Unserved_Load_Penalty = Expression(m.TIMEPOINTS, rule=lambda m, tp:
-        sum(m.DRUnservedLoad[z, tp] * m.dr_unserved_load_penalty_per_mwh for z in m.LOAD_ZONES)
+    m.DR_Unserved_Load_Penalty = Expression(
+        m.TIMEPOINTS,
+        rule=lambda m, tp: sum(
+            m.DRUnservedLoad[z, tp] * m.dr_unserved_load_penalty_per_mwh
+            for z in m.LOAD_ZONES
+        ),
     )
     # add unserved load to the zonal energy balance
-    m.Zone_Power_Injections.append('DRUnservedLoad')
+    m.Zone_Power_Injections.append("DRUnservedLoad")
     # add the unserved load penalty to the model's objective function
-    m.Cost_Components_Per_TP.append('DR_Unserved_Load_Penalty')
+    m.Cost_Components_Per_TP.append("DR_Unserved_Load_Penalty")
 
     # list of products (commodities and reserves) that can be bought or sold
-    m.DR_PRODUCTS = Set(initialize=['energy', 'energy up', 'energy down'])
+    m.DR_PRODUCTS = Set(initialize=["energy", "energy up", "energy down"])
 
     ###################
     # Price Responsive Demand bids
     ##################
 
     # list of all bids that have been received from the demand system
-    m.DR_BID_LIST = Set(initialize = [], ordered=True)
+    m.DR_BID_LIST = Set(initialize=[], ordered=True)
     # we need an explicit indexing set for everything that depends on DR_BID_LIST
     # so we can reconstruct it (and them) each time we add an element to DR_BID_LIST
     # (not needed, and actually doesn't work -- reconstruct() fails for sets)
@@ -132,16 +150,22 @@ def define_components(m):
     # data for the individual bids; each load_zone gets one bid for each timeseries,
     # and each bid covers all the timepoints in that timeseries. So we just record
     # the bid for each timepoint for each load_zone.
-    m.dr_bid = Param(m.DR_BID_LIST, m.LOAD_ZONES, m.TIMEPOINTS, m.DR_PRODUCTS, mutable=True)
+    m.dr_bid = Param(
+        m.DR_BID_LIST, m.LOAD_ZONES, m.TIMEPOINTS, m.DR_PRODUCTS, mutable=True
+    )
 
     # price used to get this bid (only kept for reference)
-    m.dr_price = Param(m.DR_BID_LIST, m.LOAD_ZONES, m.TIMEPOINTS, m.DR_PRODUCTS, mutable=True)
+    m.dr_price = Param(
+        m.DR_BID_LIST, m.LOAD_ZONES, m.TIMEPOINTS, m.DR_PRODUCTS, mutable=True
+    )
 
     # the private benefit of serving each bid
     m.dr_bid_benefit = Param(m.DR_BID_LIST, m.LOAD_ZONES, m.TIMESERIES, mutable=True)
 
     # weights to assign to the bids for each timeseries when constructing an optimal demand profile
-    m.DRBidWeight = Var(m.DR_BID_LIST, m.LOAD_ZONES, m.TIMESERIES, within=NonNegativeReals)
+    m.DRBidWeight = Var(
+        m.DR_BID_LIST, m.LOAD_ZONES, m.TIMESERIES, within=NonNegativeReals
+    )
 
     # def DR_Convex_Bid_Weight_rule(m, z, ts):
     #     if len(m.DR_BID_LIST) == 0:
@@ -152,9 +176,12 @@ def define_components(m):
     #         return (sum(m.DRBidWeight[b, z, ts] for b in m.DR_BID_LIST) == 1)
     #
     # choose a convex combination of bids for each zone and timeseries
-    m.DR_Convex_Bid_Weight = Constraint(m.LOAD_ZONES, m.TIMESERIES, rule=lambda m, z, ts:
-        Constraint.Skip if len(m.DR_BID_LIST) == 0
-            else (sum(m.DRBidWeight[b, z, ts] for b in m.DR_BID_LIST) == 1)
+    m.DR_Convex_Bid_Weight = Constraint(
+        m.LOAD_ZONES,
+        m.TIMESERIES,
+        rule=lambda m, z, ts: Constraint.Skip
+        if len(m.DR_BID_LIST) == 0
+        else (sum(m.DRBidWeight[b, z, ts] for b in m.DR_BID_LIST) == 1),
     )
 
     # Since we don't have differentiated prices for each zone, we have to use the same
@@ -163,8 +190,11 @@ def define_components(m):
     # Note: LOAD_ZONES is not an ordered set, so we have to use a trick to get a single
     # arbitrary one to refer to (list(m.LOAD_ZONES)[0] would also work).
     m.DR_Load_Zone_Shared_Bid_Weight = Constraint(
-        m.DR_BID_LIST, m.LOAD_ZONES, m.TIMESERIES, rule=lambda m, b, z, ts:
-            m.DRBidWeight[b, z, ts] == m.DRBidWeight[b, next(iter(m.LOAD_ZONES)), ts]
+        m.DR_BID_LIST,
+        m.LOAD_ZONES,
+        m.TIMESERIES,
+        rule=lambda m, b, z, ts: m.DRBidWeight[b, z, ts]
+        == m.DRBidWeight[b, next(iter(m.LOAD_ZONES)), ts],
     )
 
     # For flat-price models, we have to use the same weight for all timeseries within the
@@ -172,50 +202,54 @@ def define_components(m):
     # induce different adjustments in individual timeseries.
     if m.options.dr_flat_pricing:
         m.DR_Flat_Bid_Weight = Constraint(
-            m.DR_BID_LIST, m.LOAD_ZONES, m.TIMESERIES, rule=lambda m, b, z, ts:
-                m.DRBidWeight[b, z, ts]
-                == m.DRBidWeight[b, z, m.tp_ts[m.TPS_IN_PERIOD[m.ts_period[ts]].first()]]
+            m.DR_BID_LIST,
+            m.LOAD_ZONES,
+            m.TIMESERIES,
+            rule=lambda m, b, z, ts: m.DRBidWeight[b, z, ts]
+            == m.DRBidWeight[b, z, m.tp_ts[m.TPS_IN_PERIOD[m.ts_period[ts]].first()]],
         )
 
     # Optimal level of demand, calculated from available bids (negative, indicating consumption)
-    m.FlexibleDemand = Expression(m.LOAD_ZONES, m.TIMEPOINTS,
+    m.FlexibleDemand = Expression(
+        m.LOAD_ZONES,
+        m.TIMEPOINTS,
         rule=lambda m, z, tp: sum(
-            m.DRBidWeight[b, z, m.tp_ts[tp]] * m.dr_bid[b, z, tp, 'energy']
+            m.DRBidWeight[b, z, m.tp_ts[tp]] * m.dr_bid[b, z, tp, "energy"]
             for b in m.DR_BID_LIST
-        )
+        ),
     )
 
     # calculate available slack from demand response for use as reserves (from
     # supply perspective, so "up" means less load), then register spinning
     # reserves
     m.DemandUpReserveSales = Expression(
-        m.LOAD_ZONES, m.TIMEPOINTS,
+        m.LOAD_ZONES,
+        m.TIMEPOINTS,
         rule=lambda m, z, tp: -sum(
-            m.DRBidWeight[b, z, m.tp_ts[tp]] * m.dr_bid[b, z, tp, 'energy up']
+            m.DRBidWeight[b, z, m.tp_ts[tp]] * m.dr_bid[b, z, tp, "energy up"]
             for b in m.DR_BID_LIST
-        )
+        ),
     )
     m.DemandDownReserveSales = Expression(
-        m.LOAD_ZONES, m.TIMEPOINTS,
+        m.LOAD_ZONES,
+        m.TIMEPOINTS,
         rule=lambda m, z, tp: -sum(
-            m.DRBidWeight[b, z, m.tp_ts[tp]] * m.dr_bid[b, z, tp, 'energy down']
+            m.DRBidWeight[b, z, m.tp_ts[tp]] * m.dr_bid[b, z, tp, "energy down"]
             for b in m.DR_BID_LIST
-        )
+        ),
     )
-    if hasattr(m, 'ZONES_IN_BALANCING_AREA'):
+    if hasattr(m, "ZONES_IN_BALANCING_AREA"):
         m.DemandResponseSlackUp = Expression(
             m.BALANCING_AREA_TIMEPOINTS,
             rule=lambda m, ba, tp: sum(
-                m.DemandUpReserveSales[z, tp]
-                for z in m.ZONES_IN_BALANCING_AREA[ba]
-            )
+                m.DemandUpReserveSales[z, tp] for z in m.ZONES_IN_BALANCING_AREA[ba]
+            ),
         )
         m.DemandResponseSlackDown = Expression(
             m.BALANCING_AREA_TIMEPOINTS,
             rule=lambda m, ba, tp: sum(
-                m.DemandDownReserveSales[z, tp]
-                for z in m.ZONES_IN_BALANCING_AREA[ba]
-            )
+                m.DemandDownReserveSales[z, tp] for z in m.ZONES_IN_BALANCING_AREA[ba]
+            ),
         )
     register_demand_response_reserves(m)
 
@@ -225,23 +259,28 @@ def define_components(m):
     # a certain ordering.
     # m.Zone_Power_Withdrawals.remove('zone_demand_mw')
     # m.Zone_Power_Withdrawals.append('FlexibleDemand')
-    idx = m.Zone_Power_Withdrawals.index('zone_demand_mw')
-    m.Zone_Power_Withdrawals[idx] = 'FlexibleDemand'
+    idx = m.Zone_Power_Withdrawals.index("zone_demand_mw")
+    m.Zone_Power_Withdrawals[idx] = "FlexibleDemand"
 
     # private benefit of the electricity consumption
     # (i.e., willingness to pay for the current electricity supply)
     # reported as negative cost, i.e., positive benefit
     # also divide by number of timepoints in the timeseries
     # to convert from a cost per timeseries to a cost per timepoint.
-    m.DR_Welfare_Cost = Expression(m.TIMEPOINTS, rule=lambda m, tp:
-        (-1.0)
-        * sum(m.DRBidWeight[b, z, m.tp_ts[tp]] * m.dr_bid_benefit[b, z, m.tp_ts[tp]]
-            for b in m.DR_BID_LIST for z in m.LOAD_ZONES)
-        * m.tp_duration_hrs[tp] / m.ts_num_tps[m.tp_ts[tp]]
+    m.DR_Welfare_Cost = Expression(
+        m.TIMEPOINTS,
+        rule=lambda m, tp: (-1.0)
+        * sum(
+            m.DRBidWeight[b, z, m.tp_ts[tp]] * m.dr_bid_benefit[b, z, m.tp_ts[tp]]
+            for b in m.DR_BID_LIST
+            for z in m.LOAD_ZONES
+        )
+        * m.tp_duration_hrs[tp]
+        / m.ts_num_tps[m.tp_ts[tp]],
     )
 
     # add the private benefit to the model's objective function
-    m.Cost_Components_Per_TP.append('DR_Welfare_Cost')
+    m.Cost_Components_Per_TP.append("DR_Welfare_Cost")
 
     # variable to store the baseline data
     m.base_data = None
@@ -308,21 +347,30 @@ def pre_iterate(m):
         # model hasn't been solved yet
         m.prev_marginal_cost = {
             (z, tp, prod): None
-            for z in m.LOAD_ZONES for tp in m.TIMEPOINTS for prod in m.DR_PRODUCTS
+            for z in m.LOAD_ZONES
+            for tp in m.TIMEPOINTS
+            for prod in m.DR_PRODUCTS
         }
         m.prev_demand = {
-            (z, tp, prod): None for z in m.LOAD_ZONES for tp in m.TIMEPOINTS for prod in m.DR_PRODUCTS
+            (z, tp, prod): None
+            for z in m.LOAD_ZONES
+            for tp in m.TIMEPOINTS
+            for prod in m.DR_PRODUCTS
         }
         m.prev_SystemCost = None
     else:
         # get values from previous solution
         m.prev_marginal_cost = {
             (z, tp, prod): electricity_marginal_cost(m, z, tp, prod)
-            for z in m.LOAD_ZONES for tp in m.TIMEPOINTS for prod in m.DR_PRODUCTS
+            for z in m.LOAD_ZONES
+            for tp in m.TIMEPOINTS
+            for prod in m.DR_PRODUCTS
         }
         m.prev_demand = {
             (z, tp, prod): electricity_demand(m, z, tp, prod)
-            for z in m.LOAD_ZONES for tp in m.TIMEPOINTS for prod in m.DR_PRODUCTS
+            for z in m.LOAD_ZONES
+            for tp in m.TIMEPOINTS
+            for prod in m.DR_PRODUCTS
         }
         m.prev_SystemCost = value(m.SystemCost)
 
@@ -344,23 +392,27 @@ def pre_iterate(m):
         # different solution that would be much better than the one we have now.
         # This ignores other solutions far away, where an integer variable is flipped,
         # but that's OK. (?)
-        prev_direct_cost = value(sum(
-            (
-                sum(
-                    m.prev_marginal_cost[z, tp, prod] * m.prev_demand[z, tp, prod]
-                    for z in m.LOAD_ZONES for prod in m.DR_PRODUCTS
+        prev_direct_cost = value(
+            sum(
+                (
+                    sum(
+                        m.prev_marginal_cost[z, tp, prod] * m.prev_demand[z, tp, prod]
+                        for z in m.LOAD_ZONES
+                        for prod in m.DR_PRODUCTS
+                    )
                 )
-            ) * m.bring_timepoint_costs_to_base_year[tp]
-            for ts in m.TIMESERIES
-            for tp in m.TPS_IN_TS[ts]
-        ))
-        prev_welfare_cost = value(sum(
-            (
-                m.DR_Welfare_Cost[tp]
-            ) * m.bring_timepoint_costs_to_base_year[tp]
-            for ts in m.TIMESERIES
-            for tp in m.TPS_IN_TS[ts]
-        ))
+                * m.bring_timepoint_costs_to_base_year[tp]
+                for ts in m.TIMESERIES
+                for tp in m.TPS_IN_TS[ts]
+            )
+        )
+        prev_welfare_cost = value(
+            sum(
+                (m.DR_Welfare_Cost[tp]) * m.bring_timepoint_costs_to_base_year[tp]
+                for ts in m.TIMESERIES
+                for tp in m.TPS_IN_TS[ts]
+            )
+        )
         prev_cost = prev_direct_cost + prev_welfare_cost
 
         # prev_cost = value(sum(
@@ -375,8 +427,8 @@ def pre_iterate(m):
         # ))
 
         print("")
-        print('previous direct cost: ${:,.0f}'.format(prev_direct_cost))
-        print('previous welfare cost: ${:,.0f}'.format(prev_welfare_cost))
+        print("previous direct cost: ${:,.0f}".format(prev_direct_cost))
+        print("previous welfare cost: ${:,.0f}".format(prev_welfare_cost))
         print("")
 
     # get the next bid and attach it to the model
@@ -386,13 +438,15 @@ def pre_iterate(m):
         # get an estimate of best possible net cost of serving load
         # (if we could completely serve the last bid at the prices we quoted,
         # that would be an optimum; the actual cost may be higher but never lower)
-        b = m.DR_BID_LIST.last()    # current bid number
+        b = m.DR_BID_LIST.last()  # current bid number
         best_direct_cost = value(
             sum(
                 sum(
                     m.prev_marginal_cost[z, tp, prod] * m.dr_bid[b, z, tp, prod]
-                    for z in m.LOAD_ZONES for prod in m.DR_PRODUCTS
-                ) * m.bring_timepoint_costs_to_base_year[tp]
+                    for z in m.LOAD_ZONES
+                    for prod in m.DR_PRODUCTS
+                )
+                * m.bring_timepoint_costs_to_base_year[tp]
                 for ts in m.TIMESERIES
                 for tp in m.TPS_IN_TS[ts]
             )
@@ -400,9 +454,11 @@ def pre_iterate(m):
         best_bid_benefit = value(
             sum(
                 (
-                    - sum(m.dr_bid_benefit[b, z, ts] for z in m.LOAD_ZONES)
-                    * m.tp_duration_hrs[tp] / m.ts_num_tps[ts]
-                ) * m.bring_timepoint_costs_to_base_year[tp]
+                    -sum(m.dr_bid_benefit[b, z, ts] for z in m.LOAD_ZONES)
+                    * m.tp_duration_hrs[tp]
+                    / m.ts_num_tps[ts]
+                )
+                * m.bring_timepoint_costs_to_base_year[tp]
                 for ts in m.TIMESERIES
                 for tp in m.TPS_IN_TS[ts]
             )
@@ -423,14 +479,17 @@ def pre_iterate(m):
         # ))
 
         print("")
-        print('best direct cost: ${:,.0f}'.format(best_direct_cost))
-        print('best bid benefit: ${:,.0f}'.format(best_bid_benefit))
+        print("best direct cost: ${:,.0f}".format(best_direct_cost))
+        print("best bid benefit: ${:,.0f}".format(best_bid_benefit))
         print("")
 
-        print("lower bound=${:,.0f}, previous cost=${:,.0f}, optimality gap (vs direct cost)={}" \
-            .format(best_cost, prev_cost, (prev_cost-best_cost)/abs(prev_direct_cost)))
+        print(
+            "lower bound=${:,.0f}, previous cost=${:,.0f}, optimality gap (vs direct cost)={}".format(
+                best_cost, prev_cost, (prev_cost - best_cost) / abs(prev_direct_cost)
+            )
+        )
         if prev_cost < best_cost:
-            print (
+            print(
                 "WARNING: final cost is below reported lower bound; "
                 "there is probably a problem with the demand system."
             )
@@ -477,9 +536,13 @@ def pre_iterate(m):
     # TODO: index this to the direct costs, rather than the direct costs minus benefits
     # as it stands, it converges with about $50,000,000 optimality gap, which is about
     # 3% of direct costs.
-    converged = (m.iteration_number > 0 and (prev_cost - best_cost)/abs(prev_direct_cost) <= 0.0001)
+    converged = (
+        m.iteration_number > 0
+        and (prev_cost - best_cost) / abs(prev_direct_cost) <= 0.0001
+    )
 
     return converged
+
 
 def post_iterate(m):
     print("\n\n=======================================================")
@@ -487,18 +550,22 @@ def post_iterate(m):
     print("=======================================================")
     print("Total cost: ${v:,.0f}".format(v=value(m.SystemCost)))
 
-
     # TODO:
     # maybe calculate prices for the next round here and attach them to the
     # model, so they can be reported as final prices (currently we don't
     # report the final prices, only the prices prior to the final model run)
 
-    SystemCost = value(m.SystemCost)    # calculate once to save time
+    SystemCost = value(m.SystemCost)  # calculate once to save time
     if m.prev_SystemCost is None:
-        print("prev_SystemCost=<n/a>, SystemCost={:,.0f}, ratio=<n/a>".format(SystemCost))
+        print(
+            "prev_SystemCost=<n/a>, SystemCost={:,.0f}, ratio=<n/a>".format(SystemCost)
+        )
     else:
-        print("prev_SystemCost={:,.0f}, SystemCost={:,.0f}, ratio={}" \
-            .format(m.prev_SystemCost, SystemCost, SystemCost/m.prev_SystemCost))
+        print(
+            "prev_SystemCost={:,.0f}, SystemCost={:,.0f}, ratio={}".format(
+                m.prev_SystemCost, SystemCost, SystemCost / m.prev_SystemCost
+            )
+        )
 
     tag = m.options.scenario_name
     outputs_dir = m.options.outputs_dir
@@ -507,46 +574,58 @@ def post_iterate(m):
     if m.iteration_number == 0:
         util.create_table(
             output_file=os.path.join(outputs_dir, "bid_{t}.csv".format(t=tag)),
-            headings=
-                (
-                    "bid_num", "load_zone", "timeseries", "timepoint",
-                ) + tuple("marginal_cost " + prod for prod in m.DR_PRODUCTS)
-                + tuple("price " + prod for prod in m.DR_PRODUCTS)
-                + tuple("bid " + prod for prod in m.DR_PRODUCTS)
-                + (
-                    "wtp", "base_price", "base_load"
-                )
+            headings=(
+                "bid_num",
+                "load_zone",
+                "timeseries",
+                "timepoint",
+            )
+            + tuple("marginal_cost " + prod for prod in m.DR_PRODUCTS)
+            + tuple("price " + prod for prod in m.DR_PRODUCTS)
+            + tuple("bid " + prod for prod in m.DR_PRODUCTS)
+            + ("wtp", "base_price", "base_load"),
         )
-    b = m.DR_BID_LIST.last()    # current bid
+    b = m.DR_BID_LIST.last()  # current bid
     util.append_table(
-        m, m.LOAD_ZONES, m.TIMEPOINTS,
+        m,
+        m.LOAD_ZONES,
+        m.TIMEPOINTS,
         output_file=os.path.join(outputs_dir, "bid_{t}.csv".format(t=tag)),
-        values=lambda m, z, tp:
-            (
-                b,
-                z,
-                m.tp_ts[tp],
-                m.tp_timestamp[tp],
-            )
-            + tuple(m.prev_marginal_cost[z, tp, prod] for prod in m.DR_PRODUCTS)
-            + tuple(m.dr_price[b, z, tp, prod] for prod in m.DR_PRODUCTS)
-            + tuple(m.dr_bid[b, z, tp, prod] for prod in m.DR_PRODUCTS)
-            + (
-                m.dr_bid_benefit[b, z, m.tp_ts[tp]],
-                m.base_data_dict[z, tp][1],
-                m.base_data_dict[z, tp][0],
-            )
+        values=lambda m, z, tp: (
+            b,
+            z,
+            m.tp_ts[tp],
+            m.tp_timestamp[tp],
+        )
+        + tuple(m.prev_marginal_cost[z, tp, prod] for prod in m.DR_PRODUCTS)
+        + tuple(m.dr_price[b, z, tp, prod] for prod in m.DR_PRODUCTS)
+        + tuple(m.dr_bid[b, z, tp, prod] for prod in m.DR_PRODUCTS)
+        + (
+            m.dr_bid_benefit[b, z, m.tp_ts[tp]],
+            m.base_data_dict[z, tp][1],
+            m.base_data_dict[z, tp][0],
+        ),
     )
 
     # store the current bid weights for future reference
     if m.iteration_number == 0:
         util.create_table(
             output_file=os.path.join(outputs_dir, "bid_weights_{t}.csv".format(t=tag)),
-            headings=("iteration", "load_zone", "timeseries", "bid_num", "weight")
+            headings=("iteration", "load_zone", "timeseries", "bid_num", "weight"),
         )
-    util.append_table(m, m.LOAD_ZONES, m.TIMESERIES, m.DR_BID_LIST,
+    util.append_table(
+        m,
+        m.LOAD_ZONES,
+        m.TIMESERIES,
+        m.DR_BID_LIST,
         output_file=os.path.join(outputs_dir, "bid_weights_{t}.csv".format(t=tag)),
-        values=lambda m, z, ts, b: (len(m.DR_BID_LIST), z, ts, b, m.DRBidWeight[b, z, ts])
+        values=lambda m, z, ts, b: (
+            len(m.DR_BID_LIST),
+            z,
+            ts,
+            b,
+            m.DRBidWeight[b, z, ts],
+        ),
     )
 
     # if m.iteration_number % 5 == 0:
@@ -570,7 +649,6 @@ def post_iterate(m):
     #     import pdb; pdb.set_trace()
 
 
-
 def update_demand(m):
     """
     This should be called after solving the model, in order to calculate new bids
@@ -578,17 +656,25 @@ def update_demand(m):
     and marginal costs to calibrate the demand system, and then replaces the fixed
     demand with the flexible demand system.
     """
-    first_run = (m.base_data is None)
+    first_run = m.base_data is None
 
     print("attaching new demand bid to model")
     if first_run:
         calibrate_model(m)
-    else:   # not first run
+    else:  # not first run
         if m.options.verbose:
             print("m.DRBidWeight:")
-            pprint([(z, ts, [(b, value(m.DRBidWeight[b, z, ts])) for b in m.DR_BID_LIST])
-                for z in m.LOAD_ZONES
-                for ts in m.TIMESERIES])
+            pprint(
+                [
+                    (
+                        z,
+                        ts,
+                        [(b, value(m.DRBidWeight[b, z, ts])) for b in m.DR_BID_LIST],
+                    )
+                    for z in m.LOAD_ZONES
+                    for ts in m.TIMESERIES
+                ]
+            )
 
     # get new bids from the demand system at the current prices
     bids = get_bids(m)
@@ -625,52 +711,57 @@ def total_direct_costs_per_year(m, period):
     in each zone.)
     """
     return value(
-        sum(getattr(m, annual_cost)[period] for annual_cost in m.Cost_Components_Per_Period)
+        sum(
+            getattr(m, annual_cost)[period]
+            for annual_cost in m.Cost_Components_Per_Period
+        )
         + sum(
             getattr(m, tp_cost)[t] * m.tp_weight_in_year[t]
             for t in m.TPS_IN_PERIOD[period]
-                for tp_cost in m.Cost_Components_Per_TP
-                    if tp_cost != "DR_Welfare_Cost"
+            for tp_cost in m.Cost_Components_Per_TP
+            if tp_cost != "DR_Welfare_Cost"
         )
     )
 
+
 def electricity_marginal_cost(m, z, tp, prod):
     """Return marginal cost of providing product prod in load_zone z during timepoint tp."""
-    if hasattr(m, 'zone_balancing_area'):
+    if hasattr(m, "zone_balancing_area"):
         ba = m.zone_balancing_area[z]
-    if prod == 'energy':
+    if prod == "energy":
         component = m.Zone_Energy_Balance[z, tp]
-    elif prod == 'energy up':
-        if hasattr(m, 'Limit_DemandResponseSpinningReserveUp'):
+    elif prod == "energy up":
+        if hasattr(m, "Limit_DemandResponseSpinningReserveUp"):
             component = m.Limit_DemandResponseSpinningReserveUp[ba, tp]
         else:
             component = m.Satisfy_Spinning_Reserve_Up_Requirement[ba, tp]
-    elif prod == 'energy down':
-        if hasattr(m, 'Limit_DemandResponseSpinningReserveUp'):
+    elif prod == "energy down":
+        if hasattr(m, "Limit_DemandResponseSpinningReserveUp"):
             component = m.Limit_DemandResponseSpinningReserveDown[ba, tp]
         else:
             component = m.Satisfy_Spinning_Reserve_Down_Requirement[ba, tp]
     else:
-        raise ValueError('Unrecognized electricity product: {}.'.format(prod))
-    return m.dual[component]/m.bring_timepoint_costs_to_base_year[tp]
+        raise ValueError("Unrecognized electricity product: {}.".format(prod))
+    return m.dual[component] / m.bring_timepoint_costs_to_base_year[tp]
+
 
 def electricity_demand(m, z, tp, prod):
     """Return total consumption of product prod in load_zone z during timepoint tp (negative if customers supply product)."""
-    if prod == 'energy':
-        if len(m.DR_BID_LIST)==0:
+    if prod == "energy":
+        if len(m.DR_BID_LIST) == 0:
             # use zone_demand_mw (base demand) if no bids have been received yet
             # (needed to find flat prices before solving the model the first time)
             demand = m.zone_demand_mw[z, tp]
         else:
             demand = m.FlexibleDemand[z, tp]
-    elif prod == 'energy up':
+    elif prod == "energy up":
         # note: reserves have positive sign when provided by demand side,
         # but that should be shown as negative demand
         demand = -value(m.DemandUpReserveSales[z, tp])
-    elif prod == 'energy down':
+    elif prod == "energy down":
         demand = -value(m.DemandDownReserveSales[z, tp])
     else:
-        raise ValueError('Unrecognized electricity product: {}.'.format(prod))
+        raise ValueError("Unrecognized electricity product: {}.".format(prod))
     return demand
 
 
@@ -692,23 +783,29 @@ def calibrate_model(m):
     # For now, we just assume the base price was $180/MWh, which is HECO's average price in
     # 2007 according to EIA form 826.
     # TODO: add in something for the fixed costs, to make marginal cost commensurate with the base_price
-    #baseCosts = [m.dual[m.EnergyBalance[z, tp]] for z in m.LOAD_ZONES for tp in m.TIMEPOINTS]
+    # baseCosts = [m.dual[m.EnergyBalance[z, tp]] for z in m.LOAD_ZONES for tp in m.TIMEPOINTS]
     base_price = 180  # average retail price for 2007 ($/MWh)
-    m.base_data = [(
-        z,
-        ts,
-        [m.zone_demand_mw[z, tp] for tp in m.TPS_IN_TS[ts]],
-        [base_price] * len(m.TPS_IN_TS[ts])
-    ) for z in m.LOAD_ZONES for ts in m.TIMESERIES]
+    m.base_data = [
+        (
+            z,
+            ts,
+            [m.zone_demand_mw[z, tp] for tp in m.TPS_IN_TS[ts]],
+            [base_price] * len(m.TPS_IN_TS[ts]),
+        )
+        for z in m.LOAD_ZONES
+        for ts in m.TIMESERIES
+    ]
 
     # make a dict of base_data, indexed by load_zone and timepoint, for later reference
     m.base_data_dict = {
         (z, tp): (m.zone_demand_mw[z, tp], base_price)
-            for z in m.LOAD_ZONES for tp in m.TIMEPOINTS
+        for z in m.LOAD_ZONES
+        for tp in m.TIMEPOINTS
     }
 
     # calibrate the demand module
     demand_module.calibrate(m, m.base_data)
+
 
 def get_prices(m, flat_revenue_neutral=True):
     """Calculate appropriate prices for each day, based on the current state
@@ -720,21 +817,26 @@ def get_prices(m, flat_revenue_neutral=True):
         marginal_costs = {
             (z, ts): {
                 prod: (
-                    [m.base_data_dict[z, tp][1] for tp in m.TPS_IN_TS[ts]] if prod == 'energy'
-                    else [0.0]*len(m.TPS_IN_TS[ts])
+                    [m.base_data_dict[z, tp][1] for tp in m.TPS_IN_TS[ts]]
+                    if prod == "energy"
+                    else [0.0] * len(m.TPS_IN_TS[ts])
                 )
                 for prod in m.DR_PRODUCTS
             }
-            for z in m.LOAD_ZONES for ts in m.TIMESERIES
+            for z in m.LOAD_ZONES
+            for ts in m.TIMESERIES
         }
     else:
         # use marginal costs from last solution
         marginal_costs = {
             (z, ts): {
-                prod: [electricity_marginal_cost(m, z, tp, prod) for tp in m.TPS_IN_TS[ts]]
+                prod: [
+                    electricity_marginal_cost(m, z, tp, prod) for tp in m.TPS_IN_TS[ts]
+                ]
                 for prod in m.DR_PRODUCTS
             }
-            for z in m.LOAD_ZONES for ts in m.TIMESERIES
+            for z in m.LOAD_ZONES
+            for ts in m.TIMESERIES
         }
 
     if m.options.dr_flat_pricing:
@@ -746,6 +848,7 @@ def get_prices(m, flat_revenue_neutral=True):
         prices = marginal_costs
 
     return prices
+
 
 def get_bids(m):
     """Get bids from the demand system showing quantities at the current prices and willingness-to-pay for those quantities
@@ -767,12 +870,13 @@ def get_bids(m):
                 # assume demand side will not provide reserves, even if they offered some
                 # (at zero price)
                 for (k, v) in demand.items():
-                    if k != 'energy':
+                    if k != "energy":
                         for i in range(len(v)):
                             v[i] = 0.0
             bids.append((z, ts, prices[z, ts], demand, wtp))
 
     return bids
+
 
 # def zone_period_average_marginal_cost(m, load_zone, period):
 #     avg_cost = value(
@@ -800,34 +904,34 @@ def find_flat_prices(m, marginal_costs, revenue_neutral):
     # now  selling to the LSE rather than directly to the customers
     #
     # LSE iterates in sub-loop (scipy.optimize.newton) to find flat price:
-        # set price (e.g., simple average of MC or avg weighted by expected demand)
-        # offer price to demand side
-        # receive bids
-        # calc revenue balance for LSE (q*price - q.MC)
-        # if > 0: decrease price (q will go up across the board)
-        # if < 0: increase price (q will go down across the board) but
+    # set price (e.g., simple average of MC or avg weighted by expected demand)
+    # offer price to demand side
+    # receive bids
+    # calc revenue balance for LSE (q*price - q.MC)
+    # if > 0: decrease price (q will go up across the board)
+    # if < 0: increase price (q will go down across the board) but
 
     flat_prices = dict()
     for z in m.LOAD_ZONES:
         for p in m.PERIODS:
             price_guess = value(
                 sum(
-                    marginal_costs[z, ts]['energy'][i]
-                    * electricity_demand(m, z, tp, 'energy')
+                    marginal_costs[z, ts]["energy"][i]
+                    * electricity_demand(m, z, tp, "energy")
                     * m.tp_weight_in_year[tp]
-                    for ts in m.TS_IN_PERIOD[p] for i, tp in enumerate(m.TPS_IN_TS[ts])
+                    for ts in m.TS_IN_PERIOD[p]
+                    for i, tp in enumerate(m.TPS_IN_TS[ts])
                 )
-                /
-                sum(electricity_demand(m, z, tp, 'energy') * m.tp_weight_in_year[tp]
-                    for tp in m.TPS_IN_PERIOD[p])
+                / sum(
+                    electricity_demand(m, z, tp, "energy") * m.tp_weight_in_year[tp]
+                    for tp in m.TPS_IN_PERIOD[p]
+                )
             )
 
             if revenue_neutral:
                 # find a flat price that produces revenue equal to marginal costs
                 flat_prices[z, p] = scipy.optimize.newton(
-                    revenue_imbalance,
-                    price_guess,
-                    args=(m, z, p, marginal_costs)
+                    revenue_imbalance, price_guess, args=(m, z, p, marginal_costs)
                 )
             else:
                 # used in final round, when LSE is considered to have
@@ -837,12 +941,14 @@ def find_flat_prices(m, marginal_costs, revenue_neutral):
 
     # construct a collection of flat prices with the right structure
     final_prices = {
-        (z, ts):
-            {
-                prod: [flat_prices[z, p] if prod=='energy' else 0.0] * len(m.TPS_IN_TS[ts])
-                for prod in m.DR_PRODUCTS
-            }
-        for z in m.LOAD_ZONES for p in m.PERIODS for ts in m.TS_IN_PERIOD[p]
+        (z, ts): {
+            prod: [flat_prices[z, p] if prod == "energy" else 0.0]
+            * len(m.TPS_IN_TS[ts])
+            for prod in m.DR_PRODUCTS
+        }
+        for z in m.LOAD_ZONES
+        for p in m.PERIODS
+        for ts in m.TS_IN_PERIOD[p]
     }
     return final_prices
 
@@ -854,7 +960,7 @@ def revenue_imbalance(flat_price, m, load_zone, period, dynamic_prices):
     dynamic_price_revenue = 0.0
     for ts in m.TS_IN_PERIOD[period]:
         prices = {
-            prod: [flat_price if prod=='energy' else 0.0] * len(m.TPS_IN_TS[ts])
+            prod: [flat_price if prod == "energy" else 0.0] * len(m.TPS_IN_TS[ts])
             for prod in m.DR_PRODUCTS
         }
         demand, wtp = demand_module.bid(m, load_zone, ts, prices)
@@ -864,15 +970,19 @@ def revenue_imbalance(flat_price, m, load_zone, period, dynamic_prices):
         # )
         flat_price_revenue += flat_price * sum(
             d * m.ts_duration_of_tp[ts] * m.ts_scale_to_year[ts]
-            for d in demand['energy']
+            for d in demand["energy"]
         )
         dynamic_price_revenue += sum(
             p * d * m.ts_duration_of_tp[ts] * m.ts_scale_to_year[ts]
-            for p, d in zip(dynamic_prices[load_zone, ts]['energy'], demand['energy'])
+            for p, d in zip(dynamic_prices[load_zone, ts]["energy"], demand["energy"])
         )
     imbalance = dynamic_price_revenue - flat_price_revenue
 
-    print("{}, {}: price ${} produces revenue imbalance of ${}/year".format(load_zone, period, flat_price, imbalance))
+    print(
+        "{}, {}: price ${} produces revenue imbalance of ${}/year".format(
+            load_zone, period, flat_price, imbalance
+        )
+    )
 
     return imbalance
 
@@ -911,15 +1021,15 @@ def add_bids(m, bids):
     m.DRBidWeight.reconstruct()
     m.DR_Convex_Bid_Weight.reconstruct()
     m.DR_Load_Zone_Shared_Bid_Weight.reconstruct()
-    if hasattr(m, 'DR_Flat_Bid_Weight'):
+    if hasattr(m, "DR_Flat_Bid_Weight"):
         m.DR_Flat_Bid_Weight.reconstruct()
     m.FlexibleDemand.reconstruct()
     m.DemandUpReserveSales.reconstruct()
     m.DemandDownReserveSales.reconstruct()
-    if hasattr(m, 'DemandResponseSlackUp'):
+    if hasattr(m, "DemandResponseSlackUp"):
         m.DemandResponseSlackUp.reconstruct()
         m.DemandResponseSlackDown.reconstruct()
-    if hasattr(m, 'Limit_DemandResponseSpinningReserveUp'):
+    if hasattr(m, "Limit_DemandResponseSpinningReserveUp"):
         m.Limit_DemandResponseSpinningReserveUp.reconstruct()
         m.Limit_DemandResponseSpinningReserveDown.reconstruct()
 
@@ -931,14 +1041,15 @@ def add_bids(m, bids):
     # (i.e., Energy_Balance refers to the items returned by FlexibleDemand instead of referring
     # to FlexibleDemand itself)
     m.Zone_Energy_Balance.reconstruct()
-    if hasattr(m, 'Aggregate_Spinning_Reserve_Details'):
+    if hasattr(m, "Aggregate_Spinning_Reserve_Details"):
         m.Aggregate_Spinning_Reserve_Details.reconstruct()
-    if hasattr(m, 'Satisfy_Spinning_Reserve_Up_Requirement'):
+    if hasattr(m, "Satisfy_Spinning_Reserve_Up_Requirement"):
         m.Satisfy_Spinning_Reserve_Up_Requirement.reconstruct()
         m.Satisfy_Spinning_Reserve_Down_Requirement.reconstruct()
     # reconstruct_energy_balance(m)
     m.SystemCostPerPeriod.reconstruct()
     m.SystemCost.reconstruct()
+
 
 def reconstruct_energy_balance(m):
     """Reconstruct Energy_Balance constraint, preserving dual values (if present)."""
@@ -955,22 +1066,23 @@ def reconstruct_energy_balance(m):
 
 def register_demand_response_reserves(m):
     if m.options.demand_response_reserve_types == []:
-        if hasattr(m, 'Spinning_Reserve_Up_Provisions'):
-            m.options.demand_response_reserve_types == ['spinning']
+        if hasattr(m, "Spinning_Reserve_Up_Provisions"):
+            m.options.demand_response_reserve_types == ["spinning"]
         else:
-            m.options.demand_response_reserve_types == ['none']
+            m.options.demand_response_reserve_types == ["none"]
 
-    if [rt.lower() for rt in m.options.demand_response_reserve_types] != ['none']:
+    if [rt.lower() for rt in m.options.demand_response_reserve_types] != ["none"]:
         # Register with spinning reserves
-        if not hasattr(m, 'Spinning_Reserve_Up_Provisions'):
+        if not hasattr(m, "Spinning_Reserve_Up_Provisions"):
             raise ValueError(
                 "--demand-response-reserve-types is set to a value other than "
                 "'none' ({}). This requires that a spinning reserve module be "
-                "specified in modules.txt."
-                .format(m.options.demand_response_reserve_types)
+                "specified in modules.txt.".format(
+                    m.options.demand_response_reserve_types
+                )
             )
 
-        if hasattr(m, 'GEN_SPINNING_RESERVE_TYPES'):
+        if hasattr(m, "GEN_SPINNING_RESERVE_TYPES"):
             # using advanced formulation, index by reserve type, balancing area, timepoint
             # define variables for each type of reserves to be provided
             # choose how to allocate the slack between the different reserve products
@@ -978,40 +1090,44 @@ def register_demand_response_reserves(m):
                 initialize=m.options.demand_response_reserve_types
             )
             m.DemandResponseSpinningReserveUp = Var(
-                m.DR_SPINNING_RESERVE_TYPES, m.BALANCING_AREA_TIMEPOINTS,
-                within=NonNegativeReals
+                m.DR_SPINNING_RESERVE_TYPES,
+                m.BALANCING_AREA_TIMEPOINTS,
+                within=NonNegativeReals,
             )
             m.DemandResponseSpinningReserveDown = Var(
-                m.DR_SPINNING_RESERVE_TYPES, m.BALANCING_AREA_TIMEPOINTS,
-                within=NonNegativeReals
+                m.DR_SPINNING_RESERVE_TYPES,
+                m.BALANCING_AREA_TIMEPOINTS,
+                within=NonNegativeReals,
             )
             # constrain reserve provision within available slack
             m.Limit_DemandResponseSpinningReserveUp = Constraint(
                 m.BALANCING_AREA_TIMEPOINTS,
-                rule=lambda m, ba, tp:
-                    sum(
-                        m.DemandResponseSpinningReserveUp[rt, ba, tp]
-                        for rt in m.DR_SPINNING_RESERVE_TYPES
-                    ) <= m.DemandResponseSlackUp[ba, tp]
+                rule=lambda m, ba, tp: sum(
+                    m.DemandResponseSpinningReserveUp[rt, ba, tp]
+                    for rt in m.DR_SPINNING_RESERVE_TYPES
+                )
+                <= m.DemandResponseSlackUp[ba, tp],
             )
             m.Limit_DemandResponseSpinningReserveDown = Constraint(
                 m.BALANCING_AREA_TIMEPOINTS,
-                rule=lambda m, ba, tp:
-                    sum(
-                        m.DemandResponseSpinningReserveDown[rt, ba, tp]
-                        for rt in m.DR_SPINNING_RESERVE_TYPES
-                    ) <= m.DemandResponseSlackDown[ba, tp]
+                rule=lambda m, ba, tp: sum(
+                    m.DemandResponseSpinningReserveDown[rt, ba, tp]
+                    for rt in m.DR_SPINNING_RESERVE_TYPES
+                )
+                <= m.DemandResponseSlackDown[ba, tp],
             )
-            m.Spinning_Reserve_Up_Provisions.append('DemandResponseSpinningReserveUp')
-            m.Spinning_Reserve_Down_Provisions.append('DemandResponseSpinningReserveDown')
+            m.Spinning_Reserve_Up_Provisions.append("DemandResponseSpinningReserveUp")
+            m.Spinning_Reserve_Down_Provisions.append(
+                "DemandResponseSpinningReserveDown"
+            )
         else:
             # using older formulation, only one type of spinning reserves, indexed by balancing area, timepoint
-            if m.options.demand_response_reserve_types != ['spinning']:
+            if m.options.demand_response_reserve_types != ["spinning"]:
                 raise ValueError(
                     'Unable to use reserve types other than "spinning" with simple spinning reserves module.'
                 )
-            m.Spinning_Reserve_Up_Provisions.append('DemandResponseSlackUp')
-            m.Spinning_Reserve_Down_Provisions.append('DemandResponseSlackDown')
+            m.Spinning_Reserve_Up_Provisions.append("DemandResponseSlackUp")
+            m.Spinning_Reserve_Down_Provisions.append("DemandResponseSlackDown")
 
 
 def write_batch_results(m):
@@ -1028,36 +1144,49 @@ def write_batch_results(m):
 
     util.append_table(m, output_file=output_file, values=lambda m: summary_values(m))
 
+
 def summary_headers(m):
     return (
         ("tag", "iteration", "total_cost")
-        +tuple('total_direct_costs_per_year_'+str(p) for p in m.PERIODS)
-        +tuple('DR_Welfare_Cost_'+str(p) for p in m.PERIODS)
-        +tuple(prod + ' payment ' + str(p) for prod in m.DR_PRODUCTS for p in m.PERIODS)
-        +tuple(prod + ' sold ' + str(p) for prod in m.DR_PRODUCTS for p in m.PERIODS)
+        + tuple("total_direct_costs_per_year_" + str(p) for p in m.PERIODS)
+        + tuple("DR_Welfare_Cost_" + str(p) for p in m.PERIODS)
+        + tuple(
+            prod + " payment " + str(p) for prod in m.DR_PRODUCTS for p in m.PERIODS
+        )
+        + tuple(prod + " sold " + str(p) for prod in m.DR_PRODUCTS for p in m.PERIODS)
     )
+
 
 def summary_values(m):
     demand_components = [
-        c for c in ('zone_demand_mw', 'ShiftDemand', 'ChargeEVs', 'FlexibleDemand') if hasattr(m, c)
+        c
+        for c in ("zone_demand_mw", "ShiftDemand", "ChargeEVs", "FlexibleDemand")
+        if hasattr(m, c)
     ]
     values = []
 
     # tag (configuration)
-    values.extend([
-        m.options.scenario_name,
-        m.iteration_number,
-        m.SystemCost  # total cost (all periods)
-    ])
+    values.extend(
+        [
+            m.options.scenario_name,
+            m.iteration_number,
+            m.SystemCost,  # total cost (all periods)
+        ]
+    )
 
     # direct costs (including "other")
     values.extend([total_direct_costs_per_year(m, p) for p in m.PERIODS])
 
     # DR_Welfare_Cost
-    values.extend([
-        sum(m.DR_Welfare_Cost[t] * m.tp_weight_in_year[t] for t in m.TPS_IN_PERIOD[p])
-        for p in m.PERIODS
-    ])
+    values.extend(
+        [
+            sum(
+                m.DR_Welfare_Cost[t] * m.tp_weight_in_year[t]
+                for t in m.TPS_IN_PERIOD[p]
+            )
+            for p in m.PERIODS
+        ]
+    )
 
     # payments by customers ([expected demand] * [price offered for that demand])
     # note: this uses the final MC to set the final price, rather than using the
@@ -1069,29 +1198,38 @@ def summary_values(m):
     # as the customer payment during iteration 0, since m.dr_price[last_bid, z, tp, prod]
     # may not be defined yet.
     last_bid = m.DR_BID_LIST.last()
-    values.extend([
-        sum(
-            # we assume customers pay final marginal cost, so we don't artificially
-            # electricity_demand(m, z, tp, prod) * m.dr_price[last_bid, z, tp, prod] * m.tp_weight_in_year[tp]
-            electricity_demand(m, z, tp, prod)
-            * electricity_marginal_cost(m, z, tp, prod)
-            * m.tp_weight_in_year[tp]
-            for z in m.LOAD_ZONES for tp in m.TPS_IN_PERIOD[p]
-        )
-        for prod in m.DR_PRODUCTS for p in m.PERIODS
-    ])
+    values.extend(
+        [
+            sum(
+                # we assume customers pay final marginal cost, so we don't artificially
+                # electricity_demand(m, z, tp, prod) * m.dr_price[last_bid, z, tp, prod] * m.tp_weight_in_year[tp]
+                electricity_demand(m, z, tp, prod)
+                * electricity_marginal_cost(m, z, tp, prod)
+                * m.tp_weight_in_year[tp]
+                for z in m.LOAD_ZONES
+                for tp in m.TPS_IN_PERIOD[p]
+            )
+            for prod in m.DR_PRODUCTS
+            for p in m.PERIODS
+        ]
+    )
     # import pdb; pdb.set_trace()
 
     # total quantities bought (or sold) by customers each year
-    values.extend([
-        sum(
-            electricity_demand(m, z, tp, prod) * m.tp_weight_in_year[tp]
-            for z in m.LOAD_ZONES for tp in m.TPS_IN_PERIOD[p]
-        )
-        for prod in m.DR_PRODUCTS for p in m.PERIODS
-    ])
+    values.extend(
+        [
+            sum(
+                electricity_demand(m, z, tp, prod) * m.tp_weight_in_year[tp]
+                for z in m.LOAD_ZONES
+                for tp in m.TPS_IN_PERIOD[p]
+            )
+            for prod in m.DR_PRODUCTS
+            for p in m.PERIODS
+        ]
+    )
 
     return values
+
 
 def get(component, idx, default):
     try:
@@ -1099,11 +1237,14 @@ def get(component, idx, default):
     except KeyError:
         return default
 
+
 def write_results(m, include_iter_num=True):
     outputs_dir = m.options.outputs_dir
     tag = filename_tag(m, include_iter_num)
 
-    avg_ts_scale = float(sum(m.ts_scale_to_year[ts] for ts in m.TIMESERIES))/len(m.TIMESERIES)
+    avg_ts_scale = float(sum(m.ts_scale_to_year[ts] for ts in m.TIMESERIES)) / len(
+        m.TIMESERIES
+    )
     last_bid = m.DR_BID_LIST.last()
 
     # get final prices that will be charged to customers (not necessarily
@@ -1118,10 +1259,12 @@ def write_results(m, include_iter_num=True):
         for prod in m.DR_PRODUCTS
     }
     final_quantities = {
-        (lz, tp, prod): value(sum(
-            m.DRBidWeight[b, lz, ts] * m.dr_bid[b, lz, tp, prod]
-            for b in m.DR_BID_LIST
-        ))
+        (lz, tp, prod): value(
+            sum(
+                m.DRBidWeight[b, lz, ts] * m.dr_bid[b, lz, tp, prod]
+                for b in m.DR_BID_LIST
+            )
+        )
         for lz in m.LOAD_ZONES
         for ts in m.TIMESERIES
         for tp in m.TPS_IN_TS[ts]
@@ -1156,56 +1299,62 @@ def write_results(m, include_iter_num=True):
     #     }
 
     util.write_table(
-        m, m.LOAD_ZONES, m.TIMEPOINTS,
+        m,
+        m.LOAD_ZONES,
+        m.TIMEPOINTS,
         output_file=os.path.join(outputs_dir, "energy_sources{t}.csv".format(t=tag)),
-        headings=
-            ("load_zone", "period", "timepoint_label")
-            +tuple(m.FUELS)
-            +tuple(m.NON_FUEL_ENERGY_SOURCES)
-            +tuple("curtail_"+s for s in m.NON_FUEL_ENERGY_SOURCES)
-            +tuple(m.Zone_Power_Injections)
-            +tuple(m.Zone_Power_Withdrawals)
-            +tuple("offered price "+prod for prod in m.DR_PRODUCTS)
-            +tuple("bid q "+prod for prod in m.DR_PRODUCTS)
-            +tuple("final mc "+prod for prod in m.DR_PRODUCTS)
-            +tuple("final price "+prod for prod in m.DR_PRODUCTS)
-            +tuple("final q "+prod for prod in m.DR_PRODUCTS)
-            +("peak_day", "base_load", "base_price"),
-        values=lambda m, z, t:
-            (z, m.tp_period[t], m.tp_timestamp[t])
-            +tuple(
-                sum(DispatchGenByFuel(m, p, t, f) for p in m.GENS_BY_FUEL[f])
-                for f in m.FUELS
+        headings=("load_zone", "period", "timepoint_label")
+        + tuple(m.FUELS)
+        + tuple(m.NON_FUEL_ENERGY_SOURCES)
+        + tuple("curtail_" + s for s in m.NON_FUEL_ENERGY_SOURCES)
+        + tuple(m.Zone_Power_Injections)
+        + tuple(m.Zone_Power_Withdrawals)
+        + tuple("offered price " + prod for prod in m.DR_PRODUCTS)
+        + tuple("bid q " + prod for prod in m.DR_PRODUCTS)
+        + tuple("final mc " + prod for prod in m.DR_PRODUCTS)
+        + tuple("final price " + prod for prod in m.DR_PRODUCTS)
+        + tuple("final q " + prod for prod in m.DR_PRODUCTS)
+        + ("peak_day", "base_load", "base_price"),
+        values=lambda m, z, t: (z, m.tp_period[t], m.tp_timestamp[t])
+        + tuple(
+            sum(DispatchGenByFuel(m, p, t, f) for p in m.GENS_BY_FUEL[f])
+            for f in m.FUELS
+        )
+        + tuple(
+            sum(
+                get(m.DispatchGen, (p, t), 0.0)
+                for p in m.GENS_BY_NON_FUEL_ENERGY_SOURCE[s]
             )
-            +tuple(
-                sum(get(m.DispatchGen, (p, t), 0.0) for p in m.GENS_BY_NON_FUEL_ENERGY_SOURCE[s])
-                for s in m.NON_FUEL_ENERGY_SOURCES
+            for s in m.NON_FUEL_ENERGY_SOURCES
+        )
+        + tuple(
+            sum(
+                get(m.DispatchUpperLimit, (p, t), 0.0) - get(m.DispatchGen, (p, t), 0.0)
+                for p in m.GENS_BY_NON_FUEL_ENERGY_SOURCE[s]
             )
-            +tuple(
-                sum(
-                    get(m.DispatchUpperLimit, (p, t), 0.0) - get(m.DispatchGen, (p, t), 0.0)
-                    for p in m.GENS_BY_NON_FUEL_ENERGY_SOURCE[s]
-                )
-                for s in m.NON_FUEL_ENERGY_SOURCES
-            )
-            +tuple(getattr(m, component)[z, t] for component in m.Zone_Power_Injections)
-            +tuple(getattr(m, component)[z, t] for component in m.Zone_Power_Withdrawals)
-            +tuple(m.dr_price[last_bid, z, t, prod] for prod in m.DR_PRODUCTS)
-            +tuple(m.dr_bid[last_bid, z, t, prod] for prod in m.DR_PRODUCTS)
-            +tuple(electricity_marginal_cost(m, z, t, prod) for prod in m.DR_PRODUCTS)
-            +tuple(final_prices[z, t, prod] for prod in m.DR_PRODUCTS)
-            +tuple(final_quantities[z, t, prod] for prod in m.DR_PRODUCTS)
-            +(
-                'peak' if m.ts_scale_to_year[m.tp_ts[t]] < 0.5*avg_ts_scale else 'typical',
-                m.base_data_dict[z, t][0],
-                m.base_data_dict[z, t][1],
-            )
+            for s in m.NON_FUEL_ENERGY_SOURCES
+        )
+        + tuple(getattr(m, component)[z, t] for component in m.Zone_Power_Injections)
+        + tuple(getattr(m, component)[z, t] for component in m.Zone_Power_Withdrawals)
+        + tuple(m.dr_price[last_bid, z, t, prod] for prod in m.DR_PRODUCTS)
+        + tuple(m.dr_bid[last_bid, z, t, prod] for prod in m.DR_PRODUCTS)
+        + tuple(electricity_marginal_cost(m, z, t, prod) for prod in m.DR_PRODUCTS)
+        + tuple(final_prices[z, t, prod] for prod in m.DR_PRODUCTS)
+        + tuple(final_quantities[z, t, prod] for prod in m.DR_PRODUCTS)
+        + (
+            "peak"
+            if m.ts_scale_to_year[m.tp_ts[t]] < 0.5 * avg_ts_scale
+            else "typical",
+            m.base_data_dict[z, t][0],
+            m.base_data_dict[z, t][1],
+        ),
     )
 
     # import pprint
     # b=[(g, pe, value(m.BuildGen[g, pe]), m.gen_tech[g], m.gen_overnight_cost[g, pe]) for (g, pe) in m.BuildGen if value(m.BuildGen[g, pe]) > 0]
     # bt=set(x[3] for x in b) # technologies
     # pprint([(t, sum(x[2] for x in b if x[3]==t), sum(x[4] for x in b if x[3]==t)/sum(1.0 for x in b if x[3]==t)) for t in bt])
+
 
 def write_dual_costs(m, include_iter_num=True):
     outputs_dir = m.options.outputs_dir
@@ -1227,9 +1376,9 @@ def write_dual_costs(m, include_iter_num=True):
     outfile = os.path.join(outputs_dir, "dual_costs{t}.csv".format(t=tag))
     dual_data = []
     start_time = time.time()
-    print("Writing {} ... ".format(outfile), end=' ')
+    print("Writing {} ... ".format(outfile), end=" ")
 
-    def add_dual(const, lbound, ubound, duals, prefix='', offset=0.0):
+    def add_dual(const, lbound, ubound, duals, prefix="", offset=0.0):
         if const in duals:
             dual = duals[const]
             if dual >= 0.0:
@@ -1241,12 +1390,23 @@ def write_dual_costs(m, include_iter_num=True):
             if bound is None:
                 # Variable is unbounded; dual should be 0.0 or possibly a tiny non-zero value.
                 if not (-1e-5 < dual < 1e-5):
-                    raise ValueError("{} has no {} bound but has a non-zero dual value {}.".format(
-                        const.name, "lower" if dual > 0 else "upper", dual))
+                    raise ValueError(
+                        "{} has no {} bound but has a non-zero dual value {}.".format(
+                            const.name, "lower" if dual > 0 else "upper", dual
+                        )
+                    )
             else:
                 total_cost = dual * (bound + offset)
                 if total_cost != 0.0:
-                    dual_data.append((prefix+const.name, direction, (bound+offset), dual, total_cost))
+                    dual_data.append(
+                        (
+                            prefix + const.name,
+                            direction,
+                            (bound + offset),
+                            dual,
+                            total_cost,
+                        )
+                    )
 
     for comp in m.component_objects(ctype=Var):
         for idx in comp:
@@ -1254,7 +1414,7 @@ def write_dual_costs(m, include_iter_num=True):
             if var.value is not None:  # ignore vars that weren't used in the model
                 if var.is_integer() or var.is_binary():
                     # integrality constraint sets upper and lower bounds
-                    add_dual(var, value(var), value(var), m.rc, prefix='integer: ')
+                    add_dual(var, value(var), value(var), m.rc, prefix="integer: ")
                 else:
                     add_dual(var, var.lb, var.ub, m.rc)
     for comp in m.component_objects(ctype=Constraint):
@@ -1268,14 +1428,23 @@ def write_dual_costs(m, include_iter_num=True):
                 standard_constraint = generate_standard_repn(constr.body)
                 if standard_constraint.constant is not None:
                     offset = -standard_constraint.constant
-                add_dual(constr, value(constr.lower), value(constr.upper), m.dual, offset=offset)
+                add_dual(
+                    constr,
+                    value(constr.lower),
+                    value(constr.upper),
+                    m.dual,
+                    offset=offset,
+                )
 
-    dual_data.sort(key=lambda r: (not r[0].startswith('DR_Convex_'), r[3] >= 0)+r)
+    dual_data.sort(key=lambda r: (not r[0].startswith("DR_Convex_"), r[3] >= 0) + r)
 
-    with open(outfile, 'w') as f:
-        f.write(','.join(['constraint', 'direction', 'bound', 'dual', 'total_cost']) + '\n')
-        f.writelines(','.join(map(str, r)) + '\n' for r in dual_data)
-    print("time taken: {dur:.2f}s".format(dur=time.time()-start_time))
+    with open(outfile, "w") as f:
+        f.write(
+            ",".join(["constraint", "direction", "bound", "dual", "total_cost"]) + "\n"
+        )
+        f.writelines(",".join(map(str, r)) + "\n" for r in dual_data)
+    print("time taken: {dur:.2f}s".format(dur=time.time() - start_time))
+
 
 def filename_tag(m, include_iter_num=True):
     if m.options.scenario_name:
@@ -1287,6 +1456,7 @@ def filename_tag(m, include_iter_num=True):
     if t:
         t = "_" + t
     return t
+
 
 def post_solve(m, outputs_dir):
     # report final results, possibly after smoothing,

--- a/switch_model/balancing/demand_response/iterative/constant_elasticity_demand_system.py
+++ b/switch_model/balancing/demand_response/iterative/constant_elasticity_demand_system.py
@@ -1,4 +1,6 @@
 from __future__ import division
+
+
 def calibrate(base_data, dr_elasticity_scenario=3):
     """Accept a list of tuples showing [base hourly loads], and [base hourly prices] for each
     location (load_zone) and date (time_series). Store these for later reference by bid().
@@ -20,6 +22,7 @@ def calibrate(base_data, dr_elasticity_scenario=3):
     }
     elasticity_scenario = dr_elasticity_scenario
 
+
 def bid(load_zone, time_series, prices):
     """Accept a vector of current prices, for a particular location (load_zone) and day (time_series).
     Return a tuple showing hourly load levels and willingness to pay for those loads (relative to the
@@ -30,7 +33,7 @@ def bid(load_zone, time_series, prices):
     in total volume, but schedules itself to the cheapest hours (this part is called "shiftable load")."""
 
     elasticity = 0.1
-    shiftable_share = 0.1 * elasticity_scenario # 1-3
+    shiftable_share = 0.1 * elasticity_scenario  # 1-3
 
     # convert prices to a numpy vector, and make non-zero
     # to avoid errors when raising to a negative power
@@ -40,10 +43,9 @@ def bid(load_zone, time_series, prices):
     bl = base_load_dict[load_zone, time_series]
     bp = base_price_dict[load_zone, time_series]
 
-
     # spread shiftable load among all minimum-cost hours,
     # shaped like the original load during those hours (so base prices result in base loads)
-    mins = (p == np.min(p))
+    mins = p == np.min(p)
     shiftable_load = np.zeros(len(p))
     shiftable_load[mins] = bl[mins] * shiftable_share * np.sum(bl) / sum(bl[mins])
 
@@ -52,12 +54,14 @@ def bid(load_zone, time_series, prices):
     shiftable_load_wtp = 0
 
     elastic_base_load = (1.0 - shiftable_share) * bl
-    elastic_load =  elastic_base_load * (p/bp) ** (-elasticity)
+    elastic_load = elastic_base_load * (p / bp) ** (-elasticity)
     # _relative_ consumer surplus for the elastic load is the integral
     # of the load (quantity) function from p to bp; note: the hours are independent.
     # if p < bp, consumer surplus decreases as we move from p to bp, so cs_p - cs_p0
     # (given by this integral) is positive.
-    elastic_load_cs_diff = np.sum((1 - (p/bp)**(1-elasticity)) * bp * elastic_base_load / (1-elasticity))
+    elastic_load_cs_diff = np.sum(
+        (1 - (p / bp) ** (1 - elasticity)) * bp * elastic_base_load / (1 - elasticity)
+    )
     # _relative_ amount actually paid for elastic load under current price, vs base price
     base_elastic_load_paid = np.sum(bp * elastic_base_load)
     elastic_load_paid = np.sum(p * elastic_load)

--- a/switch_model/balancing/demand_response/iterative/r_demand_system.py
+++ b/switch_model/balancing/demand_response/iterative/r_demand_system.py
@@ -11,13 +11,22 @@ returned by the python calibrate() function and attached to the model.
 """
 from __future__ import print_function
 
+
 def define_arguments(argparser):
-    argparser.add_argument("--dr-elasticity-scenario", type=int, default=3,
-        help="Choose a scenario of customer elasticity to be used by R script")
-    argparser.add_argument("--dr-r-script", default=None,
+    argparser.add_argument(
+        "--dr-elasticity-scenario",
+        type=int,
+        default=3,
+        help="Choose a scenario of customer elasticity to be used by R script",
+    )
+    argparser.add_argument(
+        "--dr-r-script",
+        default=None,
         help="Name of R script to use for preparing demand response bids. "
         "Only takes effect when using --dr-demand-module=r_demand_system. "
-        "This script should provide calibrate() and bid() functions. ")
+        "This script should provide calibrate() and bid() functions. ",
+    )
+
 
 def define_components(m):
     # load modules for use later (import is delayed to avoid interfering with unit tests)
@@ -25,20 +34,24 @@ def define_components(m):
         global np
         import numpy as np
     except ImportError:
-        print("="*80)
-        print("Unable to load numpy package, which is used by the r_demand_system module.")
+        print("=" * 80)
+        print(
+            "Unable to load numpy package, which is used by the r_demand_system module."
+        )
         print("Please install this via 'conda install numpy' or 'pip install numpy'.")
-        print("="*80)
+        print("=" * 80)
         raise
     try:
         global rpy2  # not actually needed outside this function
         import rpy2.robjects
         import rpy2.robjects.numpy2ri
     except ImportError:
-        print("="*80)
-        print("Unable to load rpy2 package, which is used by the r_demand_system module.")
+        print("=" * 80)
+        print(
+            "Unable to load rpy2 package, which is used by the r_demand_system module."
+        )
         print("Please install this via 'conda install rpy2' or 'pip install rpy2'.")
-        print("="*80)
+        print("=" * 80)
         raise
     # initialize the R environment
     global r
@@ -61,6 +74,7 @@ def define_components(m):
         )
     r.source(m.options.dr_r_script)
 
+
 def calibrate(m, base_data):
     """Accept a list of tuples showing load_zone, time_series, [base hourly loads], [base hourly prices]
     for each load_zone and time_series (day). Perform any calibration needed in the demand system
@@ -68,21 +82,23 @@ def calibrate(m, base_data):
     Also accept an allocation among different elasticity classes (defined in the R module.)
     """
     base_load_dict = {
-        (z, ts): base_loads
-        for (z, ts, base_loads, base_prices) in base_data
+        (z, ts): base_loads for (z, ts, base_loads, base_prices) in base_data
     }
     base_price_dict = {
-        (z, ts): base_prices
-        for (z, ts, base_loads, base_prices) in base_data
+        (z, ts): base_prices for (z, ts, base_loads, base_prices) in base_data
     }
     load_zones = unique_list(z for (z, ts, base_loads, base_prices) in base_data)
     time_series = unique_list(ts for (z, ts, base_loads, base_prices) in base_data)
     # maybe this should use the hour of day from the model, but this is good enough for now
-    hours_of_day = list(range(1, 1+len(base_data[0][2])))
+    hours_of_day = list(range(1, 1 + len(base_data[0][2])))
 
     # create r arrays of base loads and prices, with indices = (hour of day, time series, load zone)
-    base_loads = make_r_value_array(base_load_dict, hours_of_day, time_series, load_zones)
-    base_prices = make_r_value_array(base_price_dict, hours_of_day, time_series, load_zones)
+    base_loads = make_r_value_array(
+        base_load_dict, hours_of_day, time_series, load_zones
+    )
+    base_prices = make_r_value_array(
+        base_price_dict, hours_of_day, time_series, load_zones
+    )
 
     # calibrate the demand system within R
     r.calibrate(base_loads, base_prices, m.options.dr_elasticity_scenario)
@@ -93,18 +109,19 @@ def bid(m, load_zone, timeseries, prices):
     Return a tuple showing hourly load levels and willingness to pay for those loads."""
 
     bid = r.bid(
-        str(load_zone), str(timeseries),
-        np.array(prices['energy']),
-        np.array(prices['energy up']),
-        np.array(prices['energy down']),
-        m.options.dr_elasticity_scenario
+        str(load_zone),
+        str(timeseries),
+        np.array(prices["energy"]),
+        np.array(prices["energy up"]),
+        np.array(prices["energy down"]),
+        m.options.dr_elasticity_scenario,
     )
     demand = {
-        'energy': list(bid[0]),
-        'energy up': list(bid[1]),
-        'energy down': list(bid[2]),
+        "energy": list(bid[0]),
+        "energy up": list(bid[1]),
+        "energy down": list(bid[2]),
     }
-    wtp = bid[3][0] # everything is a vector in R, so we have to take the first element
+    wtp = bid[3][0]  # everything is a vector in R, so we have to take the first element
 
     return (demand, wtp)
 
@@ -112,7 +129,7 @@ def bid(m, load_zone, timeseries, prices):
 def test_calib():
     """Test calibration routines with sample data. Results should match r.test_calib()."""
     base_data = [
-        ("oahu", 100, [ 500, 1000, 1500], [0.35, 0.35, 0.35]),
+        ("oahu", 100, [500, 1000, 1500], [0.35, 0.35, 0.35]),
         ("oahu", 200, [2000, 2500, 3000], [0.35, 0.35, 0.35]),
         ("maui", 100, [3500, 4000, 4500], [0.35, 0.35, 0.35]),
         ("maui", 200, [5000, 5500, 6000], [0.35, 0.35, 0.35]),
@@ -126,11 +143,12 @@ def unique_list(seq):
     seen = set()
     return [x for x in seq if not (x in seen or seen.add(x))]
 
+
 def make_r_value_array(base_value_dict, hours_of_day, time_series, load_zones):
     # create a numpy array with indices = (hour of day, time series, load zone)
     arr = np.array(
-        [ [base_value_dict[(z, ts)] for ts in time_series] for z in load_zones],
-        dtype=float
+        [[base_value_dict[(z, ts)] for ts in time_series] for z in load_zones],
+        dtype=float,
     ).transpose()
     # convert to an r array with dimnames, using R's standard array function
     # (it might be slightly neater to use rinterface to build r_array entirely
@@ -143,7 +161,7 @@ def make_r_value_array(base_value_dict, hours_of_day, time_series, load_zones):
         dimnames=r.list(
             np.array(hours_of_day, dtype=str),
             np.array(time_series, dtype=str),
-            np.array(load_zones, dtype=str)
-        )
+            np.array(load_zones, dtype=str),
+        ),
     )
     return r_array

--- a/switch_model/balancing/demand_response/simple.py
+++ b/switch_model/balancing/demand_response/simple.py
@@ -13,8 +13,8 @@ nor a Shimmy Service (fast dispatch for load following or regulation).
 import os
 from pyomo.environ import *
 
-dependencies = 'switch_model.timescales', 'switch_model.balancing.load_zones'
-optional_dependencies = 'switch_model.transmission.local_td'
+dependencies = "switch_model.timescales", "switch_model.balancing.load_zones"
+optional_dependencies = "switch_model.transmission.local_td"
 
 
 def define_components(mod):
@@ -49,32 +49,35 @@ def define_components(mod):
     """
 
     mod.dr_shift_down_limit = Param(
-        mod.LOAD_ZONES, mod.TIMEPOINTS,
-        default= 0.0,
+        mod.LOAD_ZONES,
+        mod.TIMEPOINTS,
+        default=0.0,
         within=NonNegativeReals,
-        validate=lambda m, value, z, t: value <= m.zone_demand_mw[z, t])
+        validate=lambda m, value, z, t: value <= m.zone_demand_mw[z, t],
+    )
     mod.dr_shift_up_limit = Param(
-        mod.LOAD_ZONES, mod.TIMEPOINTS,
-        default= float('inf'),
-        within=NonNegativeReals)
+        mod.LOAD_ZONES, mod.TIMEPOINTS, default=float("inf"), within=NonNegativeReals
+    )
     mod.ShiftDemand = Var(
-        mod.LOAD_ZONES, mod.TIMEPOINTS,
+        mod.LOAD_ZONES,
+        mod.TIMEPOINTS,
         within=Reals,
-        bounds=lambda m, z, t:
-        (
-            (-1.0) * m.dr_shift_down_limit[z,t],
-            m.dr_shift_up_limit[z,t]
-        ))
+        bounds=lambda m, z, t: (
+            (-1.0) * m.dr_shift_down_limit[z, t],
+            m.dr_shift_up_limit[z, t],
+        ),
+    )
 
     mod.DR_Shift_Net_Zero = Constraint(
-        mod.LOAD_ZONES, mod.TIMESERIES,
-        rule=lambda m, z, ts:
-        sum(m.ShiftDemand[z, t] for t in m.TPS_IN_TS[ts]) == 0.0)
+        mod.LOAD_ZONES,
+        mod.TIMESERIES,
+        rule=lambda m, z, ts: sum(m.ShiftDemand[z, t] for t in m.TPS_IN_TS[ts]) == 0.0,
+    )
 
     try:
-        mod.Distributed_Power_Withdrawals.append('ShiftDemand')
+        mod.Distributed_Power_Withdrawals.append("ShiftDemand")
     except AttributeError:
-        mod.Zone_Power_Withdrawals.append('ShiftDemand')
+        mod.Zone_Power_Withdrawals.append("ShiftDemand")
 
 
 def load_inputs(mod, switch_data, inputs_dir):
@@ -89,5 +92,6 @@ def load_inputs(mod, switch_data, inputs_dir):
 
     switch_data.load_aug(
         optional=True,
-        filename=os.path.join(inputs_dir, 'dr_data.csv'),
-        param=(mod.dr_shift_down_limit, mod.dr_shift_up_limit))
+        filename=os.path.join(inputs_dir, "dr_data.csv"),
+        param=(mod.dr_shift_down_limit, mod.dr_shift_up_limit),
+    )

--- a/switch_model/balancing/load_zones.py
+++ b/switch_model/balancing/load_zones.py
@@ -8,8 +8,9 @@ import os
 from pyomo.environ import *
 from switch_model.reporting import write_table
 
-dependencies = 'switch_model.timescales'
-optional_dependencies = 'switch_model.transmission.local_td'
+dependencies = "switch_model.timescales"
+optional_dependencies = "switch_model.transmission.local_td"
+
 
 def define_dynamic_lists(mod):
     """
@@ -78,37 +79,38 @@ def define_components(mod):
     """
 
     mod.LOAD_ZONES = Set()
-    mod.ZONE_TIMEPOINTS = Set(dimen=2,
+    mod.ZONE_TIMEPOINTS = Set(
+        dimen=2,
         initialize=lambda m: m.LOAD_ZONES * m.TIMEPOINTS,
-        doc="The cross product of load zones and timepoints, used for indexing.")
-    mod.zone_demand_mw = Param(
-        mod.ZONE_TIMEPOINTS,
-        within=NonNegativeReals)
+        doc="The cross product of load zones and timepoints, used for indexing.",
+    )
+    mod.zone_demand_mw = Param(mod.ZONE_TIMEPOINTS, within=NonNegativeReals)
     mod.zone_ccs_distance_km = Param(
-        mod.LOAD_ZONES,
-        within=NonNegativeReals,
-        default=0.0)
-    mod.zone_dbid = Param(
-        mod.LOAD_ZONES,
-        default=lambda m, z: z)
-    mod.min_data_check('LOAD_ZONES', 'zone_demand_mw')
+        mod.LOAD_ZONES, within=NonNegativeReals, default=0.0
+    )
+    mod.zone_dbid = Param(mod.LOAD_ZONES, default=lambda m, z: z)
+    mod.min_data_check("LOAD_ZONES", "zone_demand_mw")
     try:
-        mod.Distributed_Power_Withdrawals.append('zone_demand_mw')
+        mod.Distributed_Power_Withdrawals.append("zone_demand_mw")
     except AttributeError:
-        mod.Zone_Power_Withdrawals.append('zone_demand_mw')
+        mod.Zone_Power_Withdrawals.append("zone_demand_mw")
 
     mod.EXTERNAL_COINCIDENT_PEAK_DEMAND_ZONE_PERIODS = Set(
-        dimen=2, within=mod.LOAD_ZONES * mod.PERIODS,
-        doc="Zone-Period combinations with zone_expected_coincident_peak_demand data.")
+        dimen=2,
+        within=mod.LOAD_ZONES * mod.PERIODS,
+        doc="Zone-Period combinations with zone_expected_coincident_peak_demand data.",
+    )
     mod.zone_expected_coincident_peak_demand = Param(
-        mod.EXTERNAL_COINCIDENT_PEAK_DEMAND_ZONE_PERIODS,
-        within=NonNegativeReals)
+        mod.EXTERNAL_COINCIDENT_PEAK_DEMAND_ZONE_PERIODS, within=NonNegativeReals
+    )
     mod.zone_total_demand_in_period_mwh = Param(
-        mod.LOAD_ZONES, mod.PERIODS,
+        mod.LOAD_ZONES,
+        mod.PERIODS,
         within=NonNegativeReals,
         initialize=lambda m, z, p: (
-            sum(m.zone_demand_mw[z, t] * m.tp_weight[t]
-                for t in m.TPS_IN_PERIOD[p])))
+            sum(m.zone_demand_mw[z, t] * m.tp_weight[t] for t in m.TPS_IN_PERIOD[p])
+        ),
+    )
 
 
 def define_dynamic_components(mod):
@@ -129,12 +131,12 @@ def define_dynamic_components(mod):
     mod.Zone_Energy_Balance = Constraint(
         mod.ZONE_TIMEPOINTS,
         rule=lambda m, z, t: (
-            sum(
-                getattr(m, component)[z, t]
-                for component in m.Zone_Power_Injections
-            ) == sum(
-                getattr(m, component)[z, t]
-                for component in m.Zone_Power_Withdrawals)))
+            sum(getattr(m, component)[z, t] for component in m.Zone_Power_Injections)
+            == sum(
+                getattr(m, component)[z, t] for component in m.Zone_Power_Withdrawals
+            )
+        ),
+    )
 
 
 def load_inputs(mod, switch_data, inputs_dir):
@@ -162,17 +164,19 @@ def load_inputs(mod, switch_data, inputs_dir):
     # column names, be indifferent to column order, and throw an error
     # message if some columns are not found.
     switch_data.load_aug(
-        filename=os.path.join(inputs_dir, 'load_zones.csv'),
+        filename=os.path.join(inputs_dir, "load_zones.csv"),
         index=mod.LOAD_ZONES,
-        param=(mod.zone_ccs_distance_km, mod.zone_dbid))
+        param=(mod.zone_ccs_distance_km, mod.zone_dbid),
+    )
     switch_data.load_aug(
-        filename=os.path.join(inputs_dir, 'loads.csv'),
-        param=(mod.zone_demand_mw))
+        filename=os.path.join(inputs_dir, "loads.csv"), param=(mod.zone_demand_mw)
+    )
     switch_data.load_aug(
         optional=True,
-        filename=os.path.join(inputs_dir, 'zone_coincident_peak_demand.csv'),
+        filename=os.path.join(inputs_dir, "zone_coincident_peak_demand.csv"),
         index=mod.EXTERNAL_COINCIDENT_PEAK_DEMAND_ZONE_PERIODS,
-        param=(mod.zone_expected_coincident_peak_demand))
+        param=(mod.zone_expected_coincident_peak_demand),
+    )
 
 
 def post_solve(instance, outdir):
@@ -186,13 +190,21 @@ def post_solve(instance, outdir):
 
     """
     write_table(
-        instance, instance.LOAD_ZONES, instance.TIMEPOINTS,
+        instance,
+        instance.LOAD_ZONES,
+        instance.TIMEPOINTS,
         output_file=os.path.join(outdir, "load_balance.csv"),
-        headings=("load_zone", "timestamp",) + tuple(
-            instance.Zone_Power_Injections +
-            instance.Zone_Power_Withdrawals),
-        values=lambda m, z, t: (z, m.tp_timestamp[t],) + tuple(
+        headings=(
+            "load_zone",
+            "timestamp",
+        )
+        + tuple(instance.Zone_Power_Injections + instance.Zone_Power_Withdrawals),
+        values=lambda m, z, t: (
+            z,
+            m.tp_timestamp[t],
+        )
+        + tuple(
             getattr(m, component)[z, t]
-            for component in (
-                m.Zone_Power_Injections +
-                m.Zone_Power_Withdrawals)))
+            for component in (m.Zone_Power_Injections + m.Zone_Power_Withdrawals)
+        ),
+    )

--- a/switch_model/balancing/operating_reserves/areas.py
+++ b/switch_model/balancing/operating_reserves/areas.py
@@ -7,7 +7,8 @@ Defines balancing areas for operational reserves.
 import os
 from pyomo.environ import *
 
-dependencies = 'switch_model.timescales', 'switch_model.balancing.load_zones'
+dependencies = "switch_model.timescales", "switch_model.balancing.load_zones"
+
 
 def define_components(mod):
     """
@@ -30,15 +31,19 @@ def define_components(mod):
 
     """
 
-    mod.zone_balancing_area = Param(mod.LOAD_ZONES, default='system_wide_balancing_area')
-    mod.BALANCING_AREAS = Set(initialize=lambda m: set(
-        m.zone_balancing_area[z] for z in m.LOAD_ZONES))
+    mod.zone_balancing_area = Param(
+        mod.LOAD_ZONES, default="system_wide_balancing_area"
+    )
+    mod.BALANCING_AREAS = Set(
+        initialize=lambda m: set(m.zone_balancing_area[z] for z in m.LOAD_ZONES)
+    )
     mod.ZONES_IN_BALANCING_AREA = Set(
         mod.BALANCING_AREAS,
         initialize=lambda m, b: (
-            z for z in m.LOAD_ZONES if m.zone_balancing_area[z] == b))
-    mod.BALANCING_AREA_TIMEPOINTS = Set(
-        initialize=mod.BALANCING_AREAS * mod.TIMEPOINTS)
+            z for z in m.LOAD_ZONES if m.zone_balancing_area[z] == b
+        ),
+    )
+    mod.BALANCING_AREA_TIMEPOINTS = Set(initialize=mod.BALANCING_AREAS * mod.TIMEPOINTS)
 
 
 def load_inputs(mod, switch_data, inputs_dir):
@@ -54,5 +59,6 @@ def load_inputs(mod, switch_data, inputs_dir):
     # column names, be indifferent to column order, and throw an error
     # message if some columns are not found.
     switch_data.load_aug(
-        filename=os.path.join(inputs_dir, 'load_zones.csv'),
-        param=(mod.zone_balancing_area))
+        filename=os.path.join(inputs_dir, "load_zones.csv"),
+        param=(mod.zone_balancing_area),
+    )

--- a/switch_model/balancing/operating_reserves/spinning_reserves.py
+++ b/switch_model/balancing/operating_reserves/spinning_reserves.py
@@ -90,43 +90,55 @@ import os
 from pyomo.environ import *
 
 dependencies = (
-    'switch_model.timescales',
-    'switch_model.balancing.load_zones',
-    'switch_model.balancing.operating_reserves.areas',
-    'switch_model.financials',
-    'switch_model.energy_sources.properties',
-    'switch_model.generators.core.build',
-    'switch_model.generators.core.dispatch',
-    'switch_model.generators.core.commit.operate',
+    "switch_model.timescales",
+    "switch_model.balancing.load_zones",
+    "switch_model.balancing.operating_reserves.areas",
+    "switch_model.financials",
+    "switch_model.energy_sources.properties",
+    "switch_model.generators.core.build",
+    "switch_model.generators.core.dispatch",
+    "switch_model.generators.core.commit.operate",
 )
 
 
 def define_arguments(argparser):
     group = argparser.add_argument_group(__name__)
-    group.add_argument('--unit-contingency', default=False,
-        dest='unit_contingency', action='store_true',
-        help=("This will enable an n-1 contingency based on a single unit of "
-              "a generation project falling offline. Note: This create a new "
-              "binary variable for each project and timepoint that has a "
-              "proj_unit_size specified.")
+    group.add_argument(
+        "--unit-contingency",
+        default=False,
+        dest="unit_contingency",
+        action="store_true",
+        help=(
+            "This will enable an n-1 contingency based on a single unit of "
+            "a generation project falling offline. Note: This create a new "
+            "binary variable for each project and timepoint that has a "
+            "proj_unit_size specified."
+        ),
     )
-    group.add_argument('--project-contingency', default=False,
-        dest='project_contingency', action='store_true',
-        help=("This will enable an n-1 contingency based on the entire "
-              "committed capacity of a generation project falling offline. "
-              "Unlike unit contingencies, this is a purely linear expression.")
+    group.add_argument(
+        "--project-contingency",
+        default=False,
+        dest="project_contingency",
+        action="store_true",
+        help=(
+            "This will enable an n-1 contingency based on the entire "
+            "committed capacity of a generation project falling offline. "
+            "Unlike unit contingencies, this is a purely linear expression."
+        ),
     )
-    group.add_argument('--spinning-requirement-rule', default=None,
-        dest='spinning_requirement_rule',
-        choices = ["Hawaii", "3+5"],
-        help=("Choose rules for spinning reserves requirements as a function "
-              "of variable renewable power and load. Hawaii uses rules "
-              "bootstrapped from the GE RPS study, and '3+5' requires 3%% of "
-              "load and 5%% of variable renewable output, based on the heuristic "
-              "described in the 2010 Western Wind and Solar Integration Study.")
+    group.add_argument(
+        "--spinning-requirement-rule",
+        default=None,
+        dest="spinning_requirement_rule",
+        choices=["Hawaii", "3+5"],
+        help=(
+            "Choose rules for spinning reserves requirements as a function "
+            "of variable renewable power and load. Hawaii uses rules "
+            "bootstrapped from the GE RPS study, and '3+5' requires 3%% of "
+            "load and 5%% of variable renewable output, based on the heuristic "
+            "described in the 2010 Western Wind and Solar Integration Study."
+        ),
     )
-
-
 
 
 def define_dynamic_lists(m):
@@ -189,37 +201,44 @@ def gen_unit_contingency(m):
     # justify the duplication because I don't think discrete unit commitment
     # should be a prerequisite for this functionality.
     m.UNIT_CONTINGENCY_DISPATCH_POINTS = Set(
-        initialize=m.GEN_TPS,
-        filter=lambda m, g, tp: g in m.DISCRETELY_SIZED_GENS
+        initialize=m.GEN_TPS, filter=lambda m, g, tp: g in m.DISCRETELY_SIZED_GENS
     )
     m.GenIsCommitted = Var(
         m.UNIT_CONTINGENCY_DISPATCH_POINTS,
         within=Binary,
-        doc="Stores the status of unit committment as a binary variable."
+        doc="Stores the status of unit committment as a binary variable.",
     )
     m.Enforce_GenIsCommitted = Constraint(
         m.UNIT_CONTINGENCY_DISPATCH_POINTS,
-        rule=lambda m, g, tp:
-            m.CommitGen[g, tp] <= m.GenIsCommitted[g, tp] * (
-                m._gen_max_cap_for_binary_constraints
-                if g not in m.CAPACITY_LIMITED_GENS
-                else m.gen_capacity_limit_mw[g]
-            )
+        rule=lambda m, g, tp: m.CommitGen[g, tp]
+        <= m.GenIsCommitted[g, tp]
+        * (
+            m._gen_max_cap_for_binary_constraints
+            if g not in m.CAPACITY_LIMITED_GENS
+            else m.gen_capacity_limit_mw[g]
+        ),
     )
     m.GenUnitLargestContingency = Var(
         m.BALANCING_AREA_TIMEPOINTS,
-        doc="Largest generating unit that could drop offline.")
+        doc="Largest generating unit that could drop offline.",
+    )
+
     def Enforce_GenUnitLargestContingency_rule(m, g, t):
         b = m.zone_balancing_area[m.gen_load_zone[g]]
-        return (m.GenUnitLargestContingency[b,t] >=
-                m.GenIsCommitted[g, t] * m.gen_unit_size[g])
+        return (
+            m.GenUnitLargestContingency[b, t]
+            >= m.GenIsCommitted[g, t] * m.gen_unit_size[g]
+        )
+
     m.Enforce_GenUnitLargestContingency = Constraint(
         m.UNIT_CONTINGENCY_DISPATCH_POINTS,
         rule=Enforce_GenUnitLargestContingency_rule,
-        doc=("Force GenUnitLargestContingency to be at least as big as the "
-             "maximum unit contingency.")
+        doc=(
+            "Force GenUnitLargestContingency to be at least as big as the "
+            "maximum unit contingency."
+        ),
     )
-    m.Spinning_Reserve_Contingencies.append('GenUnitLargestContingency')
+    m.Spinning_Reserve_Contingencies.append("GenUnitLargestContingency")
 
 
 def gen_project_contingency(m):
@@ -245,21 +264,28 @@ def gen_project_contingency(m):
     """
     m.GenProjectLargestContingency = Var(
         m.BALANCING_AREA_TIMEPOINTS,
-        doc="Largest generating project that could drop offline.")
+        doc="Largest generating project that could drop offline.",
+    )
+
     def Enforce_GenProjectLargestContingency_rule(m, g, t):
         b = m.zone_balancing_area[m.gen_load_zone[g]]
         if m.gen_can_provide_spinning_reserves[g]:
-            return m.GenProjectLargestContingency[b, t] >= \
-                m.DispatchGen[g, t] + m.CommitGenSpinningReservesUp[g, t]
+            return (
+                m.GenProjectLargestContingency[b, t]
+                >= m.DispatchGen[g, t] + m.CommitGenSpinningReservesUp[g, t]
+            )
         else:
             return m.GenProjectLargestContingency[b, t] >= m.DispatchGen[g, t]
+
     m.Enforce_GenProjectLargestContingency = Constraint(
         m.GEN_TPS,
         rule=Enforce_GenProjectLargestContingency_rule,
-        doc=("Force GenProjectLargestContingency to be at least as big as the "
-             "maximum generation project contingency.")
+        doc=(
+            "Force GenProjectLargestContingency to be at least as big as the "
+            "maximum generation project contingency."
+        ),
     )
-    m.Spinning_Reserve_Contingencies.append('GenProjectLargestContingency')
+    m.Spinning_Reserve_Contingencies.append("GenProjectLargestContingency")
 
 
 def hawaii_spinning_reserve_requirements(m):
@@ -273,21 +299,26 @@ def hawaii_spinning_reserve_requirements(m):
     # fit_renewable_reserves.ipynb )
     # TODO: supply these parameters in input files
     m.var_gen_power_reserve = Param(
-        m.VARIABLE_GENS, default=1.0,
-        doc=("Spinning reserves required to back up variable renewable "
-             "generators, as fraction of potential output.")
+        m.VARIABLE_GENS,
+        default=1.0,
+        doc=(
+            "Spinning reserves required to back up variable renewable "
+            "generators, as fraction of potential output."
+        ),
     )
+
     def var_gen_cap_reserve_limit_default(m, g):
-        if m.gen_energy_source[g] == 'Solar':
+        if m.gen_energy_source[g] == "Solar":
             return 0.21288916
-        elif m.gen_energy_source[g] == 'Wind':
+        elif m.gen_energy_source[g] == "Wind":
             return 0.21624407
         else:
             raise RuntimeError()
+
     m.var_gen_cap_reserve_limit = Param(
         m.VARIABLE_GENS,
         default=var_gen_cap_reserve_limit_default,
-        doc="Maximum spinning reserves required, as fraction of installed capacity"
+        doc="Maximum spinning reserves required, as fraction of installed capacity",
     )
     m.HawaiiVarGenUpSpinningReserveRequirement = Expression(
         m.BALANCING_AREA_TIMEPOINTS,
@@ -295,25 +326,33 @@ def hawaii_spinning_reserve_requirements(m):
             m.GenCapacityInTP[g, t]
             * min(
                 m.var_gen_power_reserve[g] * m.gen_max_capacity_factor[g, t],
-                m.var_gen_cap_reserve_limit[g]
+                m.var_gen_cap_reserve_limit[g],
             )
             for g in m.VARIABLE_GENS
-            if (g, t) in m.VARIABLE_GEN_TPS and b == m.zone_balancing_area[m.gen_load_zone[g]]),
-        doc="The spinning reserves for backing up variable generation with Hawaii rules."
+            if (g, t) in m.VARIABLE_GEN_TPS
+            and b == m.zone_balancing_area[m.gen_load_zone[g]]
+        ),
+        doc="The spinning reserves for backing up variable generation with Hawaii rules.",
     )
-    m.Spinning_Reserve_Up_Requirements.append('HawaiiVarGenUpSpinningReserveRequirement')
+    m.Spinning_Reserve_Up_Requirements.append(
+        "HawaiiVarGenUpSpinningReserveRequirement"
+    )
 
     def HawaiiLoadDownSpinningReserveRequirement_rule(m, b, t):
         try:
             load = m.WithdrawFromCentralGrid
         except AttributeError:
             load = m.lz_demand_mw
-        return 0.10 * sum(load[z, t] for z in m.LOAD_ZONES if b == m.zone_balancing_area[z])
+        return 0.10 * sum(
+            load[z, t] for z in m.LOAD_ZONES if b == m.zone_balancing_area[z]
+        )
+
     m.HawaiiLoadDownSpinningReserveRequirement = Expression(
-        m.BALANCING_AREA_TIMEPOINTS,
-        rule=HawaiiLoadDownSpinningReserveRequirement_rule
+        m.BALANCING_AREA_TIMEPOINTS, rule=HawaiiLoadDownSpinningReserveRequirement_rule
     )
-    m.Spinning_Reserve_Down_Requirements.append('HawaiiLoadDownSpinningReserveRequirement')
+    m.Spinning_Reserve_Down_Requirements.append(
+        "HawaiiLoadDownSpinningReserveRequirement"
+    )
 
 
 def nrel_3_5_spinning_reserve_requirements(m):
@@ -327,22 +366,28 @@ def nrel_3_5_spinning_reserve_requirements(m):
     be set to WithdrawFromCentralGrid. Otherwise load will be set to
     lz_demand_mw.
     """
+
     def NREL35VarGenSpinningReserveRequirement_rule(m, b, t):
         try:
             load = m.WithdrawFromCentralGrid
         except AttributeError:
             load = m.lz_demand_mw
-        return (0.03 * sum(load[z, t] for z in m.LOAD_ZONES
-                           if b == m.zone_balancing_area[z])
-              + 0.05 * sum(m.DispatchGen[g, t] for g in m.VARIABLE_GENS
-                           if (g, t) in m.VARIABLE_GEN_TPS and
-                              b == m.zone_balancing_area[m.gen_load_zone[g]]))
+        return 0.03 * sum(
+            load[z, t] for z in m.LOAD_ZONES if b == m.zone_balancing_area[z]
+        ) + 0.05 * sum(
+            m.DispatchGen[g, t]
+            for g in m.VARIABLE_GENS
+            if (g, t) in m.VARIABLE_GEN_TPS
+            and b == m.zone_balancing_area[m.gen_load_zone[g]]
+        )
+
     m.NREL35VarGenSpinningReserveRequirement = Expression(
-        m.BALANCING_AREA_TIMEPOINTS,
-        rule=NREL35VarGenSpinningReserveRequirement_rule
+        m.BALANCING_AREA_TIMEPOINTS, rule=NREL35VarGenSpinningReserveRequirement_rule
     )
-    m.Spinning_Reserve_Up_Requirements.append('NREL35VarGenSpinningReserveRequirement')
-    m.Spinning_Reserve_Down_Requirements.append('NREL35VarGenSpinningReserveRequirement')
+    m.Spinning_Reserve_Up_Requirements.append("NREL35VarGenSpinningReserveRequirement")
+    m.Spinning_Reserve_Down_Requirements.append(
+        "NREL35VarGenSpinningReserveRequirement"
+    )
 
 
 def define_components(m):
@@ -388,89 +433,90 @@ def define_components(m):
     project_contingency and spinning_requirement_rule, other components may be
     added by other functions which are documented above.
     """
-    m.contingency_safety_factor = Param(default=2.0,
-        doc=("The spinning reserve requiremet will be set to this value "
-             "times the maximum contingency. This defaults to 2 to ensure "
-             "that the largest generator cannot be providing contingency "
-             "reserves for itself."))
+    m.contingency_safety_factor = Param(
+        default=2.0,
+        doc=(
+            "The spinning reserve requiremet will be set to this value "
+            "times the maximum contingency. This defaults to 2 to ensure "
+            "that the largest generator cannot be providing contingency "
+            "reserves for itself."
+        ),
+    )
     m.gen_can_provide_spinning_reserves = Param(
         m.GENERATION_PROJECTS, within=Boolean, default=True
     )
     m.SPINNING_RESERVE_GEN_TPS = Set(
         dimen=2,
         initialize=m.GEN_TPS,
-        filter=lambda m, g, t: m.gen_can_provide_spinning_reserves[g])
+        filter=lambda m, g, t: m.gen_can_provide_spinning_reserves[g],
+    )
     m.CommitGenSpinningReservesUp = Var(
-        m.SPINNING_RESERVE_GEN_TPS,
-        within=NonNegativeReals
+        m.SPINNING_RESERVE_GEN_TPS, within=NonNegativeReals
     )
     m.CommitGenSpinningReservesDown = Var(
-        m.SPINNING_RESERVE_GEN_TPS,
-        within=NonNegativeReals
+        m.SPINNING_RESERVE_GEN_TPS, within=NonNegativeReals
     )
     m.CommitGenSpinningReservesSlackUp = Var(
         m.SPINNING_RESERVE_GEN_TPS,
         within=NonNegativeReals,
         doc="Denotes the upward slack in spinning reserves that could be used "
-            "for quickstart reserves, or possibly other reserve products."
+        "for quickstart reserves, or possibly other reserve products.",
     )
     m.CommitGenSpinningReservesUp_Limit = Constraint(
         m.SPINNING_RESERVE_GEN_TPS,
         rule=lambda m, g, t: (
-            m.CommitGenSpinningReservesUp[g,t] + 
-            m.CommitGenSpinningReservesSlackUp[g,t]
-            == m.DispatchSlackUp[g, t] + 
+            m.CommitGenSpinningReservesUp[g, t]
+            + m.CommitGenSpinningReservesSlackUp[g, t]
+            == m.DispatchSlackUp[g, t] +
             # storage can give more up response by stopping charging
-            (m.ChargeStorage[g, t] 
-                if g in getattr(m, 'STORAGE_GENS', []) 
-                else 0.0
-            )
-        )
+            (m.ChargeStorage[g, t] if g in getattr(m, "STORAGE_GENS", []) else 0.0)
+        ),
     )
     m.CommitGenSpinningReservesDown_Limit = Constraint(
         m.SPINNING_RESERVE_GEN_TPS,
-        rule=lambda m, g, t: \
-            m.CommitGenSpinningReservesDown[g,t] <= m.DispatchSlackDown[g, t] +
-            # storage could give more down response by raising ChargeStorage
-            # to the maximum rate
-            ( 
-                (m.DispatchUpperLimit[g, t] * m.gen_store_to_release_ratio[g] 
-                 - m.ChargeStorage[g, t]
-                )
-                if g in getattr(m, 'STORAGE_GENS', [])
-                else 0.0
+        rule=lambda m, g, t: m.CommitGenSpinningReservesDown[g, t]
+        <= m.DispatchSlackDown[g, t] +
+        # storage could give more down response by raising ChargeStorage
+        # to the maximum rate
+        (
+            (
+                m.DispatchUpperLimit[g, t] * m.gen_store_to_release_ratio[g]
+                - m.ChargeStorage[g, t]
             )
+            if g in getattr(m, "STORAGE_GENS", [])
+            else 0.0
+        ),
     )
 
     # Sum of spinning reserve capacity per balancing area and timepoint..
     m.CommittedSpinningReserveUp = Expression(
         m.BALANCING_AREA_TIMEPOINTS,
-        rule=lambda m, b, t: \
-            sum(m.CommitGenSpinningReservesUp[g, t]
-                for z in m.ZONES_IN_BALANCING_AREA[b]
-                for g in m.GENS_IN_ZONE[z]
-                if (g,t) in m.SPINNING_RESERVE_GEN_TPS
-            )
+        rule=lambda m, b, t: sum(
+            m.CommitGenSpinningReservesUp[g, t]
+            for z in m.ZONES_IN_BALANCING_AREA[b]
+            for g in m.GENS_IN_ZONE[z]
+            if (g, t) in m.SPINNING_RESERVE_GEN_TPS
+        ),
     )
-    m.Spinning_Reserve_Up_Provisions.append('CommittedSpinningReserveUp')
+    m.Spinning_Reserve_Up_Provisions.append("CommittedSpinningReserveUp")
     m.CommittedSpinningReserveDown = Expression(
         m.BALANCING_AREA_TIMEPOINTS,
-        rule=lambda m, b, t: \
-            sum(m.CommitGenSpinningReservesDown[g, t]
-                for z in m.ZONES_IN_BALANCING_AREA[b]
-                for g in m.GENS_IN_ZONE[z]
-                if (g,t) in m.SPINNING_RESERVE_GEN_TPS
-            )
+        rule=lambda m, b, t: sum(
+            m.CommitGenSpinningReservesDown[g, t]
+            for z in m.ZONES_IN_BALANCING_AREA[b]
+            for g in m.GENS_IN_ZONE[z]
+            if (g, t) in m.SPINNING_RESERVE_GEN_TPS
+        ),
     )
-    m.Spinning_Reserve_Down_Provisions.append('CommittedSpinningReserveDown')
-    
+    m.Spinning_Reserve_Down_Provisions.append("CommittedSpinningReserveDown")
+
     if m.options.unit_contingency:
         gen_unit_contingency(m)
     if m.options.project_contingency:
         gen_project_contingency(m)
-    if m.options.spinning_requirement_rule == 'Hawaii':
+    if m.options.spinning_requirement_rule == "Hawaii":
         hawaii_spinning_reserve_requirements(m)
-    elif m.options.spinning_requirement_rule == '3+5':
+    elif m.options.spinning_requirement_rule == "3+5":
         nrel_3_5_spinning_reserve_requirements(m)
 
 
@@ -500,41 +546,47 @@ def define_dynamic_components(m):
     """
     m.MaximumContingency = Var(
         m.BALANCING_AREA_TIMEPOINTS,
-        doc=("Maximum of the registered Spinning_Reserve_Contingencies, after "
-             "multiplying by contingency_safety_factor.")
+        doc=(
+            "Maximum of the registered Spinning_Reserve_Contingencies, after "
+            "multiplying by contingency_safety_factor."
+        ),
     )
     m.BALANCING_AREA_TIMEPOINT_CONTINGENCIES = Set(
         initialize=m.BALANCING_AREA_TIMEPOINTS * m.Spinning_Reserve_Contingencies,
-        doc=("The set of spinning reserve contingencies, copied from the "
-             "dynamic list Spinning_Reserve_Contingencies to simplify the "
-             "process of defining one constraint per contingency in the list.")
+        doc=(
+            "The set of spinning reserve contingencies, copied from the "
+            "dynamic list Spinning_Reserve_Contingencies to simplify the "
+            "process of defining one constraint per contingency in the list."
+        ),
     )
     m.Enforce_MaximumContingency = Constraint(
         m.BALANCING_AREA_TIMEPOINT_CONTINGENCIES,
-        rule=lambda m, b, t, contingency:
-            m.MaximumContingency[b, t] >= m.contingency_safety_factor * getattr(m, contingency)[b, t]
+        rule=lambda m, b, t, contingency: m.MaximumContingency[b, t]
+        >= m.contingency_safety_factor * getattr(m, contingency)[b, t],
     )
-    m.Spinning_Reserve_Up_Requirements.append('MaximumContingency')
+    m.Spinning_Reserve_Up_Requirements.append("MaximumContingency")
 
     m.Satisfy_Spinning_Reserve_Up_Requirement = Constraint(
         m.BALANCING_AREA_TIMEPOINTS,
-        rule=lambda m, b, t: \
-            sum(getattr(m, requirement)[b,t]
-                for requirement in m.Spinning_Reserve_Up_Requirements
-            ) <=
-            sum(getattr(m, provision)[b,t]
-                for provision in m.Spinning_Reserve_Up_Provisions
-            )
+        rule=lambda m, b, t: sum(
+            getattr(m, requirement)[b, t]
+            for requirement in m.Spinning_Reserve_Up_Requirements
+        )
+        <= sum(
+            getattr(m, provision)[b, t]
+            for provision in m.Spinning_Reserve_Up_Provisions
+        ),
     )
     m.Satisfy_Spinning_Reserve_Down_Requirement = Constraint(
         m.BALANCING_AREA_TIMEPOINTS,
-        rule=lambda m, b, t: \
-            sum(getattr(m, requirement)[b,t]
-                for requirement in m.Spinning_Reserve_Down_Requirements
-            ) <=
-            sum(getattr(m, provision)[b,t]
-                for provision in m.Spinning_Reserve_Down_Provisions
-            )
+        rule=lambda m, b, t: sum(
+            getattr(m, requirement)[b, t]
+            for requirement in m.Spinning_Reserve_Down_Requirements
+        )
+        <= sum(
+            getattr(m, provision)[b, t]
+            for provision in m.Spinning_Reserve_Down_Provisions
+        ),
     )
 
 
@@ -550,12 +602,12 @@ def load_inputs(m, switch_data, inputs_dir):
     header row and one data row.
     """
     switch_data.load_aug(
-        filename=os.path.join(inputs_dir, 'generation_projects_info.csv'),
-        optional_params=['gen_can_provide_spinning_reserves'],
-        param=(m.gen_can_provide_spinning_reserves)
+        filename=os.path.join(inputs_dir, "generation_projects_info.csv"),
+        optional_params=["gen_can_provide_spinning_reserves"],
+        param=(m.gen_can_provide_spinning_reserves),
     )
     switch_data.load_aug(
-        filename=os.path.join(inputs_dir, 'spinning_reserve_params.csv'),
+        filename=os.path.join(inputs_dir, "spinning_reserve_params.csv"),
         optional=True,
-        param=(m.contingency_safety_factor,)
+        param=(m.contingency_safety_factor,),
     )

--- a/switch_model/balancing/operating_reserves/spinning_reserves_advanced.py
+++ b/switch_model/balancing/operating_reserves/spinning_reserves_advanced.py
@@ -13,64 +13,80 @@ from switch_model.utilities import iteritems
 
 
 dependencies = (
-    'switch_model.timescales',
-    'switch_model.balancing.load_zones',
-    'switch_model.balancing.operating_reserves.areas',
-    'switch_model.financials',
-    'switch_model.energy_sources.properties',
-    'switch_model.generators.core.build',
-    'switch_model.generators.core.dispatch',
-    'switch_model.generators.core.commit.operate',
+    "switch_model.timescales",
+    "switch_model.balancing.load_zones",
+    "switch_model.balancing.operating_reserves.areas",
+    "switch_model.financials",
+    "switch_model.energy_sources.properties",
+    "switch_model.generators.core.build",
+    "switch_model.generators.core.dispatch",
+    "switch_model.generators.core.commit.operate",
 )
 
 
 def define_arguments(argparser):
     group = argparser.add_argument_group(__name__)
-    group.add_argument('--unit-contingency', default=False, action='store_true',
-        help=("This will enable an n-1 contingency based on a single unit of "
-              "a generation project falling offline. Note: This create a new "
-              "binary variable for each timepoint for each generation project "
-              "that has a gen_unit_size specified.")
+    group.add_argument(
+        "--unit-contingency",
+        default=False,
+        action="store_true",
+        help=(
+            "This will enable an n-1 contingency based on a single unit of "
+            "a generation project falling offline. Note: This create a new "
+            "binary variable for each timepoint for each generation project "
+            "that has a gen_unit_size specified."
+        ),
     )
-    group.add_argument('--project-contingency', default=False, action='store_true',
-        help=("This will enable an n-1 contingency based on the entire "
-              "committed capacity of a generation project falling offline. "
-              "Unlike unit contingencies, this is a purely linear expression.")
+    group.add_argument(
+        "--project-contingency",
+        default=False,
+        action="store_true",
+        help=(
+            "This will enable an n-1 contingency based on the entire "
+            "committed capacity of a generation project falling offline. "
+            "Unlike unit contingencies, this is a purely linear expression."
+        ),
     )
-    group.add_argument('--fixed-contingency', type=float, default=0.0,
-        help=("Add a fixed generator contingency reserve margin, specified in MW. "
-              "This can be used alone or in combination with the other "
-              "contingency options.")
+    group.add_argument(
+        "--fixed-contingency",
+        type=float,
+        default=0.0,
+        help=(
+            "Add a fixed generator contingency reserve margin, specified in MW. "
+            "This can be used alone or in combination with the other "
+            "contingency options."
+        ),
     )
-    group.add_argument('--spinning-requirement-rule', default=None,
-        choices = ["Hawaii", "3+5", "none"],
-        help=("Choose rules for spinning reserves requirements as a function "
-              "of variable renewable power and load. Hawaii uses rules "
-              "bootstrapped from the GE RPS study, and '3+5' requires 3%% of "
-              "load and 5%% of variable renewable output, based on the heuristic "
-              "described in the 2010 Western Wind and Solar Integration Study. "
-              "Specify 'none' if applying your own rules instead. "
-        )
+    group.add_argument(
+        "--spinning-requirement-rule",
+        default=None,
+        choices=["Hawaii", "3+5", "none"],
+        help=(
+            "Choose rules for spinning reserves requirements as a function "
+            "of variable renewable power and load. Hawaii uses rules "
+            "bootstrapped from the GE RPS study, and '3+5' requires 3%% of "
+            "load and 5%% of variable renewable output, based on the heuristic "
+            "described in the 2010 Western Wind and Solar Integration Study. "
+            "Specify 'none' if applying your own rules instead. "
+        ),
     )
     # TODO: define these inputs in data files
     group.add_argument(
-        '--contingency-reserve-type', dest='contingency_reserve_type',
-        default='spinning',
-        help=
-            "Type of reserves to use to meet the contingency reserve requirements "
-            "defined for generation projects and sometimes for loss-of-load events "
-            "(e.g., 'contingency' or 'spinning'); default is 'spinning'."
+        "--contingency-reserve-type",
+        dest="contingency_reserve_type",
+        default="spinning",
+        help="Type of reserves to use to meet the contingency reserve requirements "
+        "defined for generation projects and sometimes for loss-of-load events "
+        "(e.g., 'contingency' or 'spinning'); default is 'spinning'.",
     )
     group.add_argument(
-        '--regulating-reserve-type', dest='regulating_reserve_type',
-        default='spinning',
-        help=
-            "Type of reserves to use to meet the regulating reserve requirements "
-            "defined by the spinning requirements rule (e.g., 'spinning' or "
-            "'regulation'); default is 'spinning'."
+        "--regulating-reserve-type",
+        dest="regulating_reserve_type",
+        default="spinning",
+        help="Type of reserves to use to meet the regulating reserve requirements "
+        "defined by the spinning requirements rule (e.g., 'spinning' or "
+        "'regulation'); default is 'spinning'.",
     )
-
-
 
 
 def define_dynamic_lists(m):
@@ -122,10 +138,10 @@ def gen_fixed_contingency(m):
     that is usually online and/or reserves are cheap).
     """
     m.GenFixedContingency = Param(
-        m.BALANCING_AREA_TIMEPOINTS,
-        initialize=lambda m: m.options.fixed_contingency
+        m.BALANCING_AREA_TIMEPOINTS, initialize=lambda m: m.options.fixed_contingency
     )
-    m.Spinning_Reserve_Up_Contingencies.append('GenFixedContingency')
+    m.Spinning_Reserve_Up_Contingencies.append("GenFixedContingency")
+
 
 def gen_unit_contingency(m):
     """
@@ -163,40 +179,50 @@ def gen_unit_contingency(m):
     # should be a prerequisite for this functionality.
     m.UNIT_CONTINGENCY_DISPATCH_POINTS = Set(
         dimen=2,
-        initialize=lambda m:
-            [(g, t) for g in m.DISCRETELY_SIZED_GENS for t in m.TPS_FOR_GEN[g]]
+        initialize=lambda m: [
+            (g, t) for g in m.DISCRETELY_SIZED_GENS for t in m.TPS_FOR_GEN[g]
+        ],
     )
     m.GenIsCommitted = Var(
         m.UNIT_CONTINGENCY_DISPATCH_POINTS,
         within=Binary,
-        doc="Stores the status of unit committment as a binary variable."
+        doc="Stores the status of unit committment as a binary variable.",
     )
     m.Enforce_GenIsCommitted = Constraint(
         m.UNIT_CONTINGENCY_DISPATCH_POINTS,
-        rule=lambda m, g, tp:
-            m.CommitGen[g, tp] <= m.GenIsCommitted[g, tp] * (
-                m._gen_max_cap_for_binary_constraints
-                if g not in m.CAPACITY_LIMITED_GENS
-                else m.gen_capacity_limit_mw[g]
-            )
+        rule=lambda m, g, tp: m.CommitGen[g, tp]
+        <= m.GenIsCommitted[g, tp]
+        * (
+            m._gen_max_cap_for_binary_constraints
+            if g not in m.CAPACITY_LIMITED_GENS
+            else m.gen_capacity_limit_mw[g]
+        ),
     )
     # TODO: would it be faster to add all generator contingencies directly
     # to Spinning_Reserve_Contingencies instead of introducing this intermediate
     # variable and constraint?
     m.GenUnitLargestContingency = Var(
-        m.BALANCING_AREA_TIMEPOINTS, within=NonNegativeReals,
-        doc="Largest generating unit that could drop offline.")
+        m.BALANCING_AREA_TIMEPOINTS,
+        within=NonNegativeReals,
+        doc="Largest generating unit that could drop offline.",
+    )
+
     def Enforce_GenUnitLargestContingency_rule(m, g, t):
         b = m.zone_balancing_area[m.gen_load_zone[g]]
-        return (m.GenUnitLargestContingency[b,t] >=
-                m.GenIsCommitted[g, t] * m.gen_unit_size[g])
+        return (
+            m.GenUnitLargestContingency[b, t]
+            >= m.GenIsCommitted[g, t] * m.gen_unit_size[g]
+        )
+
     m.Enforce_GenUnitLargestContingency = Constraint(
         m.UNIT_CONTINGENCY_DISPATCH_POINTS,
         rule=Enforce_GenUnitLargestContingency_rule,
-        doc=("Force GenUnitLargestContingency to be at least as big as the "
-             "maximum unit contingency.")
+        doc=(
+            "Force GenUnitLargestContingency to be at least as big as the "
+            "maximum unit contingency."
+        ),
     )
-    m.Spinning_Reserve_Up_Contingencies.append('GenUnitLargestContingency')
+    m.Spinning_Reserve_Up_Contingencies.append("GenUnitLargestContingency")
 
 
 def gen_project_contingency(m):
@@ -222,24 +248,33 @@ def gen_project_contingency(m):
     """
     m.GenProjectLargestContingency = Var(
         m.BALANCING_AREA_TIMEPOINTS,
-        doc="Largest generating project that could drop offline.")
+        doc="Largest generating project that could drop offline.",
+    )
+
     def Enforce_GenProjectLargestContingency_rule(m, g, t):
         b = m.zone_balancing_area[m.gen_load_zone[g]]
         if g in m.SPINNING_RESERVE_CAPABLE_GENS:
             total_up_reserves = sum(
                 m.CommitGenSpinningReservesUp[rt, g, t]
-                for rt in m.SPINNING_RESERVE_TYPES_FOR_GEN[g])
-            return m.GenProjectLargestContingency[b, t] >= \
-                m.DispatchGen[g, t] + total_up_reserves
+                for rt in m.SPINNING_RESERVE_TYPES_FOR_GEN[g]
+            )
+            return (
+                m.GenProjectLargestContingency[b, t]
+                >= m.DispatchGen[g, t] + total_up_reserves
+            )
         else:
             return m.GenProjectLargestContingency[b, t] >= m.DispatchGen[g, t]
+
     m.Enforce_GenProjectLargestContingency = Constraint(
         m.GEN_TPS,
         rule=Enforce_GenProjectLargestContingency_rule,
-        doc=("Force GenProjectLargestContingency to be at least as big as the "
-             "maximum generation project contingency.")
+        doc=(
+            "Force GenProjectLargestContingency to be at least as big as the "
+            "maximum generation project contingency."
+        ),
     )
-    m.Spinning_Reserve_Up_Contingencies.append('GenProjectLargestContingency')
+    m.Spinning_Reserve_Up_Contingencies.append("GenProjectLargestContingency")
+
 
 def hawaii_spinning_reserve_requirements(m):
     # These parameters were found by regressing the reserve requirements from
@@ -255,23 +290,30 @@ def hawaii_spinning_reserve_requirements(m):
     # (could eventually use some linearized quadratic formulation based
     # on load, magnitude of renewables and geographic dispersion of renewables)
     m.var_gen_power_reserve = Param(
-        m.VARIABLE_GENS, default=1.0,
-        doc=("Spinning reserves required to back up variable renewable "
-             "generators, as fraction of potential output.")
+        m.VARIABLE_GENS,
+        default=1.0,
+        doc=(
+            "Spinning reserves required to back up variable renewable "
+            "generators, as fraction of potential output."
+        ),
     )
+
     def var_gen_cap_reserve_limit_default(m, g):
-        if m.gen_energy_source[g] == 'SUN':
+        if m.gen_energy_source[g] == "SUN":
             return 0.21288916
-        elif m.gen_energy_source[g] == 'WND':
+        elif m.gen_energy_source[g] == "WND":
             return 0.21624407
         else:
             raise ValueError(
-                "Unable to calculate reserve requirement for energy source {}".format(m.gen_energy_source[g])
+                "Unable to calculate reserve requirement for energy source {}".format(
+                    m.gen_energy_source[g]
+                )
             )
+
     m.var_gen_cap_reserve_limit = Param(
         m.VARIABLE_GENS,
         default=var_gen_cap_reserve_limit_default,
-        doc="Maximum spinning reserves required, as fraction of installed capacity"
+        doc="Maximum spinning reserves required, as fraction of installed capacity",
     )
     m.HawaiiVarGenUpSpinningReserveRequirement = Expression(
         [m.options.regulating_reserve_type],
@@ -280,17 +322,20 @@ def hawaii_spinning_reserve_requirements(m):
             m.GenCapacityInTP[g, t]
             * min(
                 m.var_gen_power_reserve[g] * m.gen_max_capacity_factor[g, t],
-                m.var_gen_cap_reserve_limit[g]
+                m.var_gen_cap_reserve_limit[g],
             )
             for z in m.ZONES_IN_BALANCING_AREA[b]
             for g in m.VARIABLE_GENS_IN_ZONE[z]
-            if (g, t) in m.VARIABLE_GEN_TPS),
-        doc="The spinning reserves for backing up variable generation with Hawaii rules."
+            if (g, t) in m.VARIABLE_GEN_TPS
+        ),
+        doc="The spinning reserves for backing up variable generation with Hawaii rules.",
     )
-    m.Spinning_Reserve_Up_Requirements.append('HawaiiVarGenUpSpinningReserveRequirement')
+    m.Spinning_Reserve_Up_Requirements.append(
+        "HawaiiVarGenUpSpinningReserveRequirement"
+    )
 
     # Calculate and register loss-of-load (down) contingencies
-    if hasattr(m, 'WithdrawFromCentralGrid'):
+    if hasattr(m, "WithdrawFromCentralGrid"):
         rule = lambda m, ba, tp: 0.10 * sum(
             m.WithdrawFromCentralGrid[z, tp] for z in m.ZONES_IN_BALANCING_AREA[ba]
         )
@@ -299,10 +344,8 @@ def hawaii_spinning_reserve_requirements(m):
         rule = lambda m, ba, tp: 0.10 * sum(
             m.zone_demand_mw[z, tp] for z in m.ZONES_IN_BALANCING_AREA[ba]
         )
-    m.HawaiiLoadDownContingency = Expression(
-        m.BALANCING_AREA_TIMEPOINTS, rule=rule
-    )
-    m.Spinning_Reserve_Down_Contingencies.append('HawaiiLoadDownContingency')
+    m.HawaiiLoadDownContingency = Expression(m.BALANCING_AREA_TIMEPOINTS, rule=rule)
+    m.Spinning_Reserve_Down_Contingencies.append("HawaiiLoadDownContingency")
 
 
 def nrel_3_5_spinning_reserve_requirements(m):
@@ -316,26 +359,30 @@ def nrel_3_5_spinning_reserve_requirements(m):
     be set to WithdrawFromCentralGrid. Otherwise load will be set to
     zone_demand_mw.
     """
+
     def NREL35VarGenSpinningReserveRequirement_rule(m, rt, b, t):
         try:
             load = m.WithdrawFromCentralGrid
         except AttributeError:
             load = m.zone_demand_mw
-        return (
-            0.03 * sum(load[z, t]
-                       for z in m.LOAD_ZONES
-                       if b == m.zone_balancing_area[z])
-            + 0.05 * sum(m.DispatchGen[g, t]
-                         for g in m.VARIABLE_GENS
-                         if (g, t) in m.VARIABLE_GEN_TPS and
-                            b == m.zone_balancing_area[m.gen_load_zone[g]]))
+        return 0.03 * sum(
+            load[z, t] for z in m.LOAD_ZONES if b == m.zone_balancing_area[z]
+        ) + 0.05 * sum(
+            m.DispatchGen[g, t]
+            for g in m.VARIABLE_GENS
+            if (g, t) in m.VARIABLE_GEN_TPS
+            and b == m.zone_balancing_area[m.gen_load_zone[g]]
+        )
+
     m.NREL35VarGenSpinningReserveRequirement = Expression(
         [m.options.regulating_reserve_type],
         m.BALANCING_AREA_TIMEPOINTS,
-        rule=NREL35VarGenSpinningReserveRequirement_rule
+        rule=NREL35VarGenSpinningReserveRequirement_rule,
     )
-    m.Spinning_Reserve_Up_Requirements.append('NREL35VarGenSpinningReserveRequirement')
-    m.Spinning_Reserve_Down_Requirements.append('NREL35VarGenSpinningReserveRequirement')
+    m.Spinning_Reserve_Up_Requirements.append("NREL35VarGenSpinningReserveRequirement")
+    m.Spinning_Reserve_Down_Requirements.append(
+        "NREL35VarGenSpinningReserveRequirement"
+    )
 
 
 def define_components(m):
@@ -375,16 +422,18 @@ def define_components(m):
     project_contingency and spinning_requirement_rule, other components may be
     added by other functions which are documented above.
     """
-    m.contingency_safety_factor = Param(default=1.0,
-        doc=("The spinning reserve requiremet will be set to this value "
-             "times the maximum contingency. This defaults to 1 to provide "
-             "n-1 security for the largest committed generator. "))
+    m.contingency_safety_factor = Param(
+        default=1.0,
+        doc=(
+            "The spinning reserve requiremet will be set to this value "
+            "times the maximum contingency. This defaults to 1 to provide "
+            "n-1 security for the largest committed generator. "
+        ),
+    )
 
     m.GEN_SPINNING_RESERVE_TYPES = Set(dimen=2)
     m.gen_reserve_type_max_share = Param(
-        m.GEN_SPINNING_RESERVE_TYPES,
-        within=PercentFraction,
-        default=1.0
+        m.GEN_SPINNING_RESERVE_TYPES, within=PercentFraction, default=1.0
     )
 
     # reserve types that are supplied by generation projects
@@ -404,62 +453,79 @@ def define_components(m):
         for g, rt in m.GEN_SPINNING_RESERVE_TYPES:
             m.SPINNING_RESERVE_TYPES_FOR_GEN_dict[g].append(rt)
             m.GENS_FOR_SPINNING_RESERVE_TYPE_dict[rt].append(g)
+
     m.build_spinning_reserve_indexed_sets = BuildAction(rule=rule)
 
     m.SPINNING_RESERVE_TYPES_FOR_GEN = Set(
         m.SPINNING_RESERVE_CAPABLE_GENS,
-        rule=lambda m, g: m.SPINNING_RESERVE_TYPES_FOR_GEN_dict.pop(g)
+        rule=lambda m, g: m.SPINNING_RESERVE_TYPES_FOR_GEN_dict.pop(g),
     )
     m.GENS_FOR_SPINNING_RESERVE_TYPE = Set(
         m.SPINNING_RESERVE_TYPES_FROM_GENS,
-        rule=lambda m, rt: m.GENS_FOR_SPINNING_RESERVE_TYPE_dict.pop(rt)
+        rule=lambda m, rt: m.GENS_FOR_SPINNING_RESERVE_TYPE_dict.pop(rt),
     )
 
     # types, generators and timepoints when reserves could be supplied
-    m.SPINNING_RESERVE_TYPE_GEN_TPS = Set(dimen=3, initialize=lambda m: (
-        (rt, g, tp)
-        for g, rt in m.GEN_SPINNING_RESERVE_TYPES
-        for tp in m.TPS_FOR_GEN[g]
-    ))
+    m.SPINNING_RESERVE_TYPE_GEN_TPS = Set(
+        dimen=3,
+        initialize=lambda m: (
+            (rt, g, tp)
+            for g, rt in m.GEN_SPINNING_RESERVE_TYPES
+            for tp in m.TPS_FOR_GEN[g]
+        ),
+    )
     # generators and timepoints when reserves could be supplied
-    m.SPINNING_RESERVE_CAPABLE_GEN_TPS = Set(dimen=2, initialize=lambda m: (
-        (g, tp)
-        for g in m.SPINNING_RESERVE_CAPABLE_GENS
-        for tp in m.TPS_FOR_GEN[g]
-    ))
+    m.SPINNING_RESERVE_CAPABLE_GEN_TPS = Set(
+        dimen=2,
+        initialize=lambda m: (
+            (g, tp) for g in m.SPINNING_RESERVE_CAPABLE_GENS for tp in m.TPS_FOR_GEN[g]
+        ),
+    )
 
     # decide how much of each type of reserves to produce from each generator
     # during each timepoint
-    m.CommitGenSpinningReservesUp = Var(m.SPINNING_RESERVE_TYPE_GEN_TPS, within=NonNegativeReals)
-    m.CommitGenSpinningReservesDown = Var(m.SPINNING_RESERVE_TYPE_GEN_TPS, within=NonNegativeReals)
-    m.CommitGenSpinningReservesSlackUp = Var(m.SPINNING_RESERVE_CAPABLE_GEN_TPS, within=NonNegativeReals,
+    m.CommitGenSpinningReservesUp = Var(
+        m.SPINNING_RESERVE_TYPE_GEN_TPS, within=NonNegativeReals
+    )
+    m.CommitGenSpinningReservesDown = Var(
+        m.SPINNING_RESERVE_TYPE_GEN_TPS, within=NonNegativeReals
+    )
+    m.CommitGenSpinningReservesSlackUp = Var(
+        m.SPINNING_RESERVE_CAPABLE_GEN_TPS,
+        within=NonNegativeReals,
         doc="Denotes the upward slack in spinning reserves that could be used "
-            "for quickstart reserves, or possibly other reserve products."
+        "for quickstart reserves, or possibly other reserve products.",
     )
 
     # constrain reserve provision appropriately
     m.CommitGenSpinningReservesUp_Limit = Constraint(
         m.SPINNING_RESERVE_CAPABLE_GEN_TPS,
         rule=lambda m, g, tp: (
-            sum(m.CommitGenSpinningReservesUp[rt, g, tp] for rt in m.SPINNING_RESERVE_TYPES_FOR_GEN[g])
-            + m.CommitGenSpinningReservesSlackUp[g,tp]
-            ==
-            m.DispatchSlackUp[g, tp]
+            sum(
+                m.CommitGenSpinningReservesUp[rt, g, tp]
+                for rt in m.SPINNING_RESERVE_TYPES_FOR_GEN[g]
+            )
+            + m.CommitGenSpinningReservesSlackUp[g, tp]
+            == m.DispatchSlackUp[g, tp]
             # storage can give more up response by stopping charging
-            + (m.ChargeStorage[g, tp] if g in getattr(m, 'STORAGE_GENS', []) else 0.0)
-        )
+            + (m.ChargeStorage[g, tp] if g in getattr(m, "STORAGE_GENS", []) else 0.0)
+        ),
     )
     m.CommitGenSpinningReservesDown_Limit = Constraint(
         m.SPINNING_RESERVE_CAPABLE_GEN_TPS,
-        rule=lambda m, g, tp:
-            sum(m.CommitGenSpinningReservesDown[rt, g, tp] for rt in m.SPINNING_RESERVE_TYPES_FOR_GEN[g])
-            <=
-            m.DispatchSlackDown[g, tp]
-            + ( # storage could give more down response by raising ChargeStorage to the maximum rate
-                (m.DispatchUpperLimit[g, tp] * m.gen_store_to_release_ratio[g] - m.ChargeStorage[g, tp])
-                if g in getattr(m, 'STORAGE_GENS', [])
-                else 0.0
+        rule=lambda m, g, tp: sum(
+            m.CommitGenSpinningReservesDown[rt, g, tp]
+            for rt in m.SPINNING_RESERVE_TYPES_FOR_GEN[g]
+        )
+        <= m.DispatchSlackDown[g, tp]
+        + (  # storage could give more down response by raising ChargeStorage to the maximum rate
+            (
+                m.DispatchUpperLimit[g, tp] * m.gen_store_to_release_ratio[g]
+                - m.ChargeStorage[g, tp]
             )
+            if g in getattr(m, "STORAGE_GENS", [])
+            else 0.0
+        ),
     )
 
     # Calculate total spinning reserves from generation projects,
@@ -475,13 +541,16 @@ def define_components(m):
                 up[rt, ba, tp] += m.CommitGenSpinningReservesUp[rt, g, tp]
                 down[rt, ba, tp] += m.CommitGenSpinningReservesDown[rt, g, tp]
         m.TotalGenSpinningReservesUp = Expression(list(up.keys()), initialize=dict(up))
-        m.TotalGenSpinningReservesDown = Expression(list(down.keys()), initialize=dict(down))
+        m.TotalGenSpinningReservesDown = Expression(
+            list(down.keys()), initialize=dict(down)
+        )
         # construct these, so they can be used immediately
         for c in [m.TotalGenSpinningReservesUp, m.TotalGenSpinningReservesDown]:
             c.index_set().construct()
             c.construct()
-        m.Spinning_Reserve_Up_Provisions.append('TotalGenSpinningReservesUp')
-        m.Spinning_Reserve_Down_Provisions.append('TotalGenSpinningReservesDown')
+        m.Spinning_Reserve_Up_Provisions.append("TotalGenSpinningReservesUp")
+        m.Spinning_Reserve_Down_Provisions.append("TotalGenSpinningReservesDown")
+
     m.TotalGenSpinningReserves_aggregate = BuildAction(rule=rule)
 
     # define reserve requirements
@@ -491,14 +560,16 @@ def define_components(m):
         gen_unit_contingency(m)
     if m.options.project_contingency:
         gen_project_contingency(m)
-    if m.options.spinning_requirement_rule == 'Hawaii':
+    if m.options.spinning_requirement_rule == "Hawaii":
         hawaii_spinning_reserve_requirements(m)
-    elif m.options.spinning_requirement_rule == '3+5':
+    elif m.options.spinning_requirement_rule == "3+5":
         nrel_3_5_spinning_reserve_requirements(m)
-    elif m.options.spinning_requirement_rule == 'none':
-        pass # users can turn off the rules and use their own instead
+    elif m.options.spinning_requirement_rule == "none":
+        pass  # users can turn off the rules and use their own instead
     else:
-        raise ValueError('No --spinning-requirement-rule specified on command line; unable to allocate reserves.')
+        raise ValueError(
+            "No --spinning-requirement-rule specified on command line; unable to allocate reserves."
+        )
 
 
 def define_dynamic_components(m):
@@ -530,26 +601,32 @@ def define_dynamic_components(m):
 
     # define largest contingencies
     m.MaximumContingencyUp = Var(
-        m.BALANCING_AREA_TIMEPOINTS, within=NonNegativeReals,
-        doc=("Maximum of the registered Spinning_Reserve_Up_Contingencies, after "
-             "multiplying by contingency_safety_factor.")
+        m.BALANCING_AREA_TIMEPOINTS,
+        within=NonNegativeReals,
+        doc=(
+            "Maximum of the registered Spinning_Reserve_Up_Contingencies, after "
+            "multiplying by contingency_safety_factor."
+        ),
     )
     m.MaximumContingencyDown = Var(
-        m.BALANCING_AREA_TIMEPOINTS, within=NonNegativeReals,
-        doc=("Maximum of the registered Spinning_Reserve_Down_Contingencies, after "
-             "multiplying by contingency_safety_factor.")
+        m.BALANCING_AREA_TIMEPOINTS,
+        within=NonNegativeReals,
+        doc=(
+            "Maximum of the registered Spinning_Reserve_Down_Contingencies, after "
+            "multiplying by contingency_safety_factor."
+        ),
     )
     m.Calculate_MaximumContingencyUp = Constraint(
         m.BALANCING_AREA_TIMEPOINTS,
-        m.Spinning_Reserve_Up_Contingencies, # list of contingency events
-        rule=lambda m, b, t, contingency:
-            m.MaximumContingencyUp[b, t] >= m.contingency_safety_factor * getattr(m, contingency)[b, t]
+        m.Spinning_Reserve_Up_Contingencies,  # list of contingency events
+        rule=lambda m, b, t, contingency: m.MaximumContingencyUp[b, t]
+        >= m.contingency_safety_factor * getattr(m, contingency)[b, t],
     )
     m.Calculate_MaximumContingencyDown = Constraint(
         m.BALANCING_AREA_TIMEPOINTS,
-        m.Spinning_Reserve_Down_Contingencies, # list of contingency events
-        rule=lambda m, b, t, contingency:
-            m.MaximumContingencyDown[b, t] >= m.contingency_safety_factor * getattr(m, contingency)[b, t]
+        m.Spinning_Reserve_Down_Contingencies,  # list of contingency events
+        rule=lambda m, b, t, contingency: m.MaximumContingencyDown[b, t]
+        >= m.contingency_safety_factor * getattr(m, contingency)[b, t],
     )
 
     # create reserve requirements equal to the largest contingencies
@@ -557,16 +634,16 @@ def define_dynamic_components(m):
     m.MaximumContingencyUpRequirement = Expression(
         [m.options.contingency_reserve_type],
         m.BALANCING_AREA_TIMEPOINTS,
-        rule=lambda m, rt, ba, tp: m.MaximumContingencyUp[ba, tp]
+        rule=lambda m, rt, ba, tp: m.MaximumContingencyUp[ba, tp],
     )
     m.MaximumContingencyDownRequirement = Expression(
         [m.options.contingency_reserve_type],
         m.BALANCING_AREA_TIMEPOINTS,
-        rule=lambda m, rt, ba, tp: m.MaximumContingencyDown[ba, tp]
+        rule=lambda m, rt, ba, tp: m.MaximumContingencyDown[ba, tp],
     )
 
-    m.Spinning_Reserve_Up_Requirements.append('MaximumContingencyUpRequirement')
-    m.Spinning_Reserve_Down_Requirements.append('MaximumContingencyDownRequirement')
+    m.Spinning_Reserve_Up_Requirements.append("MaximumContingencyUpRequirement")
+    m.Spinning_Reserve_Down_Requirements.append("MaximumContingencyDownRequirement")
 
     # aggregate the requirements for each type of reserves during each timepoint
     def rule(m):
@@ -576,36 +653,36 @@ def define_dynamic_components(m):
             for comp in getattr(m, lst):
                 for key, val in iteritems(getattr(m, comp)):
                     d[key] += val
-            setattr(m, lst + '_dict', d)
-        makedict(m, 'Spinning_Reserve_Up_Requirements')
-        makedict(m, 'Spinning_Reserve_Down_Requirements')
-        makedict(m, 'Spinning_Reserve_Up_Provisions')
-        makedict(m, 'Spinning_Reserve_Down_Provisions')
+            setattr(m, lst + "_dict", d)
+
+        makedict(m, "Spinning_Reserve_Up_Requirements")
+        makedict(m, "Spinning_Reserve_Down_Requirements")
+        makedict(m, "Spinning_Reserve_Up_Provisions")
+        makedict(m, "Spinning_Reserve_Down_Provisions")
+
     m.Aggregate_Spinning_Reserve_Details = BuildAction(rule=rule)
 
     m.SPINNING_RESERVE_REQUIREMENT_UP_BALANCING_AREA_TIMEPOINTS = Set(
-        dimen=3,
-        rule=lambda m: list(m.Spinning_Reserve_Up_Requirements_dict.keys())
+        dimen=3, rule=lambda m: list(m.Spinning_Reserve_Up_Requirements_dict.keys())
     )
     m.SPINNING_RESERVE_REQUIREMENT_DOWN_BALANCING_AREA_TIMEPOINTS = Set(
-        dimen=3,
-        rule=lambda m: list(m.Spinning_Reserve_Down_Requirements_dict.keys())
+        dimen=3, rule=lambda m: list(m.Spinning_Reserve_Down_Requirements_dict.keys())
     )
 
     # satisfy all spinning reserve requirements
     m.Satisfy_Spinning_Reserve_Up_Requirement = Constraint(
         m.SPINNING_RESERVE_REQUIREMENT_UP_BALANCING_AREA_TIMEPOINTS,
-        rule=lambda m, rt, ba, tp:
-            m.Spinning_Reserve_Up_Provisions_dict.pop((rt, ba, tp), 0.0)
-            >=
-            m.Spinning_Reserve_Up_Requirements_dict.pop((rt, ba, tp))
+        rule=lambda m, rt, ba, tp: m.Spinning_Reserve_Up_Provisions_dict.pop(
+            (rt, ba, tp), 0.0
+        )
+        >= m.Spinning_Reserve_Up_Requirements_dict.pop((rt, ba, tp)),
     )
     m.Satisfy_Spinning_Reserve_Down_Requirement = Constraint(
         m.SPINNING_RESERVE_REQUIREMENT_DOWN_BALANCING_AREA_TIMEPOINTS,
-        rule=lambda m, rt, ba, tp:
-            m.Spinning_Reserve_Down_Provisions_dict.pop((rt, ba, tp), 0.0)
-            >=
-            m.Spinning_Reserve_Down_Requirements_dict.pop((rt, ba, tp))
+        rule=lambda m, rt, ba, tp: m.Spinning_Reserve_Down_Provisions_dict.pop(
+            (rt, ba, tp), 0.0
+        )
+        >= m.Spinning_Reserve_Down_Requirements_dict.pop((rt, ba, tp)),
     )
 
 
@@ -620,22 +697,23 @@ def load_inputs(m, switch_data, inputs_dir):
     contingency_safety_factor. Note that this only contains one header row
     and one data row.
     """
-    path=os.path.join(inputs_dir, 'generation_projects_reserve_capability.csv')
+    path = os.path.join(inputs_dir, "generation_projects_reserve_capability.csv")
     switch_data.load_aug(
         filename=path,
         optional=True,
-        optional_params=['gen_reserve_type_max_share]'],
+        optional_params=["gen_reserve_type_max_share]"],
         index=m.GEN_SPINNING_RESERVE_TYPES,
-        param=(m.gen_reserve_type_max_share)
+        param=(m.gen_reserve_type_max_share),
     )
     if not os.path.isfile(path):
-        gen_projects = switch_data.data()['GENERATION_PROJECTS'][None]
-        switch_data.data()['GEN_SPINNING_RESERVE_TYPES'] = {}
-        switch_data.data()['GEN_SPINNING_RESERVE_TYPES'][None] = \
-            [(g, "spinning") for g in gen_projects]
+        gen_projects = switch_data.data()["GENERATION_PROJECTS"][None]
+        switch_data.data()["GEN_SPINNING_RESERVE_TYPES"] = {}
+        switch_data.data()["GEN_SPINNING_RESERVE_TYPES"][None] = [
+            (g, "spinning") for g in gen_projects
+        ]
 
     switch_data.load_aug(
-        filename=os.path.join(inputs_dir, 'spinning_reserve_params.csv'),
+        filename=os.path.join(inputs_dir, "spinning_reserve_params.csv"),
         optional=True,
-        param=(m.contingency_safety_factor,)
+        param=(m.contingency_safety_factor,),
     )

--- a/switch_model/balancing/planning_reserves.py
+++ b/switch_model/balancing/planning_reserves.py
@@ -50,19 +50,20 @@ import os
 from pyomo.environ import *
 
 dependencies = (
-    'switch_model.timescales',
-    'switch_model.financials',
-    'switch_model.balancing.load_zones',
-    'switch_model.energy_sources.properties',
-    'switch_model.generators.core.build',
-    'switch_model.generators.core.dispatch',
+    "switch_model.timescales",
+    "switch_model.financials",
+    "switch_model.balancing.load_zones",
+    "switch_model.energy_sources.properties",
+    "switch_model.generators.core.build",
+    "switch_model.generators.core.dispatch",
 )
 optional_prerequisites = (
-    'switch_model.generators.storage',
-    'switch_model.transmission.local_td',
-    'switch_model.transmission.transport.build',
-    'switch_model.transmission.transport.dispatch',
+    "switch_model.generators.storage",
+    "switch_model.transmission.local_td",
+    "switch_model.transmission.transport.build",
+    "switch_model.transmission.transport.dispatch",
 )
+
 
 def define_dynamic_lists(model):
     """
@@ -131,22 +132,24 @@ def define_components(model):
     )
     model.PRR_ZONES = Set(
         dimen=2,
-        doc=("A set of (prr, z) that describes which zones contribute to each "
-             "Planning Reserve Requirement.")
+        doc=(
+            "A set of (prr, z) that describes which zones contribute to each "
+            "Planning Reserve Requirement."
+        ),
     )
     model.prr_cap_reserve_margin = Param(
-        model.PLANNING_RESERVE_REQUIREMENTS,
-        within=PercentFraction,
-        default=0.15
+        model.PLANNING_RESERVE_REQUIREMENTS, within=PercentFraction, default=0.15
     )
     model.prr_enforcement_timescale = Param(
         model.PLANNING_RESERVE_REQUIREMENTS,
-        default='period_peak_load',
-        validate=lambda m, value, prr:
-            value in ('all_timepoints', 'peak_load'),
-        doc=("Determines whether planning reserve requirements are enforced in "
-             "each timepoint, or just timepoints with peak load (zone_demand_mw).")
+        default="period_peak_load",
+        validate=lambda m, value, prr: value in ("all_timepoints", "peak_load"),
+        doc=(
+            "Determines whether planning reserve requirements are enforced in "
+            "each timepoint, or just timepoints with peak load (zone_demand_mw)."
+        ),
     )
+
     def get_peak_timepoints(m, prr):
         """
         Return the set of timepoints with peak load within a planning reserve
@@ -165,31 +168,39 @@ def define_components(model):
                     peak_load = load
             peak_timepoint_list.add(peak_timepoint)
         return peak_timepoint_list
+
     def PRR_TIMEPOINTS_init(m):
         PRR_TIMEPOINTS = []
         for prr in m.PLANNING_RESERVE_REQUIREMENTS:
-            if m.prr_enforcement_timescale[prr] == 'all_timepoints':
+            if m.prr_enforcement_timescale[prr] == "all_timepoints":
                 PRR_TIMEPOINTS.extend([(prr, t) for t in m.TIMEPOINTS])
-            elif m.prr_enforcement_timescale[prr] == 'peak_load':
+            elif m.prr_enforcement_timescale[prr] == "peak_load":
                 PRR_TIMEPOINTS.extend([(prr, t) for t in get_peak_timepoints(m, prr)])
             else:
-                raise ValueError("prr_enforcement_timescale not recognized: '{}'".format(
-                    m.prr_enforcement_timescale[prr]))
+                raise ValueError(
+                    "prr_enforcement_timescale not recognized: '{}'".format(
+                        m.prr_enforcement_timescale[prr]
+                    )
+                )
         return PRR_TIMEPOINTS
+
     model.PRR_TIMEPOINTS = Set(
         dimen=2,
         within=model.PLANNING_RESERVE_REQUIREMENTS * model.TIMEPOINTS,
         initialize=PRR_TIMEPOINTS_init,
-        doc=("The sparse set of (prr, t) for which planning reserve "
-             "requirements are enforced.")
+        doc=(
+            "The sparse set of (prr, t) for which planning reserve "
+            "requirements are enforced."
+        ),
     )
 
     model.gen_can_provide_cap_reserves = Param(
         model.GENERATION_PROJECTS,
         within=Boolean,
         default=True,
-        doc="Indicates whether a generator can provide capacity reserves."
+        doc="Indicates whether a generator can provide capacity reserves.",
     )
+
     def gen_capacity_value_default(m, g, t):
         if not m.gen_can_provide_cap_reserves[g]:
             return 0.0
@@ -199,14 +210,14 @@ def define_components(model):
             return min(1.0, m.gen_max_capacity_factor[g, t])
         else:
             return 1.0
+
     model.gen_capacity_value = Param(
         model.GEN_TPS,
         within=PercentFraction,
         default=gen_capacity_value_default,
         validate=lambda m, value, g, t: (
-            value == 0.0
-            if not m.gen_can_provide_cap_reserves[g]
-            else True)
+            value == 0.0 if not m.gen_can_provide_cap_reserves[g] else True
+        ),
     )
 
     def zones_for_prr(m, prr):
@@ -223,61 +234,70 @@ def define_components(model):
         ]
         for g in GENS:
             # Storage is only credited with its expected output
-            if g in getattr(m, 'STORAGE_GENS', set()):
+            if g in getattr(m, "STORAGE_GENS", set()):
                 reserve_cap += m.DispatchGen[g, t] - m.ChargeStorage[g, t]
             # If local_td is included with DER modeling, avoid allocating
             # distributed generation to central grid capacity because it will
             # be credited with adjusting load at the distribution node.
-            elif hasattr(m, 'Distributed_Power_Injections') and m.gen_is_distributed[g]:
+            elif hasattr(m, "Distributed_Power_Injections") and m.gen_is_distributed[g]:
                 pass
             else:
                 reserve_cap += m.gen_capacity_value[g, t] * m.GenCapacityInTP[g, t]
         return reserve_cap
+
     model.AvailableReserveCapacity = Expression(
         model.PRR_TIMEPOINTS, rule=AvailableReserveCapacity_rule
     )
-    model.CAPACITY_FOR_RESERVES.append('AvailableReserveCapacity')
+    model.CAPACITY_FOR_RESERVES.append("AvailableReserveCapacity")
 
-    if 'TXPowerNet' in model:
-        model.CAPACITY_FOR_RESERVES.append('TXPowerNet')
+    if "TXPowerNet" in model:
+        model.CAPACITY_FOR_RESERVES.append("TXPowerNet")
 
     def CapacityRequirements_rule(m, prr, t):
         ZONES = zones_for_prr(m, prr)
-        if hasattr(m, 'WithdrawFromCentralGrid'):
+        if hasattr(m, "WithdrawFromCentralGrid"):
             return sum(
-                (1 + m.prr_cap_reserve_margin[prr]) * m.WithdrawFromCentralGrid[z,t]
+                (1 + m.prr_cap_reserve_margin[prr]) * m.WithdrawFromCentralGrid[z, t]
                 for z in ZONES
             )
         else:
             return sum(
-                (1 + m.prr_cap_reserve_margin[prr]) * m.zone_demand_mw[z,t]
+                (1 + m.prr_cap_reserve_margin[prr]) * m.zone_demand_mw[z, t]
                 for z in ZONES
             )
+
     model.CapacityRequirements = Expression(
-        model.PRR_TIMEPOINTS,
-        rule=CapacityRequirements_rule
+        model.PRR_TIMEPOINTS, rule=CapacityRequirements_rule
     )
-    model.REQUIREMENTS_FOR_CAPACITY_RESERVES.append('CapacityRequirements')
+    model.REQUIREMENTS_FOR_CAPACITY_RESERVES.append("CapacityRequirements")
 
 
 def define_dynamic_components(model):
-    """
-    """
+    """"""
     model.Enforce_Planning_Reserve_Margin = Constraint(
-        model.PRR_TIMEPOINTS, rule=lambda m, prr, t: (
-            sum(getattr(m, reserve_cap)[prr,t]
+        model.PRR_TIMEPOINTS,
+        rule=lambda m, prr, t: (
+            sum(
+                getattr(m, reserve_cap)[prr, t]
                 for reserve_cap in m.CAPACITY_FOR_RESERVES
-            ) >= sum(getattr(m, cap_requirement)[prr,t]
-                for cap_requirement in m.REQUIREMENTS_FOR_CAPACITY_RESERVES)),
-        doc=("Ensures that the sum of CAPACITY_FOR_RESERVES satisfies the sum "
-             "of REQUIREMENTS_FOR_CAPACITY_RESERVES for each of PRR_TIMEPOINTS."))
+            )
+            >= sum(
+                getattr(m, cap_requirement)[prr, t]
+                for cap_requirement in m.REQUIREMENTS_FOR_CAPACITY_RESERVES
+            )
+        ),
+        doc=(
+            "Ensures that the sum of CAPACITY_FOR_RESERVES satisfies the sum "
+            "of REQUIREMENTS_FOR_CAPACITY_RESERVES for each of PRR_TIMEPOINTS."
+        ),
+    )
 
 
 def load_inputs(model, switch_data, inputs_dir):
     """
     Files or columns marked with * are optional. See notes above on default
     values.
-    
+
     reserve_capacity_value.csv*
         GEN, TIMEPOINT, gen_capacity_value
 
@@ -292,23 +312,23 @@ def load_inputs(model, switch_data, inputs_dir):
 
     """
     switch_data.load_aug(
-        filename=os.path.join(inputs_dir, 'reserve_capacity_value.csv'),
+        filename=os.path.join(inputs_dir, "reserve_capacity_value.csv"),
         optional=True,
-        param=(model.gen_capacity_value)
+        param=(model.gen_capacity_value),
     )
     switch_data.load_aug(
-        filename=os.path.join(inputs_dir, 'planning_reserve_requirements.csv'),
+        filename=os.path.join(inputs_dir, "planning_reserve_requirements.csv"),
         optional=True,
         index=model.PLANNING_RESERVE_REQUIREMENTS,
-        optional_params=['gen_can_provide_cap_reserves', "prr_enforcement_timescale"],
-        param=(model.prr_cap_reserve_margin, model.prr_enforcement_timescale)
+        optional_params=["gen_can_provide_cap_reserves", "prr_enforcement_timescale"],
+        param=(model.prr_cap_reserve_margin, model.prr_enforcement_timescale),
     )
     switch_data.load_aug(
-        filename=os.path.join(inputs_dir, 'generation_projects_info.csv'),
-        optional_params=['gen_can_provide_cap_reserves'],
-        param=(model.gen_can_provide_cap_reserves)
+        filename=os.path.join(inputs_dir, "generation_projects_info.csv"),
+        optional_params=["gen_can_provide_cap_reserves"],
+        param=(model.gen_can_provide_cap_reserves),
     )
     switch_data.load_aug(
-        filename=os.path.join(inputs_dir, 'planning_reserve_requirement_zones.csv'),
-        set=model.PRR_ZONES
+        filename=os.path.join(inputs_dir, "planning_reserve_requirement_zones.csv"),
+        set=model.PRR_ZONES,
     )

--- a/switch_model/balancing/unserved_load.py
+++ b/switch_model/balancing/unserved_load.py
@@ -11,8 +11,12 @@ strictly required in all cases.
 import os
 from pyomo.environ import *
 
-dependencies = 'switch_model.timescales',\
-    'switch_model.balancing.load_areas', 'switch_model.financials'
+dependencies = (
+    "switch_model.timescales",
+    "switch_model.balancing.load_areas",
+    "switch_model.financials",
+)
+
 
 def define_components(mod):
     """
@@ -31,19 +35,18 @@ def define_components(mod):
 
     """
 
-    mod.unserved_load_penalty = Param(
-        within=NonNegativeReals,
-        default=500)
-    mod.UnservedLoad = Var(
-        mod.LOAD_ZONES, mod.TIMEPOINTS,
-        within=NonNegativeReals)
-    mod.Zone_Power_Injections.append('UnservedLoad')
+    mod.unserved_load_penalty = Param(within=NonNegativeReals, default=500)
+    mod.UnservedLoad = Var(mod.LOAD_ZONES, mod.TIMEPOINTS, within=NonNegativeReals)
+    mod.Zone_Power_Injections.append("UnservedLoad")
 
     mod.UnservedLoadPenalty = Expression(
         mod.TIMEPOINTS,
-        rule=lambda m, tp: sum(m.UnservedLoad[z, tp] *
-            m.unserved_load_penalty for z in m.LOAD_ZONES))
-    mod.Cost_Components_Per_TP.append('UnservedLoadPenalty')
+        rule=lambda m, tp: sum(
+            m.UnservedLoad[z, tp] * m.unserved_load_penalty for z in m.LOAD_ZONES
+        ),
+    )
+    mod.Cost_Components_Per_TP.append("UnservedLoadPenalty")
+
 
 def load_inputs(mod, switch_data, inputs_dir):
     """
@@ -58,7 +61,7 @@ def load_inputs(mod, switch_data, inputs_dir):
 
     """
     switch_data.load_aug(
-        filename=os.path.join(inputs_dir, 'lost_load_cost.csv'),
+        filename=os.path.join(inputs_dir, "lost_load_cost.csv"),
         optional=True,
-        param=(mod.unserved_load_penalty,)
+        param=(mod.unserved_load_penalty,),
     )

--- a/switch_model/energy_sources/fuel_costs/markets.py
+++ b/switch_model/energy_sources/fuel_costs/markets.py
@@ -12,9 +12,14 @@ import os
 import csv
 from pyomo.environ import *
 
-dependencies = 'switch_model.timescales', 'switch_model.balancing.load_zones',\
-    'switch_model.energy_sources.properties.properties',\
-    'switch_model.generators.core.build', 'switch_model.generators.core.dispatch'
+dependencies = (
+    "switch_model.timescales",
+    "switch_model.balancing.load_zones",
+    "switch_model.energy_sources.properties.properties",
+    "switch_model.generators.core.build",
+    "switch_model.generators.core.dispatch",
+)
+
 
 def define_components(mod):
     """
@@ -207,49 +212,64 @@ def define_components(mod):
     mod.REGIONAL_FUEL_MARKETS = Set()
     mod.rfm_fuel = Param(mod.REGIONAL_FUEL_MARKETS, within=mod.FUELS)
     mod.ZONE_RFMS = Set(
-        dimen=2, validate=lambda m, z, rfm: (
-            rfm in m.REGIONAL_FUEL_MARKETS and z in m.LOAD_ZONES))
+        dimen=2,
+        validate=lambda m, z, rfm: (
+            rfm in m.REGIONAL_FUEL_MARKETS and z in m.LOAD_ZONES
+        ),
+    )
     mod.ZONE_FUELS = Set(
-        dimen=2, initialize=lambda m: set(
-            (z, m.rfm_fuel[rfm]) for (z, rfm) in m.ZONE_RFMS))
+        dimen=2,
+        initialize=lambda m: set((z, m.rfm_fuel[rfm]) for (z, rfm) in m.ZONE_RFMS),
+    )
 
     def zone_fuel_rfm_init(m, load_zone, fuel):
         # find first (only) matching rfm
         for (z, rfm) in m.ZONE_RFMS:
-            if(z == load_zone and fuel == m.rfm_fuel[rfm]):
+            if z == load_zone and fuel == m.rfm_fuel[rfm]:
                 return rfm
+
     mod.zone_fuel_rfm = Param(
-        mod.ZONE_FUELS, within=mod.REGIONAL_FUEL_MARKETS,
-        initialize=zone_fuel_rfm_init)
-    mod.min_data_check('REGIONAL_FUEL_MARKETS', 'rfm_fuel', 'zone_fuel_rfm')
+        mod.ZONE_FUELS, within=mod.REGIONAL_FUEL_MARKETS, initialize=zone_fuel_rfm_init
+    )
+    mod.min_data_check("REGIONAL_FUEL_MARKETS", "rfm_fuel", "zone_fuel_rfm")
     mod.ZONES_IN_RFM = Set(
         mod.REGIONAL_FUEL_MARKETS,
-        initialize=lambda m, rfm: set(
-            z for (z, r) in m.ZONE_RFMS if r == rfm))
+        initialize=lambda m, rfm: set(z for (z, r) in m.ZONE_RFMS if r == rfm),
+    )
 
     # RFM_SUPPLY_TIERS = [(regional_fuel_market, period, supply_tier_index)...]
     mod.RFM_SUPPLY_TIERS = Set(
-        dimen=3, validate=lambda m, r, p, st: (
-            r in m.REGIONAL_FUEL_MARKETS and p in m.PERIODS))
-    mod.rfm_supply_tier_cost = Param(
-        mod.RFM_SUPPLY_TIERS, within=Reals)
+        dimen=3,
+        validate=lambda m, r, p, st: (r in m.REGIONAL_FUEL_MARKETS and p in m.PERIODS),
+    )
+    mod.rfm_supply_tier_cost = Param(mod.RFM_SUPPLY_TIERS, within=Reals)
     mod.rfm_supply_tier_limit = Param(
-        mod.RFM_SUPPLY_TIERS, within=NonNegativeReals, default=float('inf'))
+        mod.RFM_SUPPLY_TIERS, within=NonNegativeReals, default=float("inf")
+    )
     mod.min_data_check(
-        'RFM_SUPPLY_TIERS', 'rfm_supply_tier_cost', 'rfm_supply_tier_limit')
+        "RFM_SUPPLY_TIERS", "rfm_supply_tier_cost", "rfm_supply_tier_limit"
+    )
     mod.SUPPLY_TIERS_FOR_RFM_PERIOD = Set(
-        mod.REGIONAL_FUEL_MARKETS, mod.PERIODS, dimen=3,
+        mod.REGIONAL_FUEL_MARKETS,
+        mod.PERIODS,
+        dimen=3,
         initialize=lambda m, rfm, ip: set(
-            (r, p, st) for (r, p, st) in m.RFM_SUPPLY_TIERS
-            if r == rfm and p == ip))
+            (r, p, st) for (r, p, st) in m.RFM_SUPPLY_TIERS if r == rfm and p == ip
+        ),
+    )
 
     mod.ConsumeFuelTier = Var(
         mod.RFM_SUPPLY_TIERS,
         domain=NonNegativeReals,
         bounds=lambda m, rfm, p, st: (
-            0, (m.rfm_supply_tier_limit[rfm, p, st]
-                if value(m.rfm_supply_tier_limit[rfm, p, st]) != float('inf')
-                else None)))
+            0,
+            (
+                m.rfm_supply_tier_limit[rfm, p, st]
+                if value(m.rfm_supply_tier_limit[rfm, p, st]) != float("inf")
+                else None
+            ),
+        ),
+    )
     # The if statement in the upper bound of ConsumeFuelTier is a
     # work-around for a Pyomo bug in writing a cpxlp problem file for
     # glpk. Lines 771-774 of pyomo/repn/plugins/cpxlp.py prints '<= inf'
@@ -260,10 +280,13 @@ def define_components(mod):
     # solvers is: 0, m.rfm_supply_tier_limit[rfm, p, st]))
 
     mod.FuelConsumptionInMarket = Expression(
-        mod.REGIONAL_FUEL_MARKETS, mod.PERIODS,
+        mod.REGIONAL_FUEL_MARKETS,
+        mod.PERIODS,
         rule=lambda m, rfm, p: sum(
             m.ConsumeFuelTier[rfm_supply_tier]
-                for rfm_supply_tier in m.SUPPLY_TIERS_FOR_RFM_PERIOD[rfm, p]))
+            for rfm_supply_tier in m.SUPPLY_TIERS_FOR_RFM_PERIOD[rfm, p]
+        ),
+    )
 
     # Ensure that adjusted fuel costs of unbounded supply tiers are not
     # negative because that would create an unbounded optimization
@@ -271,25 +294,34 @@ def define_components(mod):
     def zone_fuel_cost_adder_validate(model, val, z, fuel, p):
         rfm = model.zone_fuel_rfm[z, fuel]
         for rfm_supply_tier in model.SUPPLY_TIERS_FOR_RFM_PERIOD[rfm, p]:
-            if(val + model.rfm_supply_tier_cost[rfm_supply_tier] < 0 and
-               model.rfm_supply_tier_limit[rfm_supply_tier] == float('inf')):
+            if val + model.rfm_supply_tier_cost[
+                rfm_supply_tier
+            ] < 0 and model.rfm_supply_tier_limit[rfm_supply_tier] == float("inf"):
                 return False
         return True
+
     mod.zone_fuel_cost_adder = Param(
-        mod.ZONE_FUELS, mod.PERIODS,
-        within=Reals, default=0, validate=zone_fuel_cost_adder_validate)
+        mod.ZONE_FUELS,
+        mod.PERIODS,
+        within=Reals,
+        default=0,
+        validate=zone_fuel_cost_adder_validate,
+    )
 
     # Summarize annual fuel costs for the objective function
     def rfm_annual_costs(m, rfm, p):
         return sum(
             m.ConsumeFuelTier[rfm_st] * m.rfm_supply_tier_cost[rfm_st]
-            for rfm_st in m.SUPPLY_TIERS_FOR_RFM_PERIOD[rfm, p])
+            for rfm_st in m.SUPPLY_TIERS_FOR_RFM_PERIOD[rfm, p]
+        )
+
     mod.FuelCostsPerPeriod = Expression(
         mod.PERIODS,
         rule=lambda m, p: sum(
-            rfm_annual_costs(m, rfm, p)
-            for rfm in m.REGIONAL_FUEL_MARKETS))
-    mod.Cost_Components_Per_Period.append('FuelCostsPerPeriod')
+            rfm_annual_costs(m, rfm, p) for rfm in m.REGIONAL_FUEL_MARKETS
+        ),
+    )
+    mod.Cost_Components_Per_Period.append("FuelCostsPerPeriod")
 
     # Components to link aggregate fuel consumption from project
     # dispatch into market framework
@@ -305,58 +337,65 @@ def define_components(mod):
                 for f in m.FUELS_FOR_GEN[g]:
                     try:
                         _rfm = m.zone_fuel_rfm[m.gen_load_zone[g], f]
-                    except KeyError: # no rfm provides this fuel
+                    except KeyError:  # no rfm provides this fuel
                         pass
                     else:
                         for _p in m.PERIODS_FOR_GEN[g]:
                             d.setdefault((_rfm, _p), []).append(g)
-        return d.pop((rfm, p), []) # pop releases memory
+        return d.pop((rfm, p), [])  # pop releases memory
+
     mod.GENS_FOR_RFM_PERIOD = Set(
-        mod.REGIONAL_FUEL_MARKETS, mod.PERIODS,
-        initialize=GENS_FOR_RFM_PERIOD_rule
+        mod.REGIONAL_FUEL_MARKETS, mod.PERIODS, initialize=GENS_FOR_RFM_PERIOD_rule
     )
+
     def Enforce_Fuel_Consumption_rule(m, rfm, p):
         return m.FuelConsumptionInMarket[rfm, p] == sum(
             m.GenFuelUseRate[g, t, m.rfm_fuel[rfm]] * m.tp_weight_in_year[t]
             for g in m.GENS_FOR_RFM_PERIOD[rfm, p]
             for t in m.TPS_IN_PERIOD[p]
-    )
+        )
+
     mod.Enforce_Fuel_Consumption = Constraint(
-        mod.REGIONAL_FUEL_MARKETS, mod.PERIODS,
-        rule=Enforce_Fuel_Consumption_rule)
+        mod.REGIONAL_FUEL_MARKETS, mod.PERIODS, rule=Enforce_Fuel_Consumption_rule
+    )
 
     mod.GEN_TP_FUELS_UNAVAILABLE = Set(
         initialize=mod.GEN_TP_FUELS,
-        filter=lambda m, g, t, f: \
-            (m.gen_load_zone[g], f) not in m.ZONE_FUELS)
+        filter=lambda m, g, t, f: (m.gen_load_zone[g], f) not in m.ZONE_FUELS,
+    )
     mod.Enforce_Fuel_Unavailability = Constraint(
         mod.GEN_TP_FUELS_UNAVAILABLE,
-        rule=lambda m, g, t, f: m.GenFuelUseRate[g, t, f] == 0)
+        rule=lambda m, g, t, f: m.GenFuelUseRate[g, t, f] == 0,
+    )
 
     mod.AverageFuelCosts = Expression(
-        mod.REGIONAL_FUEL_MARKETS, mod.PERIODS,
+        mod.REGIONAL_FUEL_MARKETS,
+        mod.PERIODS,
         doc="Average fuel costs to allow post-optimization inspection "
-            "and cost allocation.",
+        "and cost allocation.",
         rule=lambda m, rfm, p: (
-            rfm_annual_costs(m, rfm, p) / (
+            rfm_annual_costs(m, rfm, p)
+            / (
                 # Avoid divide-by-zero errors if no fuel is consumed.
-                m.FuelConsumptionInMarket[rfm, p] + 0.0001
+                m.FuelConsumptionInMarket[rfm, p]
+                + 0.0001
             )
-        )
+        ),
     )
 
     def GenFuelCosts_rule(m, g, t, f):
         try:
             rfm = m.zone_fuel_rfm[m.gen_load_zone[g], f]
-        except KeyError: # Fuel is unavailable
+        except KeyError:  # Fuel is unavailable
             return 0.0
         p = m.tp_period[t]
         return m.GenFuelUseRate[g, t, f] * m.AverageFuelCosts[rfm, p]
+
     mod.GenFuelCosts = Expression(
         mod.GEN_TP_FUELS,
         doc="Average cost of fuel consumption, $/hr for post-optimization "
-            "reporting.",
-        rule=GenFuelCosts_rule
+        "reporting.",
+        rule=GenFuelCosts_rule,
     )
 
 
@@ -398,91 +437,116 @@ def load_inputs(mod, switch_data, inputs_dir):
     # message if some columns are not found.
 
     switch_data.load_aug(
-        filename=os.path.join(inputs_dir, 'regional_fuel_markets.csv'),
-        select=('regional_fuel_market', 'fuel'),
+        filename=os.path.join(inputs_dir, "regional_fuel_markets.csv"),
+        select=("regional_fuel_market", "fuel"),
         index=mod.REGIONAL_FUEL_MARKETS,
-        param=(mod.rfm_fuel))
+        param=(mod.rfm_fuel),
+    )
     switch_data.load_aug(
-        filename=os.path.join(inputs_dir, 'fuel_supply_curves.csv'),
-        select=('regional_fuel_market', 'period', 'tier', 'unit_cost',
-                'max_avail_at_cost'),
+        filename=os.path.join(inputs_dir, "fuel_supply_curves.csv"),
+        select=(
+            "regional_fuel_market",
+            "period",
+            "tier",
+            "unit_cost",
+            "max_avail_at_cost",
+        ),
         index=mod.RFM_SUPPLY_TIERS,
-        param=(mod.rfm_supply_tier_cost, mod.rfm_supply_tier_limit))
+        param=(mod.rfm_supply_tier_cost, mod.rfm_supply_tier_limit),
+    )
     switch_data.load_aug(
-        filename=os.path.join(inputs_dir, 'zone_to_regional_fuel_market.csv'),
-        set=mod.ZONE_RFMS)
+        filename=os.path.join(inputs_dir, "zone_to_regional_fuel_market.csv"),
+        set=mod.ZONE_RFMS,
+    )
     switch_data.load_aug(
-        filename=os.path.join(inputs_dir, 'zone_fuel_cost_diff.csv'),
+        filename=os.path.join(inputs_dir, "zone_fuel_cost_diff.csv"),
         optional=True,
-        select=('load_zone', 'fuel', 'period', 'fuel_cost_adder'),
-        param=(mod.zone_fuel_cost_adder))
+        select=("load_zone", "fuel", "period", "fuel_cost_adder"),
+        param=(mod.zone_fuel_cost_adder),
+    )
 
     # Load a simple specifications of costs if the file exists. The
     # actual loading, error checking, and casting into a supply curve is
     # slightly complicated, so I moved that logic to a separate function.
-    path = os.path.join(inputs_dir, 'fuel_cost.csv')
+    path = os.path.join(inputs_dir, "fuel_cost.csv")
     if os.path.isfile(path):
         _load_simple_cost_data(mod, switch_data, path)
 
 
 def _load_simple_cost_data(mod, switch_data, path):
-    with open(path, 'r') as simple_cost_file:
-        simple_cost_dat = list(csv.DictReader(simple_cost_file, delimiter=','))
+    with open(path, "r") as simple_cost_file:
+        simple_cost_dat = list(csv.DictReader(simple_cost_file, delimiter=","))
         # Scan once for error checking
         for row in simple_cost_dat:
-            z = row['load_zone']
-            f = row['fuel']
-            p = int(row['period'])
-            f_cost = float(row['fuel_cost'])
+            z = row["load_zone"]
+            f = row["fuel"]
+            p = int(row["period"])
+            f_cost = float(row["fuel_cost"])
             # Basic data validity checks
-            if z not in switch_data.data(name='LOAD_ZONES'):
+            if z not in switch_data.data(name="LOAD_ZONES"):
                 raise ValueError(
-                    "Load zone " + z + " in zone_simple_fuel_cost.csv is not " +
-                    "a known load zone from load_zones.csv.")
-            if f not in switch_data.data(name='FUELS'):
+                    "Load zone "
+                    + z
+                    + " in zone_simple_fuel_cost.csv is not "
+                    + "a known load zone from load_zones.csv."
+                )
+            if f not in switch_data.data(name="FUELS"):
                 raise ValueError(
-                    "Fuel " + f + " in zone_simple_fuel_cost.csv is not " +
-                    "a known fuel from fuels.csv.")
-            if p not in switch_data.data(name='PERIODS'):
+                    "Fuel "
+                    + f
+                    + " in zone_simple_fuel_cost.csv is not "
+                    + "a known fuel from fuels.csv."
+                )
+            if p not in switch_data.data(name="PERIODS"):
                 raise ValueError(
-                    "Period " + p + " in zone_simple_fuel_cost.csv is not " +
-                    "a known investment period.")
+                    "Period "
+                    + p
+                    + " in zone_simple_fuel_cost.csv is not "
+                    + "a known investment period."
+                )
             # Make sure they aren't overriding a supply curve or
             # regional fuel market defined in previous files.
-            for (z, rfm) in switch_data.data(name='ZONE_RFMS'):
-                if(z == z and
-                   switch_data.data(name='rfm_fuel')[rfm] == f):
+            for (z, rfm) in switch_data.data(name="ZONE_RFMS"):
+                if z == z and switch_data.data(name="rfm_fuel")[rfm] == f:
                     raise ValueError(
-                        "The supply for fuel '" + f + "' for load_zone '" + z +
-                        "' was already registered with the regional fuel " +
-                        "market '" + rfm + "', so you cannot " +
-                        "specify a simple fuel cost for it in " +
-                        "zone_simple_fuel_cost.csv. You either need to delete " +
-                        "that entry from zone_to_regional_fuel_market.csv, or " +
-                        "remove those entries in zone_simple_fuel_cost.csv.")
+                        "The supply for fuel '"
+                        + f
+                        + "' for load_zone '"
+                        + z
+                        + "' was already registered with the regional fuel "
+                        + "market '"
+                        + rfm
+                        + "', so you cannot "
+                        + "specify a simple fuel cost for it in "
+                        + "zone_simple_fuel_cost.csv. You either need to delete "
+                        + "that entry from zone_to_regional_fuel_market.csv, or "
+                        + "remove those entries in zone_simple_fuel_cost.csv."
+                    )
             # Make a new single-load zone regional fuel market.
             rfm = z + "_" + f
-            if rfm in switch_data.data(name='REGIONAL_FUEL_MARKETS'):
+            if rfm in switch_data.data(name="REGIONAL_FUEL_MARKETS"):
                 raise ValueError(
-                    "Trying to construct a simple Regional Fuel Market " +
-                    "called " + rfm + " from data in zone_simple_fuel_cost.csv" +
-                    ", but an RFM of that name already exists. Bailing out!")
+                    "Trying to construct a simple Regional Fuel Market "
+                    + "called "
+                    + rfm
+                    + " from data in zone_simple_fuel_cost.csv"
+                    + ", but an RFM of that name already exists. Bailing out!"
+                )
         # Scan again and actually import the data
         for row in simple_cost_dat:
-            z = row['load_zone']
-            f = row['fuel']
-            p = int(row['period'])
-            f_cost = float(row['fuel_cost'])
+            z = row["load_zone"]
+            f = row["fuel"]
+            p = int(row["period"])
+            f_cost = float(row["fuel_cost"])
             # Make a new single-load zone regional fuel market unless we
             # already defined one in this loop for a different period.
             rfm = z + "_" + f
-            if(rfm not in switch_data.data(name='REGIONAL_FUEL_MARKETS')):
-                switch_data.data(name='REGIONAL_FUEL_MARKETS').append(rfm)
-                switch_data.data(name='rfm_fuel')[rfm] = f
-                switch_data.data(name='ZONE_RFMS').append((z, rfm))
+            if rfm not in switch_data.data(name="REGIONAL_FUEL_MARKETS"):
+                switch_data.data(name="REGIONAL_FUEL_MARKETS").append(rfm)
+                switch_data.data(name="rfm_fuel")[rfm] = f
+                switch_data.data(name="ZONE_RFMS").append((z, rfm))
             # Make a single supply tier for this RFM and period
             st = 0
-            switch_data.data(name='RFM_SUPPLY_TIERS').append((rfm, p, st))
-            switch_data.data(name='rfm_supply_tier_cost')[rfm, p, st] = f_cost
-            switch_data.data(name='rfm_supply_tier_limit')[rfm, p, st] = \
-                float('inf')
+            switch_data.data(name="RFM_SUPPLY_TIERS").append((rfm, p, st))
+            switch_data.data(name="rfm_supply_tier_cost")[rfm, p, st] = f_cost
+            switch_data.data(name="rfm_supply_tier_limit")[rfm, p, st] = float("inf")

--- a/switch_model/energy_sources/fuel_costs/markets_expansion.py
+++ b/switch_model/energy_sources/fuel_costs/markets_expansion.py
@@ -21,7 +21,8 @@ Defines model components to allow capital investment to expand fuel markets.
 import os
 from pyomo.environ import *
 
-infinity = float('inf')
+infinity = float("inf")
+
 
 def define_components(m):
     """
@@ -88,16 +89,16 @@ def define_components(m):
     # during each period note: this must be zero if a tier has unlimited
     # capacity, to avoid having infinite cost
     m.rfm_supply_tier_fixed_cost = Param(
-        m.RFM_SUPPLY_TIERS, default=0.0,
-        validate=lambda m, v, r, p, st:
-            v == 0.0 or m.rfm_supply_tier_limit[r, p, st] < infinity
+        m.RFM_SUPPLY_TIERS,
+        default=0.0,
+        validate=lambda m, v, r, p, st: v == 0.0
+        or m.rfm_supply_tier_limit[r, p, st] < infinity,
     )
 
     # lifetime for each tier, once it is placed in service
     # (default is one period)
     m.rfm_supply_tier_max_age = Param(
-        m.RFM_SUPPLY_TIERS,
-        default=lambda m, r, p, st: m.period_length_years[p]
+        m.RFM_SUPPLY_TIERS, default=lambda m, r, p, st: m.period_length_years[p]
     )
 
     # Note: in large regions, a tier represents a block of expandable capacity,
@@ -118,22 +119,21 @@ def define_components(m):
                 and vintage + m.rfm_supply_tier_max_age[r, vintage, st]
                 > m.period_start[p]
             )
-        )
+        ),
     )
 
     # Don't double-activate any tier
     m.Only_One_RFMSupplyTierActive = Constraint(
-        m.RFM_SUPPLY_TIERS,
-        rule=lambda m, r, p, st: RFMSupplyTierActive[r, p, st] <= 1
+        m.RFM_SUPPLY_TIERS, rule=lambda m, r, p, st: RFMSupplyTierActive[r, p, st] <= 1
     )
 
     # force all unlimited tiers to be activated (since they must have no cost,
     # and to avoid a limit of 0.0 * infinity in the constraint below)
-    m.Force_Activate_Unlimited_RFM_Supply_Tier = Constraint(m.RFM_SUPPLY_TIERS,
-        rule=lambda m, r, p, st:
-            (m.RFMSupplyTierActive[r, p, st] == 1)
-            if (m.rfm_supply_tier_limit[r, p, st] == infinity)
-            else Constraint.Skip
+    m.Force_Activate_Unlimited_RFM_Supply_Tier = Constraint(
+        m.RFM_SUPPLY_TIERS,
+        rule=lambda m, r, p, st: (m.RFMSupplyTierActive[r, p, st] == 1)
+        if (m.rfm_supply_tier_limit[r, p, st] == infinity)
+        else Constraint.Skip,
     )
 
     # only allow delivery from activated tiers
@@ -142,12 +142,12 @@ def define_components(m):
     # complementary
     m.Enforce_RFM_Supply_Tier_Activated = Constraint(
         m.RFM_SUPPLY_TIERS,
-        rule=lambda m, r, p, st:
-            (
-                m.ConsumeFuelTier[r, p, st]
-                <=
-                m.RFMSupplyTierActive[r, p, st] * m.rfm_supply_tier_limit[r, p, st]
-            ) if m.rfm_supply_tier_limit[r, p, st] < infinity else Constraint.Skip
+        rule=lambda m, r, p, st: (
+            m.ConsumeFuelTier[r, p, st]
+            <= m.RFMSupplyTierActive[r, p, st] * m.rfm_supply_tier_limit[r, p, st]
+        )
+        if m.rfm_supply_tier_limit[r, p, st] < infinity
+        else Constraint.Skip,
     )
 
     # total cost incurred for all the activated supply tiers
@@ -156,7 +156,8 @@ def define_components(m):
         rule=lambda m, p: sum(
             (
                 # note: we dance around projects with unlimited supply and 0.0 fixed cost
-                0.0 if m.rfm_supply_tier_fixed_cost[rfm_st] == 0.0
+                0.0
+                if m.rfm_supply_tier_fixed_cost[rfm_st] == 0.0
                 else (
                     m.rfm_supply_tier_fixed_cost[rfm_st]
                     * m.RFMSupplyTierActive[rfm_st]
@@ -165,13 +166,15 @@ def define_components(m):
             )
             for r in m.REGIONAL_FUEL_MARKETS
             for rfm_st in m.SUPPLY_TIERS_FOR_RFM_PERIOD[r, p]
-        )
+        ),
     )
-    m.Cost_Components_Per_Period.append('RFM_Fixed_Costs_Annual')
+    m.Cost_Components_Per_Period.append("RFM_Fixed_Costs_Annual")
+
 
 def load_inputs(m, switch_data, inputs_dir):
     switch_data.load_aug(
         optional=True,
-        filename=os.path.join(inputs_dir, 'fuel_supply_curves.csv'),
-        select=('regional_fuel_market', 'period', 'tier', 'fixed_cost', 'max_age'),
-        param=(m.rfm_supply_tier_fixed_cost,m.rfm_supply_tier_max_age))
+        filename=os.path.join(inputs_dir, "fuel_supply_curves.csv"),
+        select=("regional_fuel_market", "period", "tier", "fixed_cost", "max_age"),
+        param=(m.rfm_supply_tier_fixed_cost, m.rfm_supply_tier_max_age),
+    )

--- a/switch_model/energy_sources/fuel_costs/simple.py
+++ b/switch_model/energy_sources/fuel_costs/simple.py
@@ -11,9 +11,14 @@ supply curves. This is mutually exclusive with the fuel_markets module.
 import os
 from pyomo.environ import *
 
-dependencies = 'switch_model.timescales', 'switch_model.balancing.load_zones',\
-    'switch_model.energy_sources.properties.properties',\
-    'switch_model.generators.core.build', 'switch_model.generators.core.dispatch'
+dependencies = (
+    "switch_model.timescales",
+    "switch_model.balancing.load_zones",
+    "switch_model.energy_sources.properties.properties",
+    "switch_model.generators.core.build",
+    "switch_model.generators.core.dispatch",
+)
+
 
 def define_components(mod):
     """
@@ -46,26 +51,25 @@ def define_components(mod):
     mod.ZONE_FUEL_PERIODS = Set(
         dimen=3,
         validate=lambda m, z, f, p: (
-            z in m.LOAD_ZONES and
-            f in m.FUELS and
-            p in m.PERIODS))
-    mod.fuel_cost = Param(
-        mod.ZONE_FUEL_PERIODS,
-        within=NonNegativeReals)
-    mod.min_data_check('ZONE_FUEL_PERIODS', 'fuel_cost')
+            z in m.LOAD_ZONES and f in m.FUELS and p in m.PERIODS
+        ),
+    )
+    mod.fuel_cost = Param(mod.ZONE_FUEL_PERIODS, within=NonNegativeReals)
+    mod.min_data_check("ZONE_FUEL_PERIODS", "fuel_cost")
 
     mod.GEN_TP_FUELS_UNAVAILABLE = Set(
         initialize=mod.GEN_TP_FUELS,
-        filter=lambda m, g, t, f:
-            (m.gen_load_zone[g], f, m.tp_period[t]) not in m.ZONE_FUEL_PERIODS
+        filter=lambda m, g, t, f: (m.gen_load_zone[g], f, m.tp_period[t])
+        not in m.ZONE_FUEL_PERIODS,
     )
     mod.Enforce_Fuel_Unavailability = Constraint(
         mod.GEN_TP_FUELS_UNAVAILABLE,
-        rule=lambda m, g, t, f: m.GenFuelUseRate[g, t, f] == 0)
+        rule=lambda m, g, t, f: m.GenFuelUseRate[g, t, f] == 0,
+    )
 
     # Summarize total fuel costs in each timepoint for the objective function
     def FuelCostsPerTP_rule(m, t):
-        if not hasattr(m, 'FuelCostsPerTP_dict'):
+        if not hasattr(m, "FuelCostsPerTP_dict"):
             # cache all Fuel_Cost_TP values in a dictionary (created in one pass)
             m.FuelCostsPerTP_dict = {t2: 0.0 for t2 in m.TIMEPOINTS}
             for (g, t2, f) in m.GEN_TP_FUELS:
@@ -77,8 +81,9 @@ def define_components(mod):
         # return a result from the dictionary and pop the element each time
         # to release memory
         return m.FuelCostsPerTP_dict.pop(t)
+
     mod.FuelCostsPerTP = Expression(mod.TIMEPOINTS, rule=FuelCostsPerTP_rule)
-    mod.Cost_Components_Per_TP.append('FuelCostsPerTP')
+    mod.Cost_Components_Per_TP.append("FuelCostsPerTP")
 
 
 def load_inputs(mod, switch_data, inputs_dir):
@@ -92,6 +97,7 @@ def load_inputs(mod, switch_data, inputs_dir):
     """
 
     switch_data.load_aug(
-        filename=os.path.join(inputs_dir, 'fuel_cost.csv'),
+        filename=os.path.join(inputs_dir, "fuel_cost.csv"),
         index=mod.ZONE_FUEL_PERIODS,
-        param=[mod.fuel_cost])
+        param=[mod.fuel_cost],
+    )

--- a/switch_model/energy_sources/properties.py
+++ b/switch_model/energy_sources/properties.py
@@ -10,7 +10,8 @@ for the Switch model.
 import os
 from pyomo.environ import *
 
-dependencies = 'switch_model.timescales', 'switch_model.balancing.load_zones'
+dependencies = "switch_model.timescales", "switch_model.balancing.load_zones"
+
 
 def define_components(mod):
     """
@@ -93,18 +94,17 @@ def define_components(mod):
     mod.NON_FUEL_ENERGY_SOURCES = Set()
     mod.FUELS = Set()
     mod.f_co2_intensity = Param(mod.FUELS, within=NonNegativeReals)
-    mod.f_upstream_co2_intensity = Param(
-        mod.FUELS, within=Reals, default=0)
-    mod.min_data_check('f_co2_intensity')
+    mod.f_upstream_co2_intensity = Param(mod.FUELS, within=Reals, default=0)
+    mod.min_data_check("f_co2_intensity")
     # Ensure that fuel and non-fuel sets have no overlap.
     mod.e_source_is_fuel_or_not_check = BuildCheck(
-        rule=lambda m: len(m.FUELS & m.NON_FUEL_ENERGY_SOURCES) == 0)
+        rule=lambda m: len(m.FUELS & m.NON_FUEL_ENERGY_SOURCES) == 0
+    )
 
     # ENERGY_SOURCES is the union of fuel and non-fuels sets. Pipe | is
     # the union operator for Pyomo sets.
-    mod.ENERGY_SOURCES = Set(
-        initialize=mod.NON_FUEL_ENERGY_SOURCES | mod.FUELS)
-    mod.min_data_check('ENERGY_SOURCES')
+    mod.ENERGY_SOURCES = Set(initialize=mod.NON_FUEL_ENERGY_SOURCES | mod.FUELS)
+    mod.min_data_check("ENERGY_SOURCES")
 
 
 def load_inputs(mod, switch_data, inputs_dir):
@@ -138,11 +138,13 @@ def load_inputs(mod, switch_data, inputs_dir):
 
     switch_data.load_aug(
         optional=True,
-        filename=os.path.join(inputs_dir, 'non_fuel_energy_sources.csv'),
-        set=('NON_FUEL_ENERGY_SOURCES'))
+        filename=os.path.join(inputs_dir, "non_fuel_energy_sources.csv"),
+        set=("NON_FUEL_ENERGY_SOURCES"),
+    )
     switch_data.load_aug(
         optional=True,
-        filename=os.path.join(inputs_dir, 'fuels.csv'),
-        select=('fuel', 'co2_intensity', 'upstream_co2_intensity'),
+        filename=os.path.join(inputs_dir, "fuels.csv"),
+        select=("fuel", "co2_intensity", "upstream_co2_intensity"),
         index=mod.FUELS,
-        param=(mod.f_co2_intensity, mod.f_upstream_co2_intensity))
+        param=(mod.f_co2_intensity, mod.f_upstream_co2_intensity),
+    )

--- a/switch_model/financials.py
+++ b/switch_model/financials.py
@@ -11,7 +11,8 @@ from pyomo.environ import *
 import os
 import pandas as pd
 
-dependencies = 'switch_model.timescales'
+dependencies = "switch_model.timescales"
+
 
 def capital_recovery_factor(ir, t):
     """
@@ -35,7 +36,7 @@ def capital_recovery_factor(ir, t):
     rate, paid over 20 years is 0.09439. If the principal was $100, loan\
     payments would be $9.44
     """
-    return 1/t if ir == 0 else ir/(1-(1+ir)**-t)
+    return 1 / t if ir == 0 else ir / (1 - (1 + ir) ** -t)
 
 
 def uniform_series_to_present_value(dr, t):
@@ -60,7 +61,7 @@ def uniform_series_to_present_value(dr, t):
         round(1/capital_recovery_factor(.07,20),7)
     True
     """
-    return t if dr == 0 else (1-(1+dr)**-t)/dr
+    return t if dr == 0 else (1 - (1 + dr) ** -t) / dr
 
 
 def future_to_present_value(dr, t):
@@ -71,7 +72,7 @@ def future_to_present_value(dr, t):
     >>> round(future_to_present_value(.07,10),7)
     0.5083493
     """
-    return (1+dr)**-t
+    return (1 + dr) ** -t
 
 
 def present_to_future_value(ir, t):
@@ -87,7 +88,8 @@ def present_to_future_value(ir, t):
         future_to_present_value(.07,10),7) == 1
     True
     """
-    return (1+ir)**t
+    return (1 + ir) ** t
+
 
 def define_dynamic_lists(mod):
     """
@@ -114,6 +116,7 @@ def define_dynamic_lists(mod):
     """
     mod.Cost_Components_Per_TP = []
     mod.Cost_Components_Per_Period = []
+
 
 def define_components(mod):
     """
@@ -221,23 +224,26 @@ def define_components(mod):
     mod.base_financial_year = Param(within=NonNegativeReals)
     mod.interest_rate = Param(within=NonNegativeReals)
     mod.discount_rate = Param(
-        within=NonNegativeReals, default=lambda m: value(m.interest_rate))
-    mod.min_data_check('base_financial_year', 'interest_rate')
+        within=NonNegativeReals, default=lambda m: value(m.interest_rate)
+    )
+    mod.min_data_check("base_financial_year", "interest_rate")
     mod.bring_annual_costs_to_base_year = Param(
         mod.PERIODS,
         within=NonNegativeReals,
         initialize=lambda m, p: (
-            uniform_series_to_present_value(
-                m.discount_rate, m.period_length_years[p]) *
-            future_to_present_value(
-                m.discount_rate,
-                m.period_start[p] - m.base_financial_year)))
+            uniform_series_to_present_value(m.discount_rate, m.period_length_years[p])
+            * future_to_present_value(
+                m.discount_rate, m.period_start[p] - m.base_financial_year
+            )
+        ),
+    )
     mod.bring_timepoint_costs_to_base_year = Param(
         mod.TIMEPOINTS,
         within=NonNegativeReals,
         initialize=lambda m, t: (
-            m.bring_annual_costs_to_base_year[m.tp_period[t]] *
-            m.tp_weight_in_year[t]))
+            m.bring_annual_costs_to_base_year[m.tp_period[t]] * m.tp_weight_in_year[t]
+        ),
+    )
 
 
 def define_dynamic_components(mod):
@@ -270,7 +276,8 @@ def define_dynamic_components(mod):
     def calc_tp_costs_in_period(m, t):
         return sum(
             getattr(m, tp_cost)[t] * m.tp_weight_in_year[t]
-            for tp_cost in m.Cost_Components_Per_TP)
+            for tp_cost in m.Cost_Components_Per_TP
+        )
 
     # Note: multiply annual costs by a conversion factor if running this
     # model on an intentional subset of annual data whose weights do not
@@ -278,31 +285,29 @@ def define_dynamic_components(mod):
     # This would also require disabling the validate_time_weights check.
     def calc_annual_costs_in_period(m, p):
         return sum(
-            getattr(m, annual_cost)[p]
-            for annual_cost in m.Cost_Components_Per_Period)
+            getattr(m, annual_cost)[p] for annual_cost in m.Cost_Components_Per_Period
+        )
 
     def calc_sys_costs_per_period(m, p):
         return (
             # All annual payments in the period
             (
-                calc_annual_costs_in_period(m, p) +
-                sum(calc_tp_costs_in_period(m, t) for t in m.TPS_IN_PERIOD[p])
-            ) *
+                calc_annual_costs_in_period(m, p)
+                + sum(calc_tp_costs_in_period(m, t) for t in m.TPS_IN_PERIOD[p])
+            )
+            *
             # Conversion from annual costs to base year
             m.bring_annual_costs_to_base_year[p]
         )
 
-    mod.SystemCostPerPeriod = Expression(
-        mod.PERIODS,
-        rule=calc_sys_costs_per_period)
+    mod.SystemCostPerPeriod = Expression(mod.PERIODS, rule=calc_sys_costs_per_period)
     # starting with Pyomo 4.2, it is impossible to call Objective.reconstruct()
     # or calculate terms like Objective / <some other model component>,
     # so it's best to define a separate expression and use that for these purposes.
     mod.SystemCost = Expression(
-        rule=lambda m: sum(m.SystemCostPerPeriod[p] for p in m.PERIODS))
-    mod.Minimize_System_Cost = Objective(
-        rule=lambda m: m.SystemCost,
-        sense=minimize)
+        rule=lambda m: sum(m.SystemCostPerPeriod[p] for p in m.PERIODS)
+    )
+    mod.Minimize_System_Cost = Objective(rule=lambda m: m.SystemCost, sense=minimize)
 
 
 def load_inputs(mod, switch_data, inputs_dir):
@@ -314,30 +319,33 @@ def load_inputs(mod, switch_data, inputs_dir):
     the second.
     """
     switch_data.load_aug(
-        filename=os.path.join(inputs_dir, 'financials.csv'),
+        filename=os.path.join(inputs_dir, "financials.csv"),
         optional=False,
-        param=(mod.base_financial_year, mod.interest_rate, mod.discount_rate)
+        param=(mod.base_financial_year, mod.interest_rate, mod.discount_rate),
     )
+
 
 def post_solve(instance, outdir):
     m = instance
     # Overall electricity costs, if appropriate (some models may be gas-only)
-    if hasattr(m, 'zone_total_demand_in_period_mwh'):
+    if hasattr(m, "zone_total_demand_in_period_mwh"):
         normalized_dat = [
             {
-            	"PERIOD": p,
-            	"SystemCostPerPeriod_NPV": value(m.SystemCostPerPeriod[p]),
-            	"SystemCostPerPeriod_Real": value(
-            	    m.SystemCostPerPeriod[p] / m.bring_annual_costs_to_base_year[p]
-            	),
-            	"EnergyCostReal_per_MWh": value(
-            	    m.SystemCostPerPeriod[p] / m.bring_annual_costs_to_base_year[p] /
-            	    sum(m.zone_total_demand_in_period_mwh[z,p] for z in m.LOAD_ZONES)
-            	),
-            	"SystemDemand_MWh": value(sum(
-            	    m.zone_total_demand_in_period_mwh[z,p] for z in m.LOAD_ZONES
-            	))
-            } for p in m.PERIODS
+                "PERIOD": p,
+                "SystemCostPerPeriod_NPV": value(m.SystemCostPerPeriod[p]),
+                "SystemCostPerPeriod_Real": value(
+                    m.SystemCostPerPeriod[p] / m.bring_annual_costs_to_base_year[p]
+                ),
+                "EnergyCostReal_per_MWh": value(
+                    m.SystemCostPerPeriod[p]
+                    / m.bring_annual_costs_to_base_year[p]
+                    / sum(m.zone_total_demand_in_period_mwh[z, p] for z in m.LOAD_ZONES)
+                ),
+                "SystemDemand_MWh": value(
+                    sum(m.zone_total_demand_in_period_mwh[z, p] for z in m.LOAD_ZONES)
+                ),
+            }
+            for p in m.PERIODS
         ]
         df = pd.DataFrame(normalized_dat)
         df.set_index(["PERIOD"], inplace=True)
@@ -346,32 +354,37 @@ def post_solve(instance, outdir):
     # Itemized annual costs
     annualized_costs = [
         {
-        	"PERIOD": p,
-        	"Component": annual_cost,
-        	"Component_type": "annual",
-        	"AnnualCost_NPV": value(
-        	    getattr(m, annual_cost)[p] * m.bring_annual_costs_to_base_year[p]
-        	),
-        	"AnnualCost_Real": value(getattr(m, annual_cost)[p])
-        } for p in m.PERIODS for annual_cost in m.Cost_Components_Per_Period
+            "PERIOD": p,
+            "Component": annual_cost,
+            "Component_type": "annual",
+            "AnnualCost_NPV": value(
+                getattr(m, annual_cost)[p] * m.bring_annual_costs_to_base_year[p]
+            ),
+            "AnnualCost_Real": value(getattr(m, annual_cost)[p]),
+        }
+        for p in m.PERIODS
+        for annual_cost in m.Cost_Components_Per_Period
     ] + [
         {
-        	"PERIOD": p,
-        	"Component": tp_cost,
-        	"Component_type": "timepoint",
-        	"AnnualCost_NPV": value(sum(
-        	    getattr(m, tp_cost)[t] * m.tp_weight_in_year[t]
-        	    for t in m.TPS_IN_PERIOD[p]
-        	) * m.bring_annual_costs_to_base_year[p]),
-        	"AnnualCost_Real": value(sum(
-        	    getattr(m, tp_cost)[t] * m.tp_weight_in_year[t]
-        	    for t in m.TPS_IN_PERIOD[p]
-        	))
-        } for p in m.PERIODS for tp_cost in m.Cost_Components_Per_TP
+            "PERIOD": p,
+            "Component": tp_cost,
+            "Component_type": "timepoint",
+            "AnnualCost_NPV": value(
+                sum(
+                    getattr(m, tp_cost)[t] * m.tp_weight_in_year[t]
+                    for t in m.TPS_IN_PERIOD[p]
+                )
+                * m.bring_annual_costs_to_base_year[p]
+            ),
+            "AnnualCost_Real": value(
+                sum(
+                    getattr(m, tp_cost)[t] * m.tp_weight_in_year[t]
+                    for t in m.TPS_IN_PERIOD[p]
+                )
+            ),
+        }
+        for p in m.PERIODS
+        for tp_cost in m.Cost_Components_Per_TP
     ]
-    df = (
-        pd.DataFrame(annualized_costs)
-        .set_index(["PERIOD", "Component"])
-        .sort_index()
-    )
+    df = pd.DataFrame(annualized_costs).set_index(["PERIOD", "Component"]).sort_index()
     df.to_csv(os.path.join(outdir, "costs_itemized.csv"))

--- a/switch_model/generators/core/__init__.py
+++ b/switch_model/generators/core/__init__.py
@@ -9,5 +9,6 @@ The core modules in the package are build and dispatch.
 
 """
 core_modules = [
-    'switch_model.generators.core.build',
-    'switch_model.generators.core.dispatch']
+    "switch_model.generators.core.build",
+    "switch_model.generators.core.dispatch",
+]

--- a/switch_model/generators/core/build.py
+++ b/switch_model/generators/core/build.py
@@ -10,8 +10,13 @@ from pyomo.environ import *
 from switch_model.financials import capital_recovery_factor as crf
 from switch_model.reporting import write_table
 
-dependencies = 'switch_model.timescales', 'switch_model.balancing.load_zones',\
-    'switch_model.financials', 'switch_model.energy_sources.properties.properties'
+dependencies = (
+    "switch_model.timescales",
+    "switch_model.balancing.load_zones",
+    "switch_model.financials",
+    "switch_model.energy_sources.properties.properties",
+)
+
 
 def define_components(mod):
     """
@@ -190,30 +195,43 @@ def define_components(mod):
     mod.GENERATION_PROJECTS = Set()
     mod.gen_dbid = Param(mod.GENERATION_PROJECTS, default=lambda m, g: g)
     mod.gen_tech = Param(mod.GENERATION_PROJECTS)
-    mod.GENERATION_TECHNOLOGIES = Set(initialize=lambda m:
-        {m.gen_tech[g] for g in m.GENERATION_PROJECTS}
+    mod.GENERATION_TECHNOLOGIES = Set(
+        initialize=lambda m: {m.gen_tech[g] for g in m.GENERATION_PROJECTS}
     )
-    mod.gen_energy_source = Param(mod.GENERATION_PROJECTS,
-        validate=lambda m,val,g: val in m.ENERGY_SOURCES or val == "multiple")
+    mod.gen_energy_source = Param(
+        mod.GENERATION_PROJECTS,
+        validate=lambda m, val, g: val in m.ENERGY_SOURCES or val == "multiple",
+    )
     mod.gen_load_zone = Param(mod.GENERATION_PROJECTS, within=mod.LOAD_ZONES)
     mod.gen_max_age = Param(mod.GENERATION_PROJECTS, within=PositiveIntegers)
     mod.gen_is_variable = Param(mod.GENERATION_PROJECTS, within=Boolean)
     mod.gen_is_baseload = Param(mod.GENERATION_PROJECTS, within=Boolean, default=False)
     mod.gen_is_cogen = Param(mod.GENERATION_PROJECTS, within=Boolean, default=False)
-    mod.gen_is_distributed = Param(mod.GENERATION_PROJECTS, within=Boolean, default=False)
-    mod.gen_scheduled_outage_rate = Param(mod.GENERATION_PROJECTS,
-        within=PercentFraction, default=0)
-    mod.gen_forced_outage_rate = Param(mod.GENERATION_PROJECTS,
-        within=PercentFraction, default=0)
-    mod.min_data_check('GENERATION_PROJECTS', 'gen_tech', 'gen_energy_source',
-        'gen_load_zone', 'gen_max_age', 'gen_is_variable')
+    mod.gen_is_distributed = Param(
+        mod.GENERATION_PROJECTS, within=Boolean, default=False
+    )
+    mod.gen_scheduled_outage_rate = Param(
+        mod.GENERATION_PROJECTS, within=PercentFraction, default=0
+    )
+    mod.gen_forced_outage_rate = Param(
+        mod.GENERATION_PROJECTS, within=PercentFraction, default=0
+    )
+    mod.min_data_check(
+        "GENERATION_PROJECTS",
+        "gen_tech",
+        "gen_energy_source",
+        "gen_load_zone",
+        "gen_max_age",
+        "gen_is_variable",
+    )
 
     """Construct GENS_* indexed sets efficiently with a
     'construction dictionary' pattern: on the first call, make a single
     traversal through all generation projects to generate a complete index,
     use that for subsequent lookups, and clean up at the last call."""
+
     def GENS_IN_ZONE_init(m, z):
-        if not hasattr(m, 'GENS_IN_ZONE_dict'):
+        if not hasattr(m, "GENS_IN_ZONE_dict"):
             m.GENS_IN_ZONE_dict = {_z: [] for _z in m.LOAD_ZONES}
             for g in m.GENERATION_PROJECTS:
                 m.GENS_IN_ZONE_dict[m.gen_load_zone[g]].append(g)
@@ -221,22 +239,21 @@ def define_components(mod):
         if not m.GENS_IN_ZONE_dict:
             del m.GENS_IN_ZONE_dict
         return result
-    mod.GENS_IN_ZONE = Set(
-        mod.LOAD_ZONES,
-        initialize=GENS_IN_ZONE_init
-    )
+
+    mod.GENS_IN_ZONE = Set(mod.LOAD_ZONES, initialize=GENS_IN_ZONE_init)
     mod.VARIABLE_GENS = Set(
-        initialize=mod.GENERATION_PROJECTS,
-        filter=lambda m, g: m.gen_is_variable[g])
+        initialize=mod.GENERATION_PROJECTS, filter=lambda m, g: m.gen_is_variable[g]
+    )
     mod.VARIABLE_GENS_IN_ZONE = Set(
         mod.LOAD_ZONES,
-        initialize=lambda m, z: [g for g in m.GENS_IN_ZONE[z] if m.gen_is_variable[g]])
+        initialize=lambda m, z: [g for g in m.GENS_IN_ZONE[z] if m.gen_is_variable[g]],
+    )
     mod.BASELOAD_GENS = Set(
-        initialize=mod.GENERATION_PROJECTS,
-        filter=lambda m, g: m.gen_is_baseload[g])
+        initialize=mod.GENERATION_PROJECTS, filter=lambda m, g: m.gen_is_baseload[g]
+    )
 
     def GENS_BY_TECHNOLOGY_init(m, t):
-        if not hasattr(m, 'GENS_BY_TECH_dict'):
+        if not hasattr(m, "GENS_BY_TECH_dict"):
             m.GENS_BY_TECH_dict = {_t: [] for _t in m.GENERATION_TECHNOLOGIES}
             for g in m.GENERATION_PROJECTS:
                 m.GENS_BY_TECH_dict[m.gen_tech[g]].append(g)
@@ -244,46 +261,47 @@ def define_components(mod):
         if not m.GENS_BY_TECH_dict:
             del m.GENS_BY_TECH_dict
         return result
+
     mod.GENS_BY_TECHNOLOGY = Set(
-        mod.GENERATION_TECHNOLOGIES,
-        initialize=GENS_BY_TECHNOLOGY_init
+        mod.GENERATION_TECHNOLOGIES, initialize=GENS_BY_TECHNOLOGY_init
     )
 
     mod.CAPACITY_LIMITED_GENS = Set(within=mod.GENERATION_PROJECTS)
     mod.gen_capacity_limit_mw = Param(
-        mod.CAPACITY_LIMITED_GENS, within=NonNegativeReals)
+        mod.CAPACITY_LIMITED_GENS, within=NonNegativeReals
+    )
     mod.DISCRETELY_SIZED_GENS = Set(within=mod.GENERATION_PROJECTS)
-    mod.gen_unit_size = Param(
-        mod.DISCRETELY_SIZED_GENS, within=PositiveReals)
+    mod.gen_unit_size = Param(mod.DISCRETELY_SIZED_GENS, within=PositiveReals)
     mod.CCS_EQUIPPED_GENS = Set(within=mod.GENERATION_PROJECTS)
     mod.gen_ccs_capture_efficiency = Param(
-        mod.CCS_EQUIPPED_GENS, within=PercentFraction)
-    mod.gen_ccs_energy_load = Param(
-        mod.CCS_EQUIPPED_GENS, within=PercentFraction)
+        mod.CCS_EQUIPPED_GENS, within=PercentFraction
+    )
+    mod.gen_ccs_energy_load = Param(mod.CCS_EQUIPPED_GENS, within=PercentFraction)
 
     mod.gen_uses_fuel = Param(
         mod.GENERATION_PROJECTS,
         initialize=lambda m, g: (
-            m.gen_energy_source[g] in m.FUELS
-                or m.gen_energy_source[g] == "multiple"))
+            m.gen_energy_source[g] in m.FUELS or m.gen_energy_source[g] == "multiple"
+        ),
+    )
     mod.NON_FUEL_BASED_GENS = Set(
-        initialize=mod.GENERATION_PROJECTS,
-        filter=lambda m, g: not m.gen_uses_fuel[g])
+        initialize=mod.GENERATION_PROJECTS, filter=lambda m, g: not m.gen_uses_fuel[g]
+    )
     mod.FUEL_BASED_GENS = Set(
-        initialize=mod.GENERATION_PROJECTS,
-        filter=lambda m, g: m.gen_uses_fuel[g])
+        initialize=mod.GENERATION_PROJECTS, filter=lambda m, g: m.gen_uses_fuel[g]
+    )
 
-    mod.gen_full_load_heat_rate = Param(
-        mod.FUEL_BASED_GENS,
-        within=NonNegativeReals)
+    mod.gen_full_load_heat_rate = Param(mod.FUEL_BASED_GENS, within=NonNegativeReals)
     mod.MULTIFUEL_GENS = Set(
         initialize=mod.GENERATION_PROJECTS,
-        filter=lambda m, g: m.gen_energy_source[g] == "multiple")
+        filter=lambda m, g: m.gen_energy_source[g] == "multiple",
+    )
     mod.MULTI_FUEL_GEN_FUELS = Set(
-        dimen=2,
-        validate=lambda m, g, f: g in m.MULTIFUEL_GENS and f in m.FUELS)
+        dimen=2, validate=lambda m, g, f: g in m.MULTIFUEL_GENS and f in m.FUELS
+    )
+
     def FUELS_FOR_MULTIFUEL_GEN_init(m, g):
-        if not hasattr(m, 'FUELS_FOR_MULTIFUEL_GEN_dict'):
+        if not hasattr(m, "FUELS_FOR_MULTIFUEL_GEN_dict"):
             m.FUELS_FOR_MULTIFUEL_GEN_dict = {_g: [] for _g in m.MULTIFUEL_GENS}
             for _g, f in m.MULTI_FUEL_GEN_FUELS:
                 m.FUELS_FOR_MULTIFUEL_GEN_dict[_g].append(f)
@@ -291,18 +309,21 @@ def define_components(mod):
         if not m.FUELS_FOR_MULTIFUEL_GEN_dict:
             del m.FUELS_FOR_MULTIFUEL_GEN_dict
         return result
+
     mod.FUELS_FOR_MULTIFUEL_GEN = Set(
-        mod.MULTIFUEL_GENS, within=mod.FUELS,
-        initialize=FUELS_FOR_MULTIFUEL_GEN_init
+        mod.MULTIFUEL_GENS, within=mod.FUELS, initialize=FUELS_FOR_MULTIFUEL_GEN_init
     )
-    mod.FUELS_FOR_GEN = Set(mod.FUEL_BASED_GENS,
+    mod.FUELS_FOR_GEN = Set(
+        mod.FUEL_BASED_GENS,
         initialize=lambda m, g: (
             m.FUELS_FOR_MULTIFUEL_GEN[g]
             if g in m.MULTIFUEL_GENS
-            else [m.gen_energy_source[g]]))
+            else [m.gen_energy_source[g]]
+        ),
+    )
 
     def GENS_BY_ENERGY_SOURCE_init(m, e):
-        if not hasattr(m, 'GENS_BY_ENERGY_dict'):
+        if not hasattr(m, "GENS_BY_ENERGY_dict"):
             m.GENS_BY_ENERGY_dict = {_e: [] for _e in m.ENERGY_SOURCES}
             for g in m.GENERATION_PROJECTS:
                 if g in m.FUEL_BASED_GENS:
@@ -314,34 +335,32 @@ def define_components(mod):
         if not m.GENS_BY_ENERGY_dict:
             del m.GENS_BY_ENERGY_dict
         return result
+
     mod.GENS_BY_ENERGY_SOURCE = Set(
-        mod.ENERGY_SOURCES,
-        initialize=GENS_BY_ENERGY_SOURCE_init
+        mod.ENERGY_SOURCES, initialize=GENS_BY_ENERGY_SOURCE_init
     )
     mod.GENS_BY_NON_FUEL_ENERGY_SOURCE = Set(
-        mod.NON_FUEL_ENERGY_SOURCES,
-        initialize=lambda m, s: m.GENS_BY_ENERGY_SOURCE[s]
+        mod.NON_FUEL_ENERGY_SOURCES, initialize=lambda m, s: m.GENS_BY_ENERGY_SOURCE[s]
     )
     mod.GENS_BY_FUEL = Set(
-        mod.FUELS,
-        initialize=lambda m, f: m.GENS_BY_ENERGY_SOURCE[f]
+        mod.FUELS, initialize=lambda m, f: m.GENS_BY_ENERGY_SOURCE[f]
     )
 
-    mod.PREDETERMINED_GEN_BLD_YRS = Set(
-        dimen=2)
+    mod.PREDETERMINED_GEN_BLD_YRS = Set(dimen=2)
     mod.GEN_BLD_YRS = Set(
         dimen=2,
         validate=lambda m, g, bld_yr: (
-            (g, bld_yr) in m.PREDETERMINED_GEN_BLD_YRS or
-            (g, bld_yr) in m.GENERATION_PROJECTS * m.PERIODS))
+            (g, bld_yr) in m.PREDETERMINED_GEN_BLD_YRS
+            or (g, bld_yr) in m.GENERATION_PROJECTS * m.PERIODS
+        ),
+    )
     mod.NEW_GEN_BLD_YRS = Set(
-        dimen=2,
-        initialize=lambda m: m.GEN_BLD_YRS - m.PREDETERMINED_GEN_BLD_YRS)
+        dimen=2, initialize=lambda m: m.GEN_BLD_YRS - m.PREDETERMINED_GEN_BLD_YRS
+    )
     mod.gen_predetermined_cap = Param(
-        mod.PREDETERMINED_GEN_BLD_YRS,
-        within=NonNegativeReals)
-    mod.min_data_check('gen_predetermined_cap')
-
+        mod.PREDETERMINED_GEN_BLD_YRS, within=NonNegativeReals
+    )
+    mod.min_data_check("gen_predetermined_cap")
 
     def gen_build_can_operate_in_period(m, g, build_year, period):
         if build_year in m.PERIODS:
@@ -349,9 +368,7 @@ def define_components(mod):
         else:
             online = build_year
         retirement = online + m.gen_max_age[g]
-        return (
-            online <= m.period_start[period] < retirement
-        )
+        return online <= m.period_start[period] < retirement
         # This is probably more correct, but is a different behavior
         # mid_period = m.period_start[period] + 0.5 * m.period_length_years[period]
         # return online <= m.period_start[period] and mid_period <= retirement
@@ -362,36 +379,44 @@ def define_components(mod):
         within=mod.PERIODS,
         ordered=True,
         initialize=lambda m, g, bld_yr: set(
-            period for period in m.PERIODS
-            if gen_build_can_operate_in_period(m, g, bld_yr, period)))
+            period
+            for period in m.PERIODS
+            if gen_build_can_operate_in_period(m, g, bld_yr, period)
+        ),
+    )
     # The set of build years that could be online in the given period
     # for the given project.
     mod.BLD_YRS_FOR_GEN_PERIOD = Set(
-        mod.GENERATION_PROJECTS, mod.PERIODS,
+        mod.GENERATION_PROJECTS,
+        mod.PERIODS,
         initialize=lambda m, g, period: set(
-            bld_yr for (gen, bld_yr) in m.GEN_BLD_YRS
-            if gen == g and
-               gen_build_can_operate_in_period(m, g, bld_yr, period)))
+            bld_yr
+            for (gen, bld_yr) in m.GEN_BLD_YRS
+            if gen == g and gen_build_can_operate_in_period(m, g, bld_yr, period)
+        ),
+    )
     # The set of periods when a generator is available to run
     mod.PERIODS_FOR_GEN = Set(
         mod.GENERATION_PROJECTS,
-        initialize=lambda m, g: [p for p in m.PERIODS if len(m.BLD_YRS_FOR_GEN_PERIOD[g, p]) > 0]
+        initialize=lambda m, g: [
+            p for p in m.PERIODS if len(m.BLD_YRS_FOR_GEN_PERIOD[g, p]) > 0
+        ],
     )
 
     def bounds_BuildGen(model, g, bld_yr):
-        if((g, bld_yr) in model.PREDETERMINED_GEN_BLD_YRS):
-            return (model.gen_predetermined_cap[g, bld_yr],
-                    model.gen_predetermined_cap[g, bld_yr])
-        elif(g in model.CAPACITY_LIMITED_GENS):
+        if (g, bld_yr) in model.PREDETERMINED_GEN_BLD_YRS:
+            return (
+                model.gen_predetermined_cap[g, bld_yr],
+                model.gen_predetermined_cap[g, bld_yr],
+            )
+        elif g in model.CAPACITY_LIMITED_GENS:
             # This does not replace Max_Build_Potential because
             # Max_Build_Potential applies across all build years.
             return (0, model.gen_capacity_limit_mw[g])
         else:
             return (0, None)
-    mod.BuildGen = Var(
-        mod.GEN_BLD_YRS,
-        within=NonNegativeReals,
-        bounds=bounds_BuildGen)
+
+    mod.BuildGen = Var(mod.GEN_BLD_YRS, within=NonNegativeReals, bounds=bounds_BuildGen)
     # Some projects are retired before the first study period, so they
     # don't appear in the objective function or any constraints.
     # In this case, pyomo may leave the variable value undefined even
@@ -402,9 +427,10 @@ def define_components(mod):
     # projects here.
     def BuildGen_assign_default_value(m, g, bld_yr):
         m.BuildGen[g, bld_yr] = m.gen_predetermined_cap[g, bld_yr]
+
     mod.BuildGen_assign_default_value = BuildAction(
-        mod.PREDETERMINED_GEN_BLD_YRS,
-        rule=BuildGen_assign_default_value)
+        mod.PREDETERMINED_GEN_BLD_YRS, rule=BuildGen_assign_default_value
+    )
 
     # note: in pull request 78, commit e7f870d..., GEN_PERIODS
     # was mistakenly redefined as GENERATION_PROJECTS * PERIODS.
@@ -417,36 +443,41 @@ def define_components(mod):
     # and 'C-Coal_ST' in m.GENS_IN_PERIOD[2020] and 'C-Coal_ST' not in m.GENS_IN_PERIOD[2030]
     mod.GEN_PERIODS = Set(
         dimen=2,
-        initialize=lambda m:
-            [(g, p) for g in m.GENERATION_PROJECTS for p in m.PERIODS_FOR_GEN[g]])
+        initialize=lambda m: [
+            (g, p) for g in m.GENERATION_PROJECTS for p in m.PERIODS_FOR_GEN[g]
+        ],
+    )
 
     mod.GenCapacity = Expression(
-        mod.GENERATION_PROJECTS, mod.PERIODS,
+        mod.GENERATION_PROJECTS,
+        mod.PERIODS,
         rule=lambda m, g, period: sum(
-            m.BuildGen[g, bld_yr]
-            for bld_yr in m.BLD_YRS_FOR_GEN_PERIOD[g, period]))
+            m.BuildGen[g, bld_yr] for bld_yr in m.BLD_YRS_FOR_GEN_PERIOD[g, period]
+        ),
+    )
 
     mod.Max_Build_Potential = Constraint(
-        mod.CAPACITY_LIMITED_GENS, mod.PERIODS,
-        rule=lambda m, g, p: (
-            m.gen_capacity_limit_mw[g] >= m.GenCapacity[g, p]))
+        mod.CAPACITY_LIMITED_GENS,
+        mod.PERIODS,
+        rule=lambda m, g, p: (m.gen_capacity_limit_mw[g] >= m.GenCapacity[g, p]),
+    )
 
     # The following components enforce minimum capacity build-outs.
     # Note that this adds binary variables to the model.
-    mod.gen_min_build_capacity = Param (mod.GENERATION_PROJECTS,
-        within=NonNegativeReals, default=0)
+    mod.gen_min_build_capacity = Param(
+        mod.GENERATION_PROJECTS, within=NonNegativeReals, default=0
+    )
     mod.NEW_GEN_WITH_MIN_BUILD_YEARS = Set(
         initialize=mod.NEW_GEN_BLD_YRS,
-        filter=lambda m, g, p: (
-            m.gen_min_build_capacity[g] > 0))
-    mod.BuildMinGenCap = Var(
-        mod.NEW_GEN_WITH_MIN_BUILD_YEARS,
-        within=Binary)
+        filter=lambda m, g, p: (m.gen_min_build_capacity[g] > 0),
+    )
+    mod.BuildMinGenCap = Var(mod.NEW_GEN_WITH_MIN_BUILD_YEARS, within=Binary)
     mod.Enforce_Min_Build_Lower = Constraint(
         mod.NEW_GEN_WITH_MIN_BUILD_YEARS,
         rule=lambda m, g, p: (
-            m.BuildMinGenCap[g, p] * m.gen_min_build_capacity[g]
-            <= m.BuildGen[g, p]))
+            m.BuildMinGenCap[g, p] * m.gen_min_build_capacity[g] <= m.BuildGen[g, p]
+        ),
+    )
 
     # Define a constant for enforcing binary constraints on project capacity
     # The value of 100 GW should be larger than any expected build size. For
@@ -454,44 +485,51 @@ def define_components(mod):
     # is 22.5 GW. I tried using 1 TW, but CBC had numerical stability problems
     # with that value and chose a suboptimal solution for the
     # discrete_and_min_build example which is installing capacity of 3-5 MW.
-    mod._gen_max_cap_for_binary_constraints = 10**5
+    mod._gen_max_cap_for_binary_constraints = 10 ** 5
     mod.Enforce_Min_Build_Upper = Constraint(
         mod.NEW_GEN_WITH_MIN_BUILD_YEARS,
         rule=lambda m, g, p: (
-            m.BuildGen[g, p] <= m.BuildMinGenCap[g, p] *
-                mod._gen_max_cap_for_binary_constraints))
+            m.BuildGen[g, p]
+            <= m.BuildMinGenCap[g, p] * mod._gen_max_cap_for_binary_constraints
+        ),
+    )
 
     # Costs
-    mod.gen_variable_om = Param (mod.GENERATION_PROJECTS, within=NonNegativeReals)
-    mod.gen_connect_cost_per_mw = Param(mod.GENERATION_PROJECTS, within=NonNegativeReals)
-    mod.min_data_check('gen_variable_om', 'gen_connect_cost_per_mw')
+    mod.gen_variable_om = Param(mod.GENERATION_PROJECTS, within=NonNegativeReals)
+    mod.gen_connect_cost_per_mw = Param(
+        mod.GENERATION_PROJECTS, within=NonNegativeReals
+    )
+    mod.min_data_check("gen_variable_om", "gen_connect_cost_per_mw")
 
-    mod.gen_overnight_cost = Param(
-        mod.GEN_BLD_YRS,
-        within=NonNegativeReals)
-    mod.gen_fixed_om = Param(
-        mod.GEN_BLD_YRS,
-        within=NonNegativeReals)
-    mod.min_data_check('gen_overnight_cost', 'gen_fixed_om')
+    mod.gen_overnight_cost = Param(mod.GEN_BLD_YRS, within=NonNegativeReals)
+    mod.gen_fixed_om = Param(mod.GEN_BLD_YRS, within=NonNegativeReals)
+    mod.min_data_check("gen_overnight_cost", "gen_fixed_om")
 
     # Derived annual costs
     mod.gen_capital_cost_annual = Param(
         mod.GEN_BLD_YRS,
         initialize=lambda m, g, bld_yr: (
-            (m.gen_overnight_cost[g, bld_yr] +
-                m.gen_connect_cost_per_mw[g]) *
-            crf(m.interest_rate, m.gen_max_age[g])))
+            (m.gen_overnight_cost[g, bld_yr] + m.gen_connect_cost_per_mw[g])
+            * crf(m.interest_rate, m.gen_max_age[g])
+        ),
+    )
 
     mod.GenCapitalCosts = Expression(
-        mod.GENERATION_PROJECTS, mod.PERIODS,
+        mod.GENERATION_PROJECTS,
+        mod.PERIODS,
         rule=lambda m, g, p: sum(
             m.BuildGen[g, bld_yr] * m.gen_capital_cost_annual[g, bld_yr]
-            for bld_yr in m.BLD_YRS_FOR_GEN_PERIOD[g, p]))
+            for bld_yr in m.BLD_YRS_FOR_GEN_PERIOD[g, p]
+        ),
+    )
     mod.GenFixedOMCosts = Expression(
-        mod.GENERATION_PROJECTS, mod.PERIODS,
+        mod.GENERATION_PROJECTS,
+        mod.PERIODS,
         rule=lambda m, g, p: sum(
             m.BuildGen[g, bld_yr] * m.gen_fixed_om[g, bld_yr]
-            for bld_yr in m.BLD_YRS_FOR_GEN_PERIOD[g, p]))
+            for bld_yr in m.BLD_YRS_FOR_GEN_PERIOD[g, p]
+        ),
+    )
     # Summarize costs for the objective function. Units should be total
     # annual future costs in $base_year real dollars. The objective
     # function will convert these to base_year Net Present Value in
@@ -500,8 +538,10 @@ def define_components(mod):
         mod.PERIODS,
         rule=lambda m, p: sum(
             m.GenCapitalCosts[g, p] + m.GenFixedOMCosts[g, p]
-            for g in m.GENERATION_PROJECTS))
-    mod.Cost_Components_Per_Period.append('TotalGenFixedCosts')
+            for g in m.GENERATION_PROJECTS
+        ),
+    )
+    mod.Cost_Components_Per_Period.append("TotalGenFixedCosts")
 
 
 def load_inputs(mod, switch_data, inputs_dir):
@@ -539,47 +579,76 @@ def load_inputs(mod, switch_data, inputs_dir):
     """
 
     switch_data.load_aug(
-        filename=os.path.join(inputs_dir, 'generation_projects_info.csv'),
-        optional_params=['gen_dbid', 'gen_is_baseload', 'gen_scheduled_outage_rate',
-        'gen_forced_outage_rate', 'gen_capacity_limit_mw', 'gen_unit_size',
-        'gen_ccs_energy_load', 'gen_ccs_capture_efficiency',
-        'gen_min_build_capacity', 'gen_is_cogen', 'gen_is_distributed'],
+        filename=os.path.join(inputs_dir, "generation_projects_info.csv"),
+        optional_params=[
+            "gen_dbid",
+            "gen_is_baseload",
+            "gen_scheduled_outage_rate",
+            "gen_forced_outage_rate",
+            "gen_capacity_limit_mw",
+            "gen_unit_size",
+            "gen_ccs_energy_load",
+            "gen_ccs_capture_efficiency",
+            "gen_min_build_capacity",
+            "gen_is_cogen",
+            "gen_is_distributed",
+        ],
         index=mod.GENERATION_PROJECTS,
-        param=(mod.gen_dbid, mod.gen_tech, mod.gen_energy_source,
-               mod.gen_load_zone, mod.gen_max_age, mod.gen_is_variable,
-               mod.gen_is_baseload, mod.gen_scheduled_outage_rate,
-               mod.gen_forced_outage_rate, mod.gen_capacity_limit_mw,
-               mod.gen_unit_size, mod.gen_ccs_energy_load,
-               mod.gen_ccs_capture_efficiency, mod.gen_full_load_heat_rate,
-               mod.gen_variable_om, mod.gen_min_build_capacity,
-               mod.gen_connect_cost_per_mw, mod.gen_is_cogen,
-               mod.gen_is_distributed))
+        param=(
+            mod.gen_dbid,
+            mod.gen_tech,
+            mod.gen_energy_source,
+            mod.gen_load_zone,
+            mod.gen_max_age,
+            mod.gen_is_variable,
+            mod.gen_is_baseload,
+            mod.gen_scheduled_outage_rate,
+            mod.gen_forced_outage_rate,
+            mod.gen_capacity_limit_mw,
+            mod.gen_unit_size,
+            mod.gen_ccs_energy_load,
+            mod.gen_ccs_capture_efficiency,
+            mod.gen_full_load_heat_rate,
+            mod.gen_variable_om,
+            mod.gen_min_build_capacity,
+            mod.gen_connect_cost_per_mw,
+            mod.gen_is_cogen,
+            mod.gen_is_distributed,
+        ),
+    )
     # Construct sets of capacity-limited, ccs-capable and unit-size-specified
     # projects. These sets include projects for which these parameters have
     # a value
-    if 'gen_capacity_limit_mw' in switch_data.data():
-        switch_data.data()['CAPACITY_LIMITED_GENS'] = {
-            None: list(switch_data.data(name='gen_capacity_limit_mw').keys())}
-    if 'gen_unit_size' in switch_data.data():
-        switch_data.data()['DISCRETELY_SIZED_GENS'] = {
-            None: list(switch_data.data(name='gen_unit_size').keys())}
-    if 'gen_ccs_capture_efficiency' in switch_data.data():
-        switch_data.data()['CCS_EQUIPPED_GENS'] = {
-            None: list(switch_data.data(name='gen_ccs_capture_efficiency').keys())}
+    if "gen_capacity_limit_mw" in switch_data.data():
+        switch_data.data()["CAPACITY_LIMITED_GENS"] = {
+            None: list(switch_data.data(name="gen_capacity_limit_mw").keys())
+        }
+    if "gen_unit_size" in switch_data.data():
+        switch_data.data()["DISCRETELY_SIZED_GENS"] = {
+            None: list(switch_data.data(name="gen_unit_size").keys())
+        }
+    if "gen_ccs_capture_efficiency" in switch_data.data():
+        switch_data.data()["CCS_EQUIPPED_GENS"] = {
+            None: list(switch_data.data(name="gen_ccs_capture_efficiency").keys())
+        }
     switch_data.load_aug(
         optional=True,
-        filename=os.path.join(inputs_dir, 'gen_build_predetermined.csv'),
+        filename=os.path.join(inputs_dir, "gen_build_predetermined.csv"),
         index=mod.PREDETERMINED_GEN_BLD_YRS,
-        param=(mod.gen_predetermined_cap))
+        param=(mod.gen_predetermined_cap),
+    )
     switch_data.load_aug(
-        filename=os.path.join(inputs_dir, 'gen_build_costs.csv'),
+        filename=os.path.join(inputs_dir, "gen_build_costs.csv"),
         index=mod.GEN_BLD_YRS,
-        param=(mod.gen_overnight_cost, mod.gen_fixed_om))
+        param=(mod.gen_overnight_cost, mod.gen_fixed_om),
+    )
     switch_data.load_aug(
         optional=True,
-        filename=os.path.join(inputs_dir, 'gen_multiple_fuels.csv'),
+        filename=os.path.join(inputs_dir, "gen_multiple_fuels.csv"),
         index=mod.MULTI_FUEL_GEN_FUELS,
-        param=tuple())
+        param=tuple(),
+    )
+
 
 def post_solve(m, outdir):
     write_table(
@@ -587,19 +656,29 @@ def post_solve(m, outdir):
         sorted(m.GEN_PERIODS) if m.options.sorted_output else m.GEN_PERIODS,
         output_file=os.path.join(outdir, "gen_cap.csv"),
         headings=(
-            "GENERATION_PROJECT", "PERIOD",
-            "gen_tech", "gen_load_zone", "gen_energy_source",
-            "GenCapacity", "GenCapitalCosts", "GenFixedOMCosts"),
+            "GENERATION_PROJECT",
+            "PERIOD",
+            "gen_tech",
+            "gen_load_zone",
+            "gen_energy_source",
+            "GenCapacity",
+            "GenCapitalCosts",
+            "GenFixedOMCosts",
+        ),
         values=lambda m, g, p: (
-            g, p,
-            m.gen_tech[g], m.gen_load_zone[g], m.gen_energy_source[g],
+            g,
+            p,
+            m.gen_tech[g],
+            m.gen_load_zone[g],
+            m.gen_energy_source[g],
             m.GenCapacity[g, p],
-            m.GenCapitalCosts[g, p] + (
+            m.GenCapitalCosts[g, p]
+            + (
                 m.StorageEnergyFixedCost[g, p]
-                if hasattr(m, 'StorageEnergyFixedCost')
-                    and (g, p) in m.StorageEnergyFixedCost
+                if hasattr(m, "StorageEnergyFixedCost")
+                and (g, p) in m.StorageEnergyFixedCost
                 else 0.0
             ),
-            m.GenFixedOMCosts[g, p]
-        )
+            m.GenFixedOMCosts[g, p],
+        ),
     )

--- a/switch_model/generators/core/commit/__init__.py
+++ b/switch_model/generators/core/commit/__init__.py
@@ -10,5 +10,6 @@ module is optional and enforces discrete unit commitment.
 
 """
 core_modules = [
-    'switch_model.generators.core.commit.operate',
-    'switch_model.generators.core.commit.fuel_use']
+    "switch_model.generators.core.commit.operate",
+    "switch_model.generators.core.commit.fuel_use",
+]

--- a/switch_model/generators/core/commit/discrete.py
+++ b/switch_model/generators/core/commit/discrete.py
@@ -8,10 +8,16 @@ generation technologies that have gen_unit_size specified.
 
 from pyomo.environ import *
 
-dependencies = 'switch_model.timescales', 'switch_model.balancing.load_zones',\
-    'switch_model.financials', 'switch_model.energy_sources.properties',\
-    'switch_model.generators.core.build',\
-    'switch_model.generators.core.dispatch', 'switch_model.operations.unitcommit'
+dependencies = (
+    "switch_model.timescales",
+    "switch_model.balancing.load_zones",
+    "switch_model.financials",
+    "switch_model.energy_sources.properties",
+    "switch_model.generators.core.build",
+    "switch_model.generators.core.dispatch",
+    "switch_model.operations.unitcommit",
+)
+
 
 def define_components(mod):
     """
@@ -50,14 +56,15 @@ def define_components(mod):
 
     mod.DISCRETE_GEN_TPS = Set(
         dimen=2,
-        initialize=lambda m:
-            [(g, t) for g in m.DISCRETELY_SIZED_GENS for t in m.TPS_FOR_GEN[g]]
+        initialize=lambda m: [
+            (g, t) for g in m.DISCRETELY_SIZED_GENS for t in m.TPS_FOR_GEN[g]
+        ],
     )
-    mod.CommitGenUnits = Var(
-        mod.DISCRETE_GEN_TPS,
-        within=NonNegativeIntegers)
+    mod.CommitGenUnits = Var(mod.DISCRETE_GEN_TPS, within=NonNegativeIntegers)
     mod.Commit_Units_Consistency = Constraint(
         mod.DISCRETE_GEN_TPS,
         rule=lambda m, g, t: (
-            m.CommitGen[g, t] == m.CommitGenUnits[g, t] *
-            m.gen_unit_size[g] * m.gen_availability[g]))
+            m.CommitGen[g, t]
+            == m.CommitGenUnits[g, t] * m.gen_unit_size[g] * m.gen_availability[g]
+        ),
+    )

--- a/switch_model/generators/core/commit/fuel_use.py
+++ b/switch_model/generators/core/commit/fuel_use.py
@@ -67,10 +67,16 @@ from pyomo.environ import *
 import csv
 from switch_model.utilities import approx_equal
 
-dependencies = 'switch_model.timescales', 'switch_model.balancing.load_zones',\
-    'switch_model.financials', 'switch_model.energy_sources.properties.properties', \
-    'switch_model.generators.core.build', 'switch_model.generators.core.dispatch',\
-    'switch_model.generators.core.commit.operate'
+dependencies = (
+    "switch_model.timescales",
+    "switch_model.balancing.load_zones",
+    "switch_model.financials",
+    "switch_model.energy_sources.properties.properties",
+    "switch_model.generators.core.build",
+    "switch_model.generators.core.dispatch",
+    "switch_model.generators.core.commit.operate",
+)
+
 
 def define_components(mod):
     """
@@ -101,18 +107,17 @@ def define_components(mod):
 
     """
 
-    mod.FUEL_USE_SEGMENTS_FOR_GEN = Set(
-        mod.FUEL_BASED_GENS,
-        dimen=2)
+    mod.FUEL_USE_SEGMENTS_FOR_GEN = Set(mod.FUEL_BASED_GENS, dimen=2)
 
     # Use BuildAction to populate a set's default values.
     def FUEL_USE_SEGMENTS_FOR_GEN_default_rule(m, g):
         if g not in m.FUEL_USE_SEGMENTS_FOR_GEN:
             heat_rate = m.gen_full_load_heat_rate[g]
             m.FUEL_USE_SEGMENTS_FOR_GEN[g] = [(0, heat_rate)]
+
     mod.FUEL_USE_SEGMENTS_FOR_GEN_default = BuildAction(
-        mod.FUEL_BASED_GENS,
-        rule=FUEL_USE_SEGMENTS_FOR_GEN_default_rule)
+        mod.FUEL_BASED_GENS, rule=FUEL_USE_SEGMENTS_FOR_GEN_default_rule
+    )
 
     mod.GEN_TPS_FUEL_PIECEWISE_CONS_SET = Set(
         dimen=4,
@@ -120,22 +125,27 @@ def define_components(mod):
             (g, t, intercept, slope)
             for (g, t) in m.FUEL_BASED_GEN_TPS
             for (intercept, slope) in m.FUEL_USE_SEGMENTS_FOR_GEN[g]
-        ]
+        ],
     )
     mod.GenFuelUseRate_Calculate = Constraint(
         mod.GEN_TPS_FUEL_PIECEWISE_CONS_SET,
         rule=lambda m, g, t, intercept, incremental_heat_rate: (
-            sum(m.GenFuelUseRate[g, t, f] for f in m.FUELS_FOR_GEN[g]) >=
+            sum(m.GenFuelUseRate[g, t, f] for f in m.FUELS_FOR_GEN[g])
+            >=
             # Do the startup
-            m.StartupGenCapacity[g, t] * m.gen_startup_fuel[g] / m.tp_duration_hrs[t] +
-            intercept * m.CommitGen[g, t] +
-            incremental_heat_rate * m.DispatchGen[g, t]))
+            m.StartupGenCapacity[g, t] * m.gen_startup_fuel[g] / m.tp_duration_hrs[t]
+            + intercept * m.CommitGen[g, t]
+            + incremental_heat_rate * m.DispatchGen[g, t]
+        ),
+    )
+
 
 # TODO: switch to defining heat rates as a collection of (output_mw, fuel_mmbtu_per_h) points;
 # read those directly as normal sets, then derive the project heat rate curves from those
 # within define_components.
 # This will simplify data preparation (the current format is hard to produce from any
 # normalized database) and the import code and help the readability of this file.
+
 
 def load_inputs(mod, switch_data, inputs_dir):
     """
@@ -181,43 +191,50 @@ def load_inputs(mod, switch_data, inputs_dir):
 
     """
 
-    path = os.path.join(inputs_dir, 'gen_inc_heat_rates.csv')
+    path = os.path.join(inputs_dir, "gen_inc_heat_rates.csv")
     if os.path.isfile(path):
         (fuel_rate_segments, min_load, full_hr) = _parse_inc_heat_rate_file(
-            path, id_column="GENERATION_PROJECT")
+            path, id_column="GENERATION_PROJECT"
+        )
         # Check implied minimum loading level for consistency with
         # gen_min_load_fraction if gen_min_load_fraction was provided. If
         # gen_min_load_fraction wasn't provided, set it to implied minimum
         # loading level.
         for g in min_load:
-            if 'gen_min_load_fraction' not in switch_data.data():
-                switch_data.data()['gen_min_load_fraction'] = {}
-            dp_dict = switch_data.data(name='gen_min_load_fraction')
+            if "gen_min_load_fraction" not in switch_data.data():
+                switch_data.data()["gen_min_load_fraction"] = {}
+            dp_dict = switch_data.data(name="gen_min_load_fraction")
             if g in dp_dict:
                 min_load_dat = dp_dict[g]
                 if not approx_equal(min_load[g], min_load_dat):
-                    raise ValueError((
-                        "gen_min_load_fraction is inconsistant with " +
-                        "incremental heat rate data for project " +
-                        "{}.").format(g))
+                    raise ValueError(
+                        (
+                            "gen_min_load_fraction is inconsistant with "
+                            + "incremental heat rate data for project "
+                            + "{}."
+                        ).format(g)
+                    )
             else:
                 dp_dict[g] = min_load[g]
         # Same thing, but for full load heat rate.
         for g in full_hr:
-            if 'gen_full_load_heat_rate' not in switch_data.data():
-                switch_data.data()['gen_full_load_heat_rate'] = {}
-            dp_dict = switch_data.data(name='gen_full_load_heat_rate')
+            if "gen_full_load_heat_rate" not in switch_data.data():
+                switch_data.data()["gen_full_load_heat_rate"] = {}
+            dp_dict = switch_data.data(name="gen_full_load_heat_rate")
             if g in dp_dict:
                 full_hr_dat = dp_dict[g]
                 if abs((full_hr[g] - full_hr_dat) / full_hr_dat) > 0.01:
-                    raise ValueError((
-                        "gen_full_load_heat_rate is inconsistant with " +
-                        "incremental heat rate data for project " +
-                        "{}.").format(g))
+                    raise ValueError(
+                        (
+                            "gen_full_load_heat_rate is inconsistant with "
+                            + "incremental heat rate data for project "
+                            + "{}."
+                        ).format(g)
+                    )
             else:
                 dp_dict[g] = full_hr[g]
         # Copy parsed data into the data portal.
-        switch_data.data()['FUEL_USE_SEGMENTS_FOR_GEN'] = fuel_rate_segments
+        switch_data.data()["FUEL_USE_SEGMENTS_FOR_GEN"] = fuel_rate_segments
 
 
 def _parse_inc_heat_rate_file(path, id_column):
@@ -237,45 +254,56 @@ def _parse_inc_heat_rate_file(path, id_column):
     full_load_hr = {}
     # Scan the file and stuff the data into dictionaries for easy access.
     # Parse the file and stuff data into dictionaries indexed by units.
-    with open(path, 'r') as hr_file:
-        dat = list(csv.DictReader(hr_file, delimiter=','))
+    with open(path, "r") as hr_file:
+        dat = list(csv.DictReader(hr_file, delimiter=","))
         for row in dat:
             u = row[id_column]
-            p1 = float(row['power_start_mw'])
-            p2 = row['power_end_mw']
-            ihr = row['incremental_heat_rate_mbtu_per_mwhr']
-            fr = row['fuel_use_rate_mmbtu_per_h']
+            p1 = float(row["power_start_mw"])
+            p2 = row["power_end_mw"]
+            ihr = row["incremental_heat_rate_mbtu_per_mwhr"]
+            fr = row["fuel_use_rate_mmbtu_per_h"]
             # Does this row give the first point?
-            if(p2 == '.' and ihr == '.'):
+            if p2 == "." and ihr == ".":
                 fr = float(fr)
-                if(u in fuel_rate_points):
+                if u in fuel_rate_points:
                     raise ValueError(
-                        "Error processing incremental heat rates for " +
-                        u + " in " + path + ". More than one row has " +
-                        "a fuel use rate specified.")
+                        "Error processing incremental heat rates for "
+                        + u
+                        + " in "
+                        + path
+                        + ". More than one row has "
+                        + "a fuel use rate specified."
+                    )
                 fuel_rate_points[u] = {p1: fr}
             # Does this row give a line segment?
-            elif(fr == '.'):
+            elif fr == ".":
                 p2 = float(p2)
                 ihr = float(ihr)
-                if(u not in ihr_dat):
+                if u not in ihr_dat:
                     ihr_dat[u] = []
                 ihr_dat[u].append((p1, p2, ihr))
             # Throw an error if the row's format is not recognized.
             else:
                 raise ValueError(
-                    "Error processing incremental heat rates for row " +
-                    u + " in " + path + ". Row format not recognized for " +
-                    "row " + str(row) + ". See documentation for acceptable " +
-                    "formats.")
+                    "Error processing incremental heat rates for row "
+                    + u
+                    + " in "
+                    + path
+                    + ". Row format not recognized for "
+                    + "row "
+                    + str(row)
+                    + ". See documentation for acceptable "
+                    + "formats."
+                )
 
     # Make sure that each project that has incremental heat rates defined
     # also has a starting point defined.
     missing_starts = [k for k in ihr_dat if k not in fuel_rate_points]
     if missing_starts:
         raise ValueError(
-            'No starting point(s) are defined for incremental heat rate curves '
-            'for the following technologies: {}'.format(','.join(missing_starts)))
+            "No starting point(s) are defined for incremental heat rate curves "
+            "for the following technologies: {}".format(",".join(missing_starts))
+        )
 
     # Construct a convex combination of lines describing a fuel use
     # curve for each representative unit "u".
@@ -293,7 +321,7 @@ def _parse_inc_heat_rate_file(path, id_column):
         # Sort the line segments by their domains.
         ihr_dat[u].sort()
         # Assume that the maximum power output is the rated capacity.
-        (junk, capacity, junk) = ihr_dat[u][len(ihr_dat[u])-1]
+        (junk, capacity, junk) = ihr_dat[u][len(ihr_dat[u]) - 1]
         # Retrieve the first incremental heat rate for error checking.
         (min_power, junk, ihr_prev) = ihr_dat[u][0]
         min_cap_factor[u] = min_power / capacity
@@ -302,20 +330,24 @@ def _parse_inc_heat_rate_file(path, id_column):
             # Error check: This incremental heat rate cannot be less than
             # the previous one.
             if ihr_prev > ihr:
-                raise ValueError((
-                    "Error processing incremental heat rates for " +
-                    "{} in file {}. The incremental heat rate " +
-                    "between power output levels {}-{} is less than " +
-                    "that of the prior line segment.").format(
-                        u, path, p_start, p_end))
+                raise ValueError(
+                    (
+                        "Error processing incremental heat rates for "
+                        + "{} in file {}. The incremental heat rate "
+                        + "between power output levels {}-{} is less than "
+                        + "that of the prior line segment."
+                    ).format(u, path, p_start, p_end)
+                )
             # Error check: This segment needs to start at an existing point.
             if p_start not in fr_points:
-                raise ValueError((
-                    "Error processing incremental heat rates for " +
-                    "{} in file {}. The incremental heat rate " +
-                    "between power output levels {}-{} does not start at a " +
-                    "previously defined point or line segment.").format(
-                        u, path, p_start, p_end))
+                raise ValueError(
+                    (
+                        "Error processing incremental heat rates for "
+                        + "{} in file {}. The incremental heat rate "
+                        + "between power output levels {}-{} does not start at a "
+                        + "previously defined point or line segment."
+                    ).format(u, path, p_start, p_end)
+                )
             # Calculate the y-intercept then normalize it by the capacity.
             intercept_norm = (fr_points[p_start] - ihr * p_start) / capacity
             # Save the line segment's definition.

--- a/switch_model/generators/core/gen_discrete_build.py
+++ b/switch_model/generators/core/gen_discrete_build.py
@@ -8,9 +8,14 @@ that have gen_unit_size specified.
 
 from pyomo.environ import *
 
-dependencies = 'switch_model.timescales', 'switch_model.balancing.load_zones',\
-    'switch_model.financials', 'switch_model.energy_sources.properties', \
-    'switch_model.generators.core.build'
+dependencies = (
+    "switch_model.timescales",
+    "switch_model.balancing.load_zones",
+    "switch_model.financials",
+    "switch_model.energy_sources.properties",
+    "switch_model.generators.core.build",
+)
+
 
 def define_components(mod):
     """
@@ -34,12 +39,12 @@ def define_components(mod):
 
     mod.DISCRETE_GEN_BLD_YRS = Set(
         initialize=mod.GEN_BLD_YRS,
-        filter=lambda m, g, bld_yr: g in m.DISCRETELY_SIZED_GENS)
-    mod.BuildUnits = Var(
-        mod.DISCRETE_GEN_BLD_YRS,
-        within=NonNegativeIntegers)
+        filter=lambda m, g, bld_yr: g in m.DISCRETELY_SIZED_GENS,
+    )
+    mod.BuildUnits = Var(mod.DISCRETE_GEN_BLD_YRS, within=NonNegativeIntegers)
     mod.Build_Units_Consistency = Constraint(
         mod.DISCRETE_GEN_BLD_YRS,
         rule=lambda m, g, bld_yr: (
-            m.BuildGen[g, bld_yr] ==
-            m.BuildUnits[g, bld_yr] * m.gen_unit_size[g]))
+            m.BuildGen[g, bld_yr] == m.BuildUnits[g, bld_yr] * m.gen_unit_size[g]
+        ),
+    )

--- a/switch_model/generators/core/no_commit.py
+++ b/switch_model/generators/core/no_commit.py
@@ -9,9 +9,15 @@ module which constrains dispatch to unit commitment decisions.
 
 from pyomo.environ import *
 
-dependencies = 'switch_model.timescales', 'switch_model.balancing.load_zones',\
-    'switch_model.financials', 'switch_model.energy_sources.properties.properties', \
-    'switch_model.generators.core.build', 'switch_model.generators.core.dispatch'
+dependencies = (
+    "switch_model.timescales",
+    "switch_model.balancing.load_zones",
+    "switch_model.financials",
+    "switch_model.energy_sources.properties.properties",
+    "switch_model.generators.core.build",
+    "switch_model.generators.core.dispatch",
+)
+
 
 def define_components(mod):
     """
@@ -80,37 +86,44 @@ def define_components(mod):
     # and dispatch.
     mod.BASELOAD_GEN_PERIODS = Set(
         dimen=2,
-        rule=lambda m:
-            [(g, p) for g in m.BASELOAD_GENS for p in m.PERIODS_FOR_GEN[g]])
+        rule=lambda m: [(g, p) for g in m.BASELOAD_GENS for p in m.PERIODS_FOR_GEN[g]],
+    )
     mod.BASELOAD_GEN_TPS = Set(
         dimen=2,
-        rule=lambda m:
-            [(g, t) for g, p in m.BASELOAD_GEN_PERIODS for t in m.TPS_IN_PERIOD[p]])
+        rule=lambda m: [
+            (g, t) for g, p in m.BASELOAD_GEN_PERIODS for t in m.TPS_IN_PERIOD[p]
+        ],
+    )
 
     mod.DispatchBaseloadByPeriod = Var(mod.BASELOAD_GEN_PERIODS)
 
     def DispatchUpperLimit_expr(m, g, t):
         if g in m.VARIABLE_GENS:
-            return (m.GenCapacityInTP[g, t] * m.gen_availability[g] *
-                    m.gen_max_capacity_factor[g, t])
+            return (
+                m.GenCapacityInTP[g, t]
+                * m.gen_availability[g]
+                * m.gen_max_capacity_factor[g, t]
+            )
         else:
             return m.GenCapacityInTP[g, t] * m.gen_availability[g]
-    mod.DispatchUpperLimit = Expression(
-        mod.GEN_TPS,
-        rule=DispatchUpperLimit_expr)
+
+    mod.DispatchUpperLimit = Expression(mod.GEN_TPS, rule=DispatchUpperLimit_expr)
 
     mod.Enforce_Dispatch_Baseload_Flat = Constraint(
         mod.BASELOAD_GEN_TPS,
-        rule=lambda m, g, t:
-            m.DispatchGen[g, t] == m.DispatchBaseloadByPeriod[g, m.tp_period[t]])
+        rule=lambda m, g, t: m.DispatchGen[g, t]
+        == m.DispatchBaseloadByPeriod[g, m.tp_period[t]],
+    )
 
     mod.Enforce_Dispatch_Upper_Limit = Constraint(
         mod.GEN_TPS,
-        rule=lambda m, g, t: (
-            m.DispatchGen[g, t] <= m.DispatchUpperLimit[g, t]))
+        rule=lambda m, g, t: (m.DispatchGen[g, t] <= m.DispatchUpperLimit[g, t]),
+    )
 
     mod.GenFuelUseRate_Calculate = Constraint(
         mod.FUEL_BASED_GEN_TPS,
         rule=lambda m, g, t: (
             sum(m.GenFuelUseRate[g, t, f] for f in m.FUELS_FOR_GEN[g])
-            == m.DispatchGen[g, t] * m.gen_full_load_heat_rate[g]))
+            == m.DispatchGen[g, t] * m.gen_full_load_heat_rate[g]
+        ),
+    )

--- a/switch_model/generators/extensions/hydro_simple.py
+++ b/switch_model/generators/extensions/hydro_simple.py
@@ -37,13 +37,14 @@ import os
 from pyomo.environ import *
 
 dependencies = (
-    'switch_model.timescales',
-    'switch_model.balancing.load_zones',
-    'switch_model.financials',
-    'switch_model.energy_sources.properties.properties',
-    'switch_model.generators.core.build',
-    'switch_model.generators.core.dispatch'
+    "switch_model.timescales",
+    "switch_model.balancing.load_zones",
+    "switch_model.financials",
+    "switch_model.energy_sources.properties.properties",
+    "switch_model.generators.core.build",
+    "switch_model.generators.core.dispatch",
 )
+
 
 def define_components(mod):
     """
@@ -57,7 +58,7 @@ def define_components(mod):
     HYDRO_GEN_TPS is the set of Hydro projects and available
     dispatch points. This is a filtered version of GEN_TPS that
     only includes hydro projects.
-    
+
     hydro_min_flow_mw[(g, ts) in HYDRO_GEN_TS] is a parameter that
     determines minimum flow levels, specified in units of MW dispatch.
 
@@ -81,30 +82,29 @@ def define_components(mod):
 
     mod.HYDRO_GEN_TS_RAW = Set(
         dimen=2,
-        validate=lambda m, g, ts: (
-            (g in m.GENERATION_PROJECTS) & (ts in m.TIMESERIES)
-        )
+        validate=lambda m, g, ts: ((g in m.GENERATION_PROJECTS) & (ts in m.TIMESERIES)),
     )
     mod.HYDRO_GENS = Set(
         initialize=lambda m: set(g for (g, ts) in m.HYDRO_GEN_TS_RAW),
-        doc="Dispatchable hydro projects")
+        doc="Dispatchable hydro projects",
+    )
     mod.HYDRO_GEN_TS = Set(
         dimen=2,
         initialize=lambda m: set(
-            (g, m.tp_ts[tp])
-                for g in m.HYDRO_GENS
-                    for tp in m.TPS_FOR_GEN[g]))
+            (g, m.tp_ts[tp]) for g in m.HYDRO_GENS for tp in m.TPS_FOR_GEN[g]
+        ),
+    )
     mod.HYDRO_GEN_TPS = Set(
-        initialize=mod.GEN_TPS,
-        filter=lambda m, g, t: g in m.HYDRO_GENS)
+        initialize=mod.GEN_TPS, filter=lambda m, g, t: g in m.HYDRO_GENS
+    )
 
     # Validate that a timeseries data is specified for every hydro generator /
     # timeseries that we need. Extra data points (ex: outside of planning
     # horizon or beyond a plant's lifetime) can safely be ignored to make it
     # easier to create input files.
     mod.have_minimal_hydro_params = BuildCheck(
-        mod.HYDRO_GEN_TS,
-        rule=lambda m, g, ts: (g,ts) in m.HYDRO_GEN_TS_RAW)
+        mod.HYDRO_GEN_TS, rule=lambda m, g, ts: (g, ts) in m.HYDRO_GEN_TS_RAW
+    )
     # Generate a warning if the input files specify timeseries for renewable
     # plant capacity factors that extend beyond the expected lifetime of the
     # plant. This could be caused by simple logic to build input files, or
@@ -112,13 +112,14 @@ def define_components(mod):
     # than indicated.
     def _warn_on_extra_HYDRO_GEN_TS(m):
         extra_indexes = set(m.HYDRO_GEN_TS_RAW) - set(m.HYDRO_GEN_TS)
-        num_impacted_generators = len(set([g for g,t in extra_indexes]))
-        extraneous = {g: [] for (g,t) in extra_indexes}
-        for (g,t) in extra_indexes:
+        num_impacted_generators = len(set([g for g, t in extra_indexes]))
+        extraneous = {g: [] for (g, t) in extra_indexes}
+        for (g, t) in extra_indexes:
             extraneous[g].append(t)
         pprint = "\n".join(
             "* {}: {} to {}".format(g, min(tps), max(tps))
-            for g, tps in extraneous.items())
+            for g, tps in extraneous.items()
+        )
         warning_msg = (
             "{} hydro plants with predetermined builds have timeseries data "
             "in periods when they are not operating (either after retirement, "
@@ -129,38 +130,38 @@ def define_components(mod):
             "be useful, then those plants need to either come online earlier "
             ", have longer lifetimes, or have options to build new capacity "
             "when the old capacity reaches the provided end-of-life date."
-            "\n".format(num_impacted_generators))
+            "\n".format(num_impacted_generators)
+        )
         if extra_indexes:
             logging.warning(warning_msg)
             logging.info("Plants with extra timepoints:\n{}".format(pprint))
-        return(True)
-    mod.warn_on_extra_HYDRO_GEN_TS = BuildCheck(
-        rule=_warn_on_extra_HYDRO_GEN_TS)
+        return True
+
+    mod.warn_on_extra_HYDRO_GEN_TS = BuildCheck(rule=_warn_on_extra_HYDRO_GEN_TS)
 
     mod.hydro_min_flow_mw = Param(
-        mod.HYDRO_GEN_TS_RAW,
-        within=NonNegativeReals,
-        default=0.0)
+        mod.HYDRO_GEN_TS_RAW, within=NonNegativeReals, default=0.0
+    )
     mod.Enforce_Hydro_Min_Flow = Constraint(
         mod.HYDRO_GEN_TPS,
         rule=lambda m, g, t: (
-            m.DispatchGen[g, t] >= m.hydro_min_flow_mw[g, m.tp_ts[t]]))
+            m.DispatchGen[g, t] >= m.hydro_min_flow_mw[g, m.tp_ts[t]]
+        ),
+    )
 
     mod.hydro_avg_flow_mw = Param(
-        mod.HYDRO_GEN_TS_RAW,
-        within=NonNegativeReals,
-        default=0.0)
-    mod.SpillHydro = Var(
-        mod.HYDRO_GEN_TPS,
-        within=NonNegativeReals)
+        mod.HYDRO_GEN_TS_RAW, within=NonNegativeReals, default=0.0
+    )
+    mod.SpillHydro = Var(mod.HYDRO_GEN_TPS, within=NonNegativeReals)
     mod.Enforce_Hydro_Avg_Flow = Constraint(
         mod.HYDRO_GEN_TS,
         rule=lambda m, g, ts: (
-            sum(m.DispatchGen[g, t] + m.SpillHydro[g,t]
-                for t in m.TPS_IN_TS[ts]
-            ) == m.hydro_avg_flow_mw[g, ts] * m.ts_num_tps[ts]))
+            sum(m.DispatchGen[g, t] + m.SpillHydro[g, t] for t in m.TPS_IN_TS[ts])
+            == m.hydro_avg_flow_mw[g, ts] * m.ts_num_tps[ts]
+        ),
+    )
 
-    mod.min_data_check('hydro_min_flow_mw', 'hydro_avg_flow_mw')
+    mod.min_data_check("hydro_min_flow_mw", "hydro_avg_flow_mw")
 
 
 def load_inputs(mod, switch_data, inputs_dir):
@@ -181,7 +182,7 @@ def load_inputs(mod, switch_data, inputs_dir):
     """
     switch_data.load_aug(
         optional=True,
-        filename=os.path.join(inputs_dir, 'hydro_timeseries.csv'),
+        filename=os.path.join(inputs_dir, "hydro_timeseries.csv"),
         index=mod.HYDRO_GEN_TS_RAW,
-        param=(mod.hydro_min_flow_mw, mod.hydro_avg_flow_mw)
+        param=(mod.hydro_min_flow_mw, mod.hydro_avg_flow_mw),
     )

--- a/switch_model/generators/extensions/hydro_system.py
+++ b/switch_model/generators/extensions/hydro_system.py
@@ -32,9 +32,15 @@ from __future__ import division
 import os
 from pyomo.environ import *
 
-dependencies = 'switch_model.timescales', 'switch_model.balancing.load_zones',\
-    'switch_model.financials', 'switch_model.energy_sources.properties.properties', \
-    'switch_model.generators.core.build', 'switch_model.generators.core.dispatch'
+dependencies = (
+    "switch_model.timescales",
+    "switch_model.balancing.load_zones",
+    "switch_model.financials",
+    "switch_model.energy_sources.properties.properties",
+    "switch_model.generators.core.build",
+    "switch_model.generators.core.dispatch",
+)
+
 
 def define_components(mod):
     """
@@ -255,126 +261,115 @@ def define_components(mod):
     #################
     # Nodes of the water network
     mod.WATER_NODES = Set()
-    mod.WNODE_TPS = Set(
-        dimen=2,
-        initialize=lambda m: m.WATER_NODES * m.TIMEPOINTS)
+    mod.WNODE_TPS = Set(dimen=2, initialize=lambda m: m.WATER_NODES * m.TIMEPOINTS)
     mod.wnode_constant_inflow = Param(
-        mod.WATER_NODES,
-        within=NonNegativeReals,
-        default=0.0)
+        mod.WATER_NODES, within=NonNegativeReals, default=0.0
+    )
     mod.wnode_constant_consumption = Param(
-        mod.WATER_NODES,
-        within=NonNegativeReals,
-        default=0.0)
+        mod.WATER_NODES, within=NonNegativeReals, default=0.0
+    )
     mod.wnode_tp_inflow = Param(
         mod.WNODE_TPS,
         within=NonNegativeReals,
-        default=lambda m, wn, t: m.wnode_constant_inflow[wn])
+        default=lambda m, wn, t: m.wnode_constant_inflow[wn],
+    )
     mod.wnode_tp_consumption = Param(
         mod.WNODE_TPS,
         within=NonNegativeReals,
-        default=lambda m, wn, t: m.wnode_constant_consumption[wn])
-    mod.wn_is_sink = Param(
-        mod.WATER_NODES,
-        within=Boolean)
-    mod.min_data_check('wn_is_sink')
-    mod.spillage_penalty = Param(
-        within=NonNegativeReals,
-        default=100)
-    mod.SpillWaterAtNode = Var(
-        mod.WNODE_TPS,
-        within=NonNegativeReals)
+        default=lambda m, wn, t: m.wnode_constant_consumption[wn],
+    )
+    mod.wn_is_sink = Param(mod.WATER_NODES, within=Boolean)
+    mod.min_data_check("wn_is_sink")
+    mod.spillage_penalty = Param(within=NonNegativeReals, default=100)
+    mod.SpillWaterAtNode = Var(mod.WNODE_TPS, within=NonNegativeReals)
 
     #################
     # Reservoir nodes
-    mod.RESERVOIRS = Set(
-        within=mod.WATER_NODES)
-    mod.RESERVOIR_TPS = Set(
-        dimen=2,
-        initialize=lambda m: m.RESERVOIRS * m.TIMEPOINTS)
-    mod.res_min_vol = Param(
-        mod.RESERVOIRS,
-        within=NonNegativeReals)
+    mod.RESERVOIRS = Set(within=mod.WATER_NODES)
+    mod.RESERVOIR_TPS = Set(dimen=2, initialize=lambda m: m.RESERVOIRS * m.TIMEPOINTS)
+    mod.res_min_vol = Param(mod.RESERVOIRS, within=NonNegativeReals)
     mod.res_max_vol = Param(
         mod.RESERVOIRS,
         within=NonNegativeReals,
-        validate=lambda m, val, r: val >= m.res_min_vol[r])
+        validate=lambda m, val, r: val >= m.res_min_vol[r],
+    )
     mod.res_min_vol_tp = Param(
         mod.RESERVOIR_TPS,
         within=NonNegativeReals,
-        default=lambda m, r, t: m.res_min_vol[r])
+        default=lambda m, r, t: m.res_min_vol[r],
+    )
     mod.res_max_vol_tp = Param(
         mod.RESERVOIR_TPS,
         within=NonNegativeReals,
-        default=lambda m, r, t: m.res_max_vol[r])
+        default=lambda m, r, t: m.res_max_vol[r],
+    )
     mod.initial_res_vol = Param(
         mod.RESERVOIRS,
         within=NonNegativeReals,
-        validate=lambda m, val, r: (
-            m.res_min_vol[r] <= val <= m.res_max_vol[r]))
+        validate=lambda m, val, r: (m.res_min_vol[r] <= val <= m.res_max_vol[r]),
+    )
     mod.final_res_vol = Param(
         mod.RESERVOIRS,
         within=NonNegativeReals,
-        validate=lambda m, val, r: (
-            m.res_min_vol[r] <= val <= m.res_max_vol[r]))
-    mod.min_data_check('res_min_vol', 'res_max_vol', 'initial_res_vol',
-        'final_res_vol')
+        validate=lambda m, val, r: (m.res_min_vol[r] <= val <= m.res_max_vol[r]),
+    )
+    mod.min_data_check("res_min_vol", "res_max_vol", "initial_res_vol", "final_res_vol")
+
     def ReservoirVol_bounds(m, r, t):
         # In the first timepoint of each period, this is externally defined
         if t == m.TPS_IN_PERIOD[m.tp_period[t]].first():
-            return(m.initial_res_vol[r], m.initial_res_vol[r])
+            return (m.initial_res_vol[r], m.initial_res_vol[r])
         # In all other timepoints, this is constrained by min & max params
         else:
-            return(m.res_min_vol[r], m.res_max_vol[r])
+            return (m.res_min_vol[r], m.res_max_vol[r])
+
     mod.ReservoirVol = Var(
-        mod.RESERVOIR_TPS,
-        within=NonNegativeReals,
-        bounds=ReservoirVol_bounds)
+        mod.RESERVOIR_TPS, within=NonNegativeReals, bounds=ReservoirVol_bounds
+    )
     mod.ReservoirFinalVol = Var(
-        mod.RESERVOIRS, mod.PERIODS,
+        mod.RESERVOIRS,
+        mod.PERIODS,
         within=NonNegativeReals,
-        bounds=lambda m, r, p: (m.final_res_vol[r], m.res_max_vol[r]))
+        bounds=lambda m, r, p: (m.final_res_vol[r], m.res_max_vol[r]),
+    )
 
     ################
     # Edges of the water network
     mod.WATER_CONNECTIONS = Set()
-    mod.WCON_TPS = Set(
-        dimen=2,
-        initialize=lambda m: m.WATER_CONNECTIONS * m.TIMEPOINTS)
-    mod.water_node_from = Param(
-        mod.WATER_CONNECTIONS,
-        within=mod.WATER_NODES)
-    mod.water_node_to = Param(
-        mod.WATER_CONNECTIONS,
-        within=mod.WATER_NODES)
+    mod.WCON_TPS = Set(dimen=2, initialize=lambda m: m.WATER_CONNECTIONS * m.TIMEPOINTS)
+    mod.water_node_from = Param(mod.WATER_CONNECTIONS, within=mod.WATER_NODES)
+    mod.water_node_to = Param(mod.WATER_CONNECTIONS, within=mod.WATER_NODES)
     mod.wc_capacity = Param(
-        mod.WATER_CONNECTIONS,
-        within=NonNegativeReals,
-        default=float('inf'))
-    mod.min_eco_flow = Param(
-        mod.WCON_TPS,
-        within=NonNegativeReals,
-        default=0.0)
-    mod.min_data_check('water_node_from', 'water_node_to')
+        mod.WATER_CONNECTIONS, within=NonNegativeReals, default=float("inf")
+    )
+    mod.min_eco_flow = Param(mod.WCON_TPS, within=NonNegativeReals, default=0.0)
+    mod.min_data_check("water_node_from", "water_node_to")
     mod.INWARD_WCONS_TO_WNODE = Set(
         mod.WATER_NODES,
-        initialize=lambda m, wn: set(wc for wc in m.WATER_CONNECTIONS
-            if m.water_node_to[wc] == wn))
+        initialize=lambda m, wn: set(
+            wc for wc in m.WATER_CONNECTIONS if m.water_node_to[wc] == wn
+        ),
+    )
     mod.OUTWARD_WCONS_FROM_WNODE = Set(
         mod.WATER_NODES,
-        initialize=lambda m, wn: set(wc for wc in m.WATER_CONNECTIONS
-            if m.water_node_from[wc] == wn))
+        initialize=lambda m, wn: set(
+            wc for wc in m.WATER_CONNECTIONS if m.water_node_from[wc] == wn
+        ),
+    )
     mod.DispatchWater = Var(
         mod.WCON_TPS,
         within=NonNegativeReals,
-        bounds=lambda m, wc, t: (m.min_eco_flow[wc, t], m.wc_capacity[wc]))
+        bounds=lambda m, wc, t: (m.min_eco_flow[wc, t], m.wc_capacity[wc]),
+    )
 
     def Enforce_Wnode_Balance_rule(m, wn, t):
         # Sum inflows and outflows from and to other nodes
-        dispatch_inflow = sum(m.DispatchWater[wc, t]
-            for wc in m.INWARD_WCONS_TO_WNODE[wn])
-        dispatch_outflow = sum(m.DispatchWater[wc, t]
-            for wc in m.OUTWARD_WCONS_FROM_WNODE[wn])
+        dispatch_inflow = sum(
+            m.DispatchWater[wc, t] for wc in m.INWARD_WCONS_TO_WNODE[wn]
+        )
+        dispatch_outflow = sum(
+            m.DispatchWater[wc, t] for wc in m.OUTWARD_WCONS_FROM_WNODE[wn]
+        )
         # net change in reservoir volume (m3/s): 0 for non-reservoirs
         reservoir_fill_rate = 0.0
         if wn in m.RESERVOIRS:
@@ -384,62 +379,62 @@ def define_components(mod):
             else:
                 end_of_tp_volume = m.ReservoirVol[wn, m.TPS_IN_PERIOD[p].next(t)]
             reservoir_fill_rate = (
-                (end_of_tp_volume - m.ReservoirVol[wn, t]) * 1000000.0 /
-                (m.tp_duration_hrs[t] * 3600))
+                (end_of_tp_volume - m.ReservoirVol[wn, t])
+                * 1000000.0
+                / (m.tp_duration_hrs[t] * 3600)
+            )
         # Conservation of mass flow
         return (
             # inflows (m3/s)
             m.wnode_tp_inflow[wn, t] + dispatch_inflow
             # less outflows (m3/s)
-            - m.wnode_tp_consumption[wn, t] - dispatch_outflow
+            - m.wnode_tp_consumption[wn, t]
+            - dispatch_outflow
             - m.SpillWaterAtNode[wn, t]
             # net change in volume (m3/s)
             == reservoir_fill_rate
         )
+
     mod.Enforce_Wnode_Balance = Constraint(
-        mod.WNODE_TPS,
-        rule=Enforce_Wnode_Balance_rule)
+        mod.WNODE_TPS, rule=Enforce_Wnode_Balance_rule
+    )
 
     mod.NodeSpillageCosts = Expression(
         mod.TIMEPOINTS,
         rule=lambda m, t: sum(
             # prior to Switch 2.0.3, this did not account for tp_duration_hrs
-            m.SpillWaterAtNode[wn,t] * 3600 * m.tp_duration_hrs[t] *
-            m.spillage_penalty
+            m.SpillWaterAtNode[wn, t] * 3600 * m.tp_duration_hrs[t] * m.spillage_penalty
             for wn in m.WATER_NODES
             if not m.wn_is_sink[wn]
-        )
+        ),
     )
-    mod.Cost_Components_Per_TP.append('NodeSpillageCosts')
+    mod.Cost_Components_Per_TP.append("NodeSpillageCosts")
 
     ################
     # Hydro projects
-    mod.HYDRO_GENS = Set(
-        validate=lambda m, val: val in m.GENERATION_PROJECTS)
+    mod.HYDRO_GENS = Set(validate=lambda m, val: val in m.GENERATION_PROJECTS)
     mod.HYDRO_GEN_TPS = Set(
-        initialize=mod.GEN_TPS,
-        filter=lambda m, g, t: g in m.HYDRO_GENS)
-    mod.hydro_efficiency = Param(
-        mod.HYDRO_GENS,
-        within=NonNegativeReals)
+        initialize=mod.GEN_TPS, filter=lambda m, g, t: g in m.HYDRO_GENS
+    )
+    mod.hydro_efficiency = Param(mod.HYDRO_GENS, within=NonNegativeReals)
     mod.hydraulic_location = Param(
-        mod.HYDRO_GENS,
-        validate=lambda m, val, g: val in m.WATER_CONNECTIONS)
-    mod.TurbinateFlow = Var(
-        mod.HYDRO_GEN_TPS,
-        within=NonNegativeReals)
-    mod.SpillFlow = Var(
-        mod.HYDRO_GEN_TPS,
-        within=NonNegativeReals)
+        mod.HYDRO_GENS, validate=lambda m, val, g: val in m.WATER_CONNECTIONS
+    )
+    mod.TurbinateFlow = Var(mod.HYDRO_GEN_TPS, within=NonNegativeReals)
+    mod.SpillFlow = Var(mod.HYDRO_GEN_TPS, within=NonNegativeReals)
     mod.Enforce_Hydro_Generation = Constraint(
         mod.HYDRO_GEN_TPS,
-        rule=lambda m, g, t: (m.DispatchGen[g, t] ==
-            m.hydro_efficiency[g] * m.TurbinateFlow[g, t]))
+        rule=lambda m, g, t: (
+            m.DispatchGen[g, t] == m.hydro_efficiency[g] * m.TurbinateFlow[g, t]
+        ),
+    )
     mod.Enforce_Hydro_Extraction = Constraint(
         mod.HYDRO_GEN_TPS,
-        rule=lambda m, g, t: (m.TurbinateFlow[g, t] +
-            m.SpillFlow[g, t] ==
-            m.DispatchWater[m.hydraulic_location[g], t]))
+        rule=lambda m, g, t: (
+            m.TurbinateFlow[g, t] + m.SpillFlow[g, t]
+            == m.DispatchWater[m.hydraulic_location[g], t]
+        ),
+    )
 
 
 def load_inputs(mod, switch_data, inputs_dir):
@@ -463,46 +458,59 @@ def load_inputs(mod, switch_data, inputs_dir):
     """
 
     switch_data.load_aug(
-        filename=os.path.join(inputs_dir, 'water_nodes.csv'),
+        filename=os.path.join(inputs_dir, "water_nodes.csv"),
         index=mod.WATER_NODES,
-        optional_params=['mod.wnode_constant_inflow',
-            'mod.wnode_constant_consumption'],
-        param=(mod.wn_is_sink, mod.wnode_constant_inflow,
-            mod.wnode_constant_consumption))
+        optional_params=["mod.wnode_constant_inflow", "mod.wnode_constant_consumption"],
+        param=(
+            mod.wn_is_sink,
+            mod.wnode_constant_inflow,
+            mod.wnode_constant_consumption,
+        ),
+    )
     switch_data.load_aug(
         optional=True,
-        filename=os.path.join(inputs_dir, 'water_node_tp_flows.csv'),
-        optional_params=['mod.wnode_tp_inflow', 'mod.wnode_tp_consumption'],
-        param=(mod.wnode_tp_inflow, mod.wnode_tp_consumption))
+        filename=os.path.join(inputs_dir, "water_node_tp_flows.csv"),
+        optional_params=["mod.wnode_tp_inflow", "mod.wnode_tp_consumption"],
+        param=(mod.wnode_tp_inflow, mod.wnode_tp_consumption),
+    )
     switch_data.load_aug(
-        filename=os.path.join(inputs_dir, 'reservoirs.csv'),
+        filename=os.path.join(inputs_dir, "reservoirs.csv"),
         index=mod.RESERVOIRS,
-        param=(mod.res_min_vol, mod.res_max_vol,
-            mod.initial_res_vol, mod.final_res_vol))
-    if os.path.exists(os.path.join(inputs_dir, 'reservoir_tp_data.csv')):
+        param=(
+            mod.res_min_vol,
+            mod.res_max_vol,
+            mod.initial_res_vol,
+            mod.final_res_vol,
+        ),
+    )
+    if os.path.exists(os.path.join(inputs_dir, "reservoir_tp_data.csv")):
         raise NotImplementedError(
             "Code needs to be added to hydro_system module to enforce "
             "reservoir volume limits per timepoint."
         )
     switch_data.load_aug(
-        filename=os.path.join(inputs_dir, 'reservoir_tp_data.csv'),
+        filename=os.path.join(inputs_dir, "reservoir_tp_data.csv"),
         optional=True,
-        optional_params=['mod.res_max_vol_tp', 'mod.res_min_vol_tp'],
-        param=(mod.res_max_vol_tp, mod.res_min_vol_tp))
+        optional_params=["mod.res_max_vol_tp", "mod.res_min_vol_tp"],
+        param=(mod.res_max_vol_tp, mod.res_min_vol_tp),
+    )
     switch_data.load_aug(
-        filename=os.path.join(inputs_dir, 'water_connections.csv'),
+        filename=os.path.join(inputs_dir, "water_connections.csv"),
         index=mod.WATER_CONNECTIONS,
-        param=(mod.water_node_from, mod.water_node_to, mod.wc_capacity))
+        param=(mod.water_node_from, mod.water_node_to, mod.wc_capacity),
+    )
     switch_data.load_aug(
         optional=True,
-        filename=os.path.join(inputs_dir, 'min_eco_flows.csv'),
-        param=(mod.min_eco_flow))
+        filename=os.path.join(inputs_dir, "min_eco_flows.csv"),
+        param=(mod.min_eco_flow),
+    )
     switch_data.load_aug(
-        filename=os.path.join(inputs_dir, 'hydro_generation_projects.csv'),
+        filename=os.path.join(inputs_dir, "hydro_generation_projects.csv"),
         index=mod.HYDRO_GENS,
-        param=(mod.hydro_efficiency, mod.hydraulic_location))
+        param=(mod.hydro_efficiency, mod.hydraulic_location),
+    )
     switch_data.load_aug(
-        filename=os.path.join(inputs_dir, 'spillage_penalty.csv'),
+        filename=os.path.join(inputs_dir, "spillage_penalty.csv"),
         optional=True,
-        param=(mod.spillage_penalty,)
+        param=(mod.spillage_penalty,),
     )

--- a/switch_model/generators/extensions/storage.py
+++ b/switch_model/generators/extensions/storage.py
@@ -11,9 +11,15 @@ from pyomo.environ import *
 import os, collections
 from switch_model.financials import capital_recovery_factor as crf
 
-dependencies = 'switch_model.timescales', 'switch_model.balancing.load_zones',\
-    'switch_model.financials', 'switch_model.energy_sources.properties', \
-    'switch_model.generators.core.build', 'switch_model.generators.core.dispatch'
+dependencies = (
+    "switch_model.timescales",
+    "switch_model.balancing.load_zones",
+    "switch_model.financials",
+    "switch_model.energy_sources.properties",
+    "switch_model.generators.core.build",
+    "switch_model.generators.core.dispatch",
+)
+
 
 def define_components(mod):
     """
@@ -106,67 +112,69 @@ def define_components(mod):
     mod.STORAGE_GENS = Set(within=mod.GENERATION_PROJECTS)
     mod.STORAGE_GEN_PERIODS = Set(
         within=mod.GEN_PERIODS,
-        initialize=lambda m: [(g, p) for g in m.STORAGE_GENS for p in m.PERIODS_FOR_GEN[g]]
+        initialize=lambda m: [
+            (g, p) for g in m.STORAGE_GENS for p in m.PERIODS_FOR_GEN[g]
+        ],
     )
-    mod.gen_storage_efficiency = Param(
-        mod.STORAGE_GENS,
-        within=PercentFraction)
+    mod.gen_storage_efficiency = Param(mod.STORAGE_GENS, within=PercentFraction)
     # TODO: rename to gen_charge_to_discharge_ratio?
     mod.gen_store_to_release_ratio = Param(
-        mod.STORAGE_GENS,
-        within=NonNegativeReals,
-        default=1.0)
+        mod.STORAGE_GENS, within=NonNegativeReals, default=1.0
+    )
     mod.gen_storage_energy_to_power_ratio = Param(
-        mod.STORAGE_GENS,
-        within=NonNegativeReals,
-        default=float("inf")) # inf is a flag that no value is specified (nan and None don't work)
+        mod.STORAGE_GENS, within=NonNegativeReals, default=float("inf")
+    )  # inf is a flag that no value is specified (nan and None don't work)
     mod.gen_storage_max_cycles_per_year = Param(
-        mod.STORAGE_GENS,
-        within=NonNegativeReals,
-        default=float('inf'))
+        mod.STORAGE_GENS, within=NonNegativeReals, default=float("inf")
+    )
 
     # TODO: build this set up instead of filtering down, to improve performance
     mod.STORAGE_GEN_BLD_YRS = Set(
         dimen=2,
         initialize=mod.GEN_BLD_YRS,
-        filter=lambda m, g, bld_yr: g in m.STORAGE_GENS)
+        filter=lambda m, g, bld_yr: g in m.STORAGE_GENS,
+    )
     mod.gen_storage_energy_overnight_cost = Param(
-        mod.STORAGE_GEN_BLD_YRS,
-        within=NonNegativeReals)
-    mod.min_data_check('gen_storage_energy_overnight_cost')
+        mod.STORAGE_GEN_BLD_YRS, within=NonNegativeReals
+    )
+    mod.min_data_check("gen_storage_energy_overnight_cost")
     mod.gen_predetermined_storage_energy_mwh = Param(
-        mod.PREDETERMINED_GEN_BLD_YRS,
-        within=NonNegativeReals)
+        mod.PREDETERMINED_GEN_BLD_YRS, within=NonNegativeReals
+    )
+
     def bounds_BuildStorageEnergy(m, g, bld_yr):
-        if((g, bld_yr) in m.gen_predetermined_storage_energy_mwh):
-            return (m.gen_predetermined_storage_energy_mwh[g, bld_yr],
-                    m.gen_predetermined_storage_energy_mwh[g, bld_yr])
+        if (g, bld_yr) in m.gen_predetermined_storage_energy_mwh:
+            return (
+                m.gen_predetermined_storage_energy_mwh[g, bld_yr],
+                m.gen_predetermined_storage_energy_mwh[g, bld_yr],
+            )
         else:
             return (0, None)
+
     mod.BuildStorageEnergy = Var(
         mod.STORAGE_GEN_BLD_YRS,
         within=NonNegativeReals,
-        bounds=bounds_BuildStorageEnergy)
+        bounds=bounds_BuildStorageEnergy,
+    )
 
     # Summarize capital costs of energy storage for the objective function
     # Note: A bug in to 2.0.0b3 - 2.0.5, assigned costs that were several times
     # too high
     mod.StorageEnergyCapitalCost = Expression(
-        mod.STORAGE_GENS, mod.PERIODS,
+        mod.STORAGE_GENS,
+        mod.PERIODS,
         rule=lambda m, g, p: sum(
             m.BuildStorageEnergy[g, bld_yr]
             * m.gen_storage_energy_overnight_cost[g, bld_yr]
             * crf(m.interest_rate, m.gen_max_age[g])
             for bld_yr in m.BLD_YRS_FOR_GEN_PERIOD[g, p]
-        )
+        ),
     )
     mod.StorageEnergyFixedCost = Expression(
         mod.PERIODS,
-        rule=lambda m, p: sum(
-            m.StorageEnergyCapitalCost[g, p] for g in m.STORAGE_GENS
-        )
+        rule=lambda m, p: sum(m.StorageEnergyCapitalCost[g, p] for g in m.STORAGE_GENS),
     )
-    mod.Cost_Components_Per_Period.append('StorageEnergyFixedCost')
+    mod.Cost_Components_Per_Period.append("StorageEnergyFixedCost")
 
     # 2.0.0b3 code:
     # mod.StorageEnergyInstallCosts = Expression(
@@ -177,30 +185,29 @@ def define_components(mod):
     #            for (g, bld_yr) in m.STORAGE_GEN_BLD_YRS))
 
     mod.StorageEnergyCapacity = Expression(
-        mod.STORAGE_GENS, mod.PERIODS,
+        mod.STORAGE_GENS,
+        mod.PERIODS,
         rule=lambda m, g, period: sum(
             m.BuildStorageEnergy[g, bld_yr]
             for bld_yr in m.BLD_YRS_FOR_GEN_PERIOD[g, period]
-        )
+        ),
     )
 
     mod.STORAGE_GEN_TPS = Set(
         dimen=2,
         initialize=lambda m: (
-            (g, tp)
-                for g in m.STORAGE_GENS
-                    for tp in m.TPS_FOR_GEN[g]))
+            (g, tp) for g in m.STORAGE_GENS for tp in m.TPS_FOR_GEN[g]
+        ),
+    )
 
-    mod.ChargeStorage = Var(
-        mod.STORAGE_GEN_TPS,
-        within=NonNegativeReals)
+    mod.ChargeStorage = Var(mod.STORAGE_GEN_TPS, within=NonNegativeReals)
 
     # Summarize storage charging for the energy balance equations
     # TODO: rename this StorageTotalCharging or similar (to indicate it's a
     # sum for a zone, not a net quantity for a project)
     def rule(m, z, t):
         # Construct and cache a set for summation as needed
-        if not hasattr(m, 'Storage_Charge_Summation_dict'):
+        if not hasattr(m, "Storage_Charge_Summation_dict"):
             m.Storage_Charge_Summation_dict = collections.defaultdict(set)
             for g, t2 in m.STORAGE_GEN_TPS:
                 z2 = m.gen_load_zone[g]
@@ -208,58 +215,73 @@ def define_components(mod):
         # Use pop to free memory
         relevant_projects = m.Storage_Charge_Summation_dict.pop((z, t), {})
         return sum(m.ChargeStorage[g, t] for g in relevant_projects)
+
     mod.StorageNetCharge = Expression(mod.LOAD_ZONES, mod.TIMEPOINTS, rule=rule)
     # Register net charging with zonal energy balance. Discharging is already
     # covered by DispatchGen.
-    mod.Zone_Power_Withdrawals.append('StorageNetCharge')
+    mod.Zone_Power_Withdrawals.append("StorageNetCharge")
 
     # use fixed energy/power ratio (# hours of capacity) when specified
     mod.Enforce_Fixed_Energy_Storage_Ratio = Constraint(
         mod.STORAGE_GEN_BLD_YRS,
-        rule=lambda m, g, y:
-            Constraint.Skip if m.gen_storage_energy_to_power_ratio[g] == float("inf") # no value specified
-            else
-            (m.BuildStorageEnergy[g, y] == m.gen_storage_energy_to_power_ratio[g] * m.BuildGen[g, y])
+        rule=lambda m, g, y: Constraint.Skip
+        if m.gen_storage_energy_to_power_ratio[g] == float("inf")  # no value specified
+        else (
+            m.BuildStorageEnergy[g, y]
+            == m.gen_storage_energy_to_power_ratio[g] * m.BuildGen[g, y]
+        ),
     )
 
     def Charge_Storage_Upper_Limit_rule(m, g, t):
-        return m.ChargeStorage[g,t] <= \
-            m.DispatchUpperLimit[g, t] * m.gen_store_to_release_ratio[g]
-    mod.Charge_Storage_Upper_Limit = Constraint(
-        mod.STORAGE_GEN_TPS,
-        rule=Charge_Storage_Upper_Limit_rule)
+        return (
+            m.ChargeStorage[g, t]
+            <= m.DispatchUpperLimit[g, t] * m.gen_store_to_release_ratio[g]
+        )
 
-    mod.StateOfCharge = Var(
-        mod.STORAGE_GEN_TPS,
-        within=NonNegativeReals)
+    mod.Charge_Storage_Upper_Limit = Constraint(
+        mod.STORAGE_GEN_TPS, rule=Charge_Storage_Upper_Limit_rule
+    )
+
+    mod.StateOfCharge = Var(mod.STORAGE_GEN_TPS, within=NonNegativeReals)
 
     def Track_State_Of_Charge_rule(m, g, t):
-        return m.StateOfCharge[g, t] == \
-            m.StateOfCharge[g, m.tp_previous[t]] + \
-            (m.ChargeStorage[g, t] * m.gen_storage_efficiency[g] -
-             m.DispatchGen[g, t]) * m.tp_duration_hrs[t]
+        return (
+            m.StateOfCharge[g, t]
+            == m.StateOfCharge[g, m.tp_previous[t]]
+            + (
+                m.ChargeStorage[g, t] * m.gen_storage_efficiency[g]
+                - m.DispatchGen[g, t]
+            )
+            * m.tp_duration_hrs[t]
+        )
+
     mod.Track_State_Of_Charge = Constraint(
-        mod.STORAGE_GEN_TPS,
-        rule=Track_State_Of_Charge_rule)
+        mod.STORAGE_GEN_TPS, rule=Track_State_Of_Charge_rule
+    )
 
     def State_Of_Charge_Upper_Limit_rule(m, g, t):
-        return m.StateOfCharge[g, t] <= \
-            m.StorageEnergyCapacity[g, m.tp_period[t]]
+        return m.StateOfCharge[g, t] <= m.StorageEnergyCapacity[g, m.tp_period[t]]
+
     mod.State_Of_Charge_Upper_Limit = Constraint(
-        mod.STORAGE_GEN_TPS,
-        rule=State_Of_Charge_Upper_Limit_rule)
+        mod.STORAGE_GEN_TPS, rule=State_Of_Charge_Upper_Limit_rule
+    )
 
     # batteries can only complete the specified number of cycles per year, averaged over each period
     mod.Battery_Cycle_Limit = Constraint(
         mod.STORAGE_GEN_PERIODS,
         rule=lambda m, g, p:
-            # solvers sometimes perform badly with infinite constraint
-            Constraint.Skip if m.gen_storage_max_cycles_per_year[g] == float('inf')
-            else (
-                sum(m.DispatchGen[g, tp] * m.tp_duration_hrs[tp] for tp in m.TPS_IN_PERIOD[p])
-                <=
-                m.gen_storage_max_cycles_per_year[g] * m.StorageEnergyCapacity[g, p] * m.period_length_years[p]
+        # solvers sometimes perform badly with infinite constraint
+        Constraint.Skip
+        if m.gen_storage_max_cycles_per_year[g] == float("inf")
+        else (
+            sum(
+                m.DispatchGen[g, tp] * m.tp_duration_hrs[tp]
+                for tp in m.TPS_IN_PERIOD[p]
             )
+            <= m.gen_storage_max_cycles_per_year[g]
+            * m.StorageEnergyCapacity[g, p]
+            * m.period_length_years[p]
+        ),
     )
 
 
@@ -290,27 +312,34 @@ def load_inputs(mod, switch_data, inputs_dir):
     # gen_storage_efficiency has been specified, then require valid settings for all
     # STORAGE_GENS.
     switch_data.load_aug(
-        filename=os.path.join(inputs_dir, 'generation_projects_info.csv'),
+        filename=os.path.join(inputs_dir, "generation_projects_info.csv"),
         optional_params=[
-            'gen_store_to_release_ratio',
-            'gen_storage_energy_to_power_ratio',
-            'gen_storage_max_cycles_per_year'],
+            "gen_store_to_release_ratio",
+            "gen_storage_energy_to_power_ratio",
+            "gen_storage_max_cycles_per_year",
+        ],
         param=(
             mod.gen_storage_efficiency,
             mod.gen_store_to_release_ratio,
             mod.gen_storage_energy_to_power_ratio,
-            mod.gen_storage_max_cycles_per_year))
+            mod.gen_storage_max_cycles_per_year,
+        ),
+    )
     # Base the set of storage projects on storage efficiency being specified.
     # TODO: define this in a more normal way
-    switch_data.data()['STORAGE_GENS'] = {
-        None: list(switch_data.data(name='gen_storage_efficiency').keys())}
+    switch_data.data()["STORAGE_GENS"] = {
+        None: list(switch_data.data(name="gen_storage_efficiency").keys())
+    }
     switch_data.load_aug(
-        filename=os.path.join(inputs_dir, 'gen_build_costs.csv'),
-        param=(mod.gen_storage_energy_overnight_cost))
+        filename=os.path.join(inputs_dir, "gen_build_costs.csv"),
+        param=(mod.gen_storage_energy_overnight_cost),
+    )
     switch_data.load_aug(
         optional=True,
-        filename=os.path.join(inputs_dir, 'gen_build_predetermined.csv'),
-        param=(mod.gen_predetermined_storage_energy_mwh,))
+        filename=os.path.join(inputs_dir, "gen_build_predetermined.csv"),
+        param=(mod.gen_predetermined_storage_energy_mwh,),
+    )
+
 
 def post_solve(instance, outdir):
     """
@@ -318,25 +347,56 @@ def post_solve(instance, outdir):
     dispatch info to storage_dispatch.csv
     """
     import switch_model.reporting as reporting
+
     reporting.write_table(
-        instance, instance.STORAGE_GEN_BLD_YRS,
+        instance,
+        instance.STORAGE_GEN_BLD_YRS,
         output_file=os.path.join(outdir, "storage_builds.csv"),
-        headings=("generation_project", "period", "load_zone",
-                  "IncrementalPowerCapacityMW", "IncrementalEnergyCapacityMWh",
-                  "OnlinePowerCapacityMW", "OnlineEnergyCapacityMWh" ),
+        headings=(
+            "generation_project",
+            "period",
+            "load_zone",
+            "IncrementalPowerCapacityMW",
+            "IncrementalEnergyCapacityMWh",
+            "OnlinePowerCapacityMW",
+            "OnlineEnergyCapacityMWh",
+        ),
         values=lambda m, g, bld_yr: (
-            g, bld_yr, m.gen_load_zone[g],
-            m.BuildGen[g, bld_yr], m.BuildStorageEnergy[g, bld_yr],
-            (m.GenCapacity[g, bld_yr] if bld_yr in m.PERIODS else m.BuildGen[g, bld_yr]),
-            (m.StorageEnergyCapacity[g, bld_yr] if bld_yr in m.PERIODS else m.BuildStorageEnergy[g, bld_yr])
-            ))
+            g,
+            bld_yr,
+            m.gen_load_zone[g],
+            m.BuildGen[g, bld_yr],
+            m.BuildStorageEnergy[g, bld_yr],
+            (
+                m.GenCapacity[g, bld_yr]
+                if bld_yr in m.PERIODS
+                else m.BuildGen[g, bld_yr]
+            ),
+            (
+                m.StorageEnergyCapacity[g, bld_yr]
+                if bld_yr in m.PERIODS
+                else m.BuildStorageEnergy[g, bld_yr]
+            ),
+        ),
+    )
     reporting.write_table(
-        instance, instance.STORAGE_GEN_TPS,
+        instance,
+        instance.STORAGE_GEN_TPS,
         output_file=os.path.join(outdir, "storage_dispatch.csv"),
-        headings=("generation_project", "timepoint", "load_zone",
-                  "ChargeMW", "DischargeMW", "StateOfCharge"),
+        headings=(
+            "generation_project",
+            "timepoint",
+            "load_zone",
+            "ChargeMW",
+            "DischargeMW",
+            "StateOfCharge",
+        ),
         values=lambda m, g, t: (
-            g, m.tp_timestamp[t], m.gen_load_zone[g],
-            m.ChargeStorage[g, t], m.DispatchGen[g, t],
-            m.StateOfCharge[g, t]
-            ))
+            g,
+            m.tp_timestamp[t],
+            m.gen_load_zone[g],
+            m.ChargeStorage[g, t],
+            m.DispatchGen[g, t],
+            m.StateOfCharge[g, t],
+        ),
+    )

--- a/switch_model/hawaii/batteries_fixed_calendar_life.py
+++ b/switch_model/hawaii/batteries_fixed_calendar_life.py
@@ -3,14 +3,19 @@ import os
 from pyomo.environ import *
 from switch_model.financials import capital_recovery_factor as crf
 
+
 def define_components(m):
 
     # TODO: change this to allow multiple storage technologies.
 
     # battery capital cost
     # TODO: accept a single battery_capital_cost_per_mwh_capacity value or the annual values shown here
-    m.BATTERY_CAPITAL_COST_YEARS = Set() # list of all years for which capital costs are available
-    m.battery_capital_cost_per_mwh_capacity_by_year = Param(m.BATTERY_CAPITAL_COST_YEARS)
+    m.BATTERY_CAPITAL_COST_YEARS = (
+        Set()
+    )  # list of all years for which capital costs are available
+    m.battery_capital_cost_per_mwh_capacity_by_year = Param(
+        m.BATTERY_CAPITAL_COST_YEARS
+    )
 
     # TODO: merge this code with batteries.py and auto-select between fixed calendar life and cycle life
     # based on whether battery_n_years or battery_n_cycles is provided. (Or find some hybrid that can
@@ -27,11 +32,14 @@ def define_components(m):
     # amount of battery capacity to build and use (in MWh)
     # TODO: integrate this with other project data, so it can contribute to reserves, etc.
     m.BuildBattery = Var(m.LOAD_ZONES, m.PERIODS, within=NonNegativeReals)
-    m.Battery_Capacity = Expression(m.LOAD_ZONES, m.PERIODS, rule=lambda m, z, p:
-        sum(
+    m.Battery_Capacity = Expression(
+        m.LOAD_ZONES,
+        m.PERIODS,
+        rule=lambda m, z, p: sum(
             m.BuildBattery[z, bld_yr]
-                for bld_yr in m.CURRENT_AND_PRIOR_PERIODS_FOR_PERIOD[p] if bld_yr + m.battery_n_years > p
-        )
+            for bld_yr in m.CURRENT_AND_PRIOR_PERIODS_FOR_PERIOD[p]
+            if bld_yr + m.battery_n_years > p
+        ),
     )
 
     # rate of charging/discharging battery
@@ -42,8 +50,8 @@ def define_components(m):
     m.BatteryLevel = Var(m.LOAD_ZONES, m.TIMEPOINTS, within=NonNegativeReals)
 
     # add storage dispatch to the zonal energy balance
-    m.Zone_Power_Injections.append('DischargeBattery')
-    m.Zone_Power_Withdrawals.append('ChargeBattery')
+    m.Zone_Power_Injections.append("DischargeBattery")
+    m.Zone_Power_Withdrawals.append("ChargeBattery")
 
     # add the batteries to the objective function
 
@@ -54,95 +62,115 @@ def define_components(m):
             m.BuildBattery[z, bld_yr]
             * m.battery_capital_cost_per_mwh_capacity_by_year[bld_yr]
             * crf(m.interest_rate, m.battery_n_years)
-                for bld_yr in m.CURRENT_AND_PRIOR_PERIODS_FOR_PERIOD[p] if bld_yr + m.battery_n_years > p
-                    for z in m.LOAD_ZONES
-        )
+            for bld_yr in m.CURRENT_AND_PRIOR_PERIODS_FOR_PERIOD[p]
+            if bld_yr + m.battery_n_years > p
+            for z in m.LOAD_ZONES
+        ),
     )
-    m.Cost_Components_Per_Period.append('BatteryAnnualCost')
+    m.Cost_Components_Per_Period.append("BatteryAnnualCost")
 
     # Calculate the state of charge based on conservation of energy
     # NOTE: this is circular for each day
     # NOTE: the overall level for the day is free, but the levels each timepoint are chained.
-    m.Battery_Level_Calc = Constraint(m.LOAD_ZONES, m.TIMEPOINTS, rule=lambda m, z, t:
-        m.BatteryLevel[z, t] ==
-            m.BatteryLevel[z, m.tp_previous[t]]
-            + m.tp_duration_hrs[t] * (
-                m.battery_efficiency * m.ChargeBattery[z, m.tp_previous[t]]
-                - m.DischargeBattery[z, m.tp_previous[t]]
-            )
+    m.Battery_Level_Calc = Constraint(
+        m.LOAD_ZONES,
+        m.TIMEPOINTS,
+        rule=lambda m, z, t: m.BatteryLevel[z, t]
+        == m.BatteryLevel[z, m.tp_previous[t]]
+        + m.tp_duration_hrs[t]
+        * (
+            m.battery_efficiency * m.ChargeBattery[z, m.tp_previous[t]]
+            - m.DischargeBattery[z, m.tp_previous[t]]
+        ),
     )
 
     # limits on storage level
-    m.Battery_Min_Level = Constraint(m.LOAD_ZONES, m.TIMEPOINTS, rule=lambda m, z, t:
-        (1.0 - m.battery_max_discharge) * m.Battery_Capacity[z, m.tp_period[t]]
-        <=
-        m.BatteryLevel[z, t]
+    m.Battery_Min_Level = Constraint(
+        m.LOAD_ZONES,
+        m.TIMEPOINTS,
+        rule=lambda m, z, t: (1.0 - m.battery_max_discharge)
+        * m.Battery_Capacity[z, m.tp_period[t]]
+        <= m.BatteryLevel[z, t],
     )
-    m.Battery_Max_Level = Constraint(m.LOAD_ZONES, m.TIMEPOINTS, rule=lambda m, z, t:
-        m.BatteryLevel[z, t]
-        <=
-        m.Battery_Capacity[z, m.tp_period[t]]
+    m.Battery_Max_Level = Constraint(
+        m.LOAD_ZONES,
+        m.TIMEPOINTS,
+        rule=lambda m, z, t: m.BatteryLevel[z, t]
+        <= m.Battery_Capacity[z, m.tp_period[t]],
     )
 
-    m.Battery_Max_Charge_Rate = Constraint(m.LOAD_ZONES, m.TIMEPOINTS, rule=lambda m, z, t:
-        m.ChargeBattery[z, t]
-        <=
+    m.Battery_Max_Charge_Rate = Constraint(
+        m.LOAD_ZONES,
+        m.TIMEPOINTS,
+        rule=lambda m, z, t: m.ChargeBattery[z, t] <=
         # changed 2018-02-20 to allow full discharge in min_discharge_time,
         # (previously pegged to battery_max_discharge)
-        m.Battery_Capacity[z, m.tp_period[t]] / m.battery_min_discharge_time
+        m.Battery_Capacity[z, m.tp_period[t]] / m.battery_min_discharge_time,
     )
-    m.Battery_Max_Discharge_Rate = Constraint(m.LOAD_ZONES, m.TIMEPOINTS, rule=lambda m, z, t:
-        m.DischargeBattery[z, t]
-        <=
-        m.Battery_Capacity[z, m.tp_period[t]] / m.battery_min_discharge_time
+    m.Battery_Max_Discharge_Rate = Constraint(
+        m.LOAD_ZONES,
+        m.TIMEPOINTS,
+        rule=lambda m, z, t: m.DischargeBattery[z, t]
+        <= m.Battery_Capacity[z, m.tp_period[t]] / m.battery_min_discharge_time,
     )
 
     # how much could output/input be increased on short notice (to provide reserves)
-    m.BatterySlackUp = Expression(m.LOAD_ZONES, m.TIMEPOINTS, rule=lambda m, z, t:
-        m.Battery_Capacity[z, m.tp_period[t]] / m.battery_min_discharge_time
+    m.BatterySlackUp = Expression(
+        m.LOAD_ZONES,
+        m.TIMEPOINTS,
+        rule=lambda m, z, t: m.Battery_Capacity[z, m.tp_period[t]]
+        / m.battery_min_discharge_time
         - m.DischargeBattery[z, t]
-        + m.ChargeBattery[z, t]
+        + m.ChargeBattery[z, t],
     )
-    m.BatterySlackDown = Expression(m.LOAD_ZONES, m.TIMEPOINTS, rule=lambda m, z, t:
-        m.Battery_Capacity[z, m.tp_period[t]] / m.battery_min_discharge_time
+    m.BatterySlackDown = Expression(
+        m.LOAD_ZONES,
+        m.TIMEPOINTS,
+        rule=lambda m, z, t: m.Battery_Capacity[z, m.tp_period[t]]
+        / m.battery_min_discharge_time
         - m.ChargeBattery[z, t]
-        + m.DischargeBattery[z, t]
+        + m.DischargeBattery[z, t],
     )
 
     # assume batteries can only complete one full cycle per day, averaged over each period
     # (this was pegged to battery_max_discharge before 2018-02-20)
-    m.Battery_Cycle_Limit = Constraint(m.LOAD_ZONES, m.PERIODS, rule=lambda m, z, p:
-        sum(m.DischargeBattery[z, tp] * m.tp_duration_hrs[tp] for tp in m.TPS_IN_PERIOD[p])
-        <=
-        m.Battery_Capacity[z, p] * m.period_length_hours[p]
+    m.Battery_Cycle_Limit = Constraint(
+        m.LOAD_ZONES,
+        m.PERIODS,
+        rule=lambda m, z, p: sum(
+            m.DischargeBattery[z, tp] * m.tp_duration_hrs[tp]
+            for tp in m.TPS_IN_PERIOD[p]
+        )
+        <= m.Battery_Capacity[z, p] * m.period_length_hours[p],
     )
 
     # Register with spinning reserves if it is available
-    if hasattr(m, 'Spinning_Reserve_Up_Provisions'):
+    if hasattr(m, "Spinning_Reserve_Up_Provisions"):
         m.BatterySpinningReserveUp = Expression(
             m.BALANCING_AREA_TIMEPOINTS,
-            rule=lambda m, b, t:
-                sum(m.BatterySlackUp[z, t]
-                    for z in m.ZONES_IN_BALANCING_AREA[b])
+            rule=lambda m, b, t: sum(
+                m.BatterySlackUp[z, t] for z in m.ZONES_IN_BALANCING_AREA[b]
+            ),
         )
-        m.Spinning_Reserve_Up_Provisions.append('BatterySpinningReserveUp')
+        m.Spinning_Reserve_Up_Provisions.append("BatterySpinningReserveUp")
 
         m.BatterySpinningReserveDown = Expression(
             m.BALANCING_AREA_TIMEPOINTS,
-            rule=lambda m, b, t: \
-                sum(m.BatterySlackDown[z, t]
-                    for z in m.ZONES_IN_BALANCING_AREA[b])
+            rule=lambda m, b, t: sum(
+                m.BatterySlackDown[z, t] for z in m.ZONES_IN_BALANCING_AREA[b]
+            ),
         )
-        m.Spinning_Reserve_Down_Provisions.append('BatterySpinningReserveDown')
+        m.Spinning_Reserve_Down_Provisions.append("BatterySpinningReserveDown")
 
 
 def load_inputs(m, switch_data, inputs_dir):
     """
     Import battery data from .dat and .csv files.
     """
-    switch_data.load(filename=os.path.join(inputs_dir, 'batteries.dat'))
+    switch_data.load(filename=os.path.join(inputs_dir, "batteries.dat"))
     switch_data.load_aug(
         optional=False,
-        filename=os.path.join(inputs_dir, 'battery_capital_cost.csv'),
+        filename=os.path.join(inputs_dir, "battery_capital_cost.csv"),
         index=m.BATTERY_CAPITAL_COST_YEARS,
-        param=(m.battery_capital_cost_per_mwh_capacity_by_year,))
+        param=(m.battery_capital_cost_per_mwh_capacity_by_year,),
+    )

--- a/switch_model/hawaii/demand_response_no_reserves.py
+++ b/switch_model/hawaii/demand_response_no_reserves.py
@@ -18,21 +18,35 @@ import os, sys, time
 from pprint import pprint
 from pyomo.environ import *
 import switch_model.utilities as utilities
-demand_module = None    # will be set via command-line options
+
+demand_module = None  # will be set via command-line options
 
 from . import util
 from .util import get
 
+
 def define_arguments(argparser):
-    argparser.add_argument("--dr-flat-pricing", action='store_true', default=False,
-        help="Charge a constant (average) price for electricity, rather than varying hour by hour")
-    argparser.add_argument("--dr-total-cost-pricing", action='store_true', default=False,
-        help="Include both marginal and non-marginal(fixed) costs when setting prices")
-    argparser.add_argument("--dr-demand-module", default=None,
+    argparser.add_argument(
+        "--dr-flat-pricing",
+        action="store_true",
+        default=False,
+        help="Charge a constant (average) price for electricity, rather than varying hour by hour",
+    )
+    argparser.add_argument(
+        "--dr-total-cost-pricing",
+        action="store_true",
+        default=False,
+        help="Include both marginal and non-marginal(fixed) costs when setting prices",
+    )
+    argparser.add_argument(
+        "--dr-demand-module",
+        default=None,
         help="Name of module to use for demand-response bids. This should also be "
         "specified in the modules list, and should provide calibrate() and bid() functions. "
         "Pre-written options include constant_elasticity_demand_system or r_demand_system. "
-        "Specify one of these in the modules list and use --help again to see module-specific options.")
+        "Specify one of these in the modules list and use --help again to see module-specific options.",
+    )
+
 
 def define_components(m):
 
@@ -76,20 +90,24 @@ def define_components(m):
     # amount of unserved load during each timepoint
     m.DRUnservedLoad = Var(m.LOAD_ZONES, m.TIMEPOINTS, within=NonNegativeReals)
     # total cost for unserved load
-    m.DR_Unserved_Load_Penalty = Expression(m.TIMEPOINTS, rule=lambda m, tp:
-        sum(m.DRUnservedLoad[z, tp] * m.dr_unserved_load_penalty_per_mwh for z in m.LOAD_ZONES)
+    m.DR_Unserved_Load_Penalty = Expression(
+        m.TIMEPOINTS,
+        rule=lambda m, tp: sum(
+            m.DRUnservedLoad[z, tp] * m.dr_unserved_load_penalty_per_mwh
+            for z in m.LOAD_ZONES
+        ),
     )
     # add unserved load to the zonal energy balance
-    m.Zone_Power_Injections.append('DRUnservedLoad')
+    m.Zone_Power_Injections.append("DRUnservedLoad")
     # add the unserved load penalty to the model's objective function
-    m.Cost_Components_Per_TP.append('DR_Unserved_Load_Penalty')
+    m.Cost_Components_Per_TP.append("DR_Unserved_Load_Penalty")
 
     ###################
     # Price Responsive Demand bids
     ##################
 
     # list of all bids that have been received from the demand system
-    m.DR_BID_LIST = Set(initialize = [], ordered=True)
+    m.DR_BID_LIST = Set(initialize=[], ordered=True)
     # we need an explicit indexing set for everything that depends on DR_BID_LIST
     # so we can reconstruct it (and them) each time we add an element to DR_BID_LIST
     # (not needed, and actually doesn't work -- reconstruct() fails for sets)
@@ -108,7 +126,9 @@ def define_components(m):
     m.dr_bid_benefit = Param(m.DR_BID_LIST, m.LOAD_ZONES, m.TIMESERIES, mutable=True)
 
     # weights to assign to the bids for each timeseries when constructing an optimal demand profile
-    m.DRBidWeight = Var(m.DR_BID_LIST, m.LOAD_ZONES, m.TIMESERIES, within=NonNegativeReals)
+    m.DRBidWeight = Var(
+        m.DR_BID_LIST, m.LOAD_ZONES, m.TIMESERIES, within=NonNegativeReals
+    )
 
     # def DR_Convex_Bid_Weight_rule(m, z, ts):
     #     if len(m.DR_BID_LIST) == 0:
@@ -119,9 +139,12 @@ def define_components(m):
     #         return (sum(m.DRBidWeight[b, z, ts] for b in m.DR_BID_LIST) == 1)
     #
     # choose a convex combination of bids for each zone and timeseries
-    m.DR_Convex_Bid_Weight = Constraint(m.LOAD_ZONES, m.TIMESERIES, rule=lambda m, z, ts:
-        Constraint.Skip if len(m.DR_BID_LIST) == 0
-            else (sum(m.DRBidWeight[b, z, ts] for b in m.DR_BID_LIST) == 1)
+    m.DR_Convex_Bid_Weight = Constraint(
+        m.LOAD_ZONES,
+        m.TIMESERIES,
+        rule=lambda m, z, ts: Constraint.Skip
+        if len(m.DR_BID_LIST) == 0
+        else (sum(m.DRBidWeight[b, z, ts] for b in m.DR_BID_LIST) == 1),
     )
 
     # Since we don't have differentiated prices for each zone, we have to use the same
@@ -130,8 +153,11 @@ def define_components(m):
     # Note: LOAD_ZONES is not an ordered set, so we have to use a trick to get a single
     # arbitrary one to refer to (next(iter(m.LOAD_ZONES)) would also work).
     m.DR_Load_Zone_Shared_Bid_Weight = Constraint(
-        m.DR_BID_LIST, m.LOAD_ZONES, m.TIMESERIES, rule=lambda m, b, z, ts:
-            m.DRBidWeight[b, z, ts] == m.DRBidWeight[b, list(m.LOAD_ZONES)[0], ts]
+        m.DR_BID_LIST,
+        m.LOAD_ZONES,
+        m.TIMESERIES,
+        rule=lambda m, b, z, ts: m.DRBidWeight[b, z, ts]
+        == m.DRBidWeight[b, list(m.LOAD_ZONES)[0], ts],
     )
 
     # For flat-price models, we have to use the same weight for all timeseries within the
@@ -139,16 +165,20 @@ def define_components(m):
     # induce different adjustments in individual timeseries.
     if m.options.dr_flat_pricing:
         m.DR_Flat_Bid_Weight = Constraint(
-            m.DR_BID_LIST, m.LOAD_ZONES, m.TIMESERIES, rule=lambda m, b, z, ts:
-                m.DRBidWeight[b, z, ts]
-                == m.DRBidWeight[b, z, m.tp_ts[m.TPS_IN_PERIOD[m.ts_period[ts]].first()]]
+            m.DR_BID_LIST,
+            m.LOAD_ZONES,
+            m.TIMESERIES,
+            rule=lambda m, b, z, ts: m.DRBidWeight[b, z, ts]
+            == m.DRBidWeight[b, z, m.tp_ts[m.TPS_IN_PERIOD[m.ts_period[ts]].first()]],
         )
 
-
     # Optimal level of demand, calculated from available bids (negative, indicating consumption)
-    m.FlexibleDemand = Expression(m.LOAD_ZONES, m.TIMEPOINTS,
-        rule=lambda m, z, tp:
-            sum(m.DRBidWeight[b, z, m.tp_ts[tp]] * m.dr_bid[b, z, tp] for b in m.DR_BID_LIST)
+    m.FlexibleDemand = Expression(
+        m.LOAD_ZONES,
+        m.TIMEPOINTS,
+        rule=lambda m, z, tp: sum(
+            m.DRBidWeight[b, z, m.tp_ts[tp]] * m.dr_bid[b, z, tp] for b in m.DR_BID_LIST
+        ),
     )
 
     # replace zone_demand_mw with FlexibleDemand in the energy balance constraint
@@ -157,31 +187,37 @@ def define_components(m):
     # a certain ordering.
     # m.Zone_Power_Withdrawals.remove('zone_demand_mw')
     # m.Zone_Power_Withdrawals.append('FlexibleDemand')
-    idx = m.Zone_Power_Withdrawals.index('zone_demand_mw')
-    m.Zone_Power_Withdrawals[idx] = 'FlexibleDemand'
+    idx = m.Zone_Power_Withdrawals.index("zone_demand_mw")
+    m.Zone_Power_Withdrawals[idx] = "FlexibleDemand"
 
     # private benefit of the electricity consumption
     # (i.e., willingness to pay for the current electricity supply)
     # reported as negative cost, i.e., positive benefit
     # also divide by number of timepoints in the timeseries
     # to convert from a cost per timeseries to a cost per timepoint.
-    m.DR_Welfare_Cost = Expression(m.TIMEPOINTS, rule=lambda m, tp:
-        (-1.0)
-        * sum(m.DRBidWeight[b, z, m.tp_ts[tp]] * m.dr_bid_benefit[b, z, m.tp_ts[tp]]
-            for b in m.DR_BID_LIST for z in m.LOAD_ZONES)
-        * m.tp_duration_hrs[tp] / m.ts_num_tps[m.tp_ts[tp]]
+    m.DR_Welfare_Cost = Expression(
+        m.TIMEPOINTS,
+        rule=lambda m, tp: (-1.0)
+        * sum(
+            m.DRBidWeight[b, z, m.tp_ts[tp]] * m.dr_bid_benefit[b, z, m.tp_ts[tp]]
+            for b in m.DR_BID_LIST
+            for z in m.LOAD_ZONES
+        )
+        * m.tp_duration_hrs[tp]
+        / m.ts_num_tps[m.tp_ts[tp]],
     )
 
     # add the private benefit to the model's objective function
-    m.Cost_Components_Per_TP.append('DR_Welfare_Cost')
+    m.Cost_Components_Per_TP.append("DR_Welfare_Cost")
 
     # annual costs, recovered via baseline prices
     # but not included in switch's calculation of costs
     m.other_costs = Param(m.PERIODS, mutable=True, default=0.0)
-    m.Cost_Components_Per_Period.append('other_costs')
+    m.Cost_Components_Per_Period.append("other_costs")
 
     # variable to store the baseline data
     m.base_data = None
+
 
 def pre_iterate(m):
     # could all prev values be stored in post_iterate?
@@ -195,20 +231,28 @@ def pre_iterate(m):
 
     # store various properties from previous model solution for later reference
     m.prev_marginal_cost = (
-        {(z, tp): None for z in m.LOAD_ZONES for tp in m.TIMEPOINTS} # model hasn't been solved yet
-        if m.iteration_number == 0 else
-        {(z, tp): electricity_marginal_cost(m, z, tp) for z in m.LOAD_ZONES for tp in m.TIMEPOINTS}
+        {
+            (z, tp): None for z in m.LOAD_ZONES for tp in m.TIMEPOINTS
+        }  # model hasn't been solved yet
+        if m.iteration_number == 0
+        else {
+            (z, tp): electricity_marginal_cost(m, z, tp)
+            for z in m.LOAD_ZONES
+            for tp in m.TIMEPOINTS
+        }
     )
     m.prev_demand = (
-        {(z, tp): None for z in m.LOAD_ZONES for tp in m.TIMEPOINTS} # model hasn't been solved yet
-        if m.iteration_number == 0 else
-        {(z, tp): electricity_demand(m, z, tp) for z in m.LOAD_ZONES for tp in m.TIMEPOINTS}
+        {
+            (z, tp): None for z in m.LOAD_ZONES for tp in m.TIMEPOINTS
+        }  # model hasn't been solved yet
+        if m.iteration_number == 0
+        else {
+            (z, tp): electricity_demand(m, z, tp)
+            for z in m.LOAD_ZONES
+            for tp in m.TIMEPOINTS
+        }
     )
-    m.prev_SystemCost = (
-        None
-        if m.iteration_number == 0 else
-        value(m.SystemCost)
-    )
+    m.prev_SystemCost = None if m.iteration_number == 0 else value(m.SystemCost)
 
     if m.iteration_number > 0:
         # store cost of previous solution before it gets altered by update_demand()
@@ -228,47 +272,61 @@ def pre_iterate(m):
         # different solution that would be much better than the one we have now.
         # This ignores other solutions far away, where an integer variable is flipped,
         # but that's OK. (?)
-        prev_cost = value(sum(
-            (
-                sum(
-                    m.prev_marginal_cost[z, tp] * m.prev_demand[z, tp]
+        prev_cost = value(
+            sum(
+                (
+                    sum(
+                        m.prev_marginal_cost[z, tp] * m.prev_demand[z, tp]
                         for z in m.LOAD_ZONES
-                ) + m.DR_Welfare_Cost[tp]
-            ) * m.bring_timepoint_costs_to_base_year[tp]
+                    )
+                    + m.DR_Welfare_Cost[tp]
+                )
+                * m.bring_timepoint_costs_to_base_year[tp]
                 for ts in m.TIMESERIES
-                    for tp in m.TPS_IN_TS[ts]
-        ))
+                for tp in m.TPS_IN_TS[ts]
+            )
+        )
 
     # get the next bid and attach it to the model
     update_demand(m)
 
-    b = m.DR_BID_LIST.last()    # current bid number
+    b = m.DR_BID_LIST.last()  # current bid number
 
     if m.iteration_number > 0:
         # get an estimate of best possible net cost of serving load
         # (if we could completely serve the last bid at the prices we quoted,
         # that would be an optimum; the actual cost may be higher but never lower)
-        best_cost = value(sum(
+        best_cost = value(
             sum(
-                m.prev_marginal_cost[z, tp] * m.dr_bid[b, z, tp]
-                - m.dr_bid_benefit[b, z, ts] * m.tp_duration_hrs[tp] / m.ts_num_tps[ts]
-                for z in m.LOAD_ZONES
+                sum(
+                    m.prev_marginal_cost[z, tp] * m.dr_bid[b, z, tp]
+                    - m.dr_bid_benefit[b, z, ts]
+                    * m.tp_duration_hrs[tp]
+                    / m.ts_num_tps[ts]
+                    for z in m.LOAD_ZONES
+                )
+                * m.bring_timepoint_costs_to_base_year[tp]
+                for ts in m.TIMESERIES
+                for tp in m.TPS_IN_TS[ts]
             )
-            * m.bring_timepoint_costs_to_base_year[tp]
-            for ts in m.TIMESERIES
-            for tp in m.TPS_IN_TS[ts]
-        ))
-        print("lower bound={}, previous cost={}, ratio={}".format(
-            best_cost, prev_cost, prev_cost/best_cost))
+        )
+        print(
+            "lower bound={}, previous cost={}, ratio={}".format(
+                best_cost, prev_cost, prev_cost / best_cost
+            )
+        )
 
     # Check for convergence -- optimality gap is less than 0.1% of best possible cost
     # (which may be negative)
     # TODO: index this to the direct costs, rather than the direct costs minus benefits
     # as it stands, it converges with about $50,000,000 optimality gap, which is about
     # 3% of direct costs.
-    converged = (m.iteration_number > 0 and (prev_cost - best_cost)/abs(best_cost) <= 0.0001)
+    converged = (
+        m.iteration_number > 0 and (prev_cost - best_cost) / abs(best_cost) <= 0.0001
+    )
 
     return converged
+
 
 def post_iterate(m):
     print("\n\n=======================================================")
@@ -276,17 +334,19 @@ def post_iterate(m):
     print("=======================================================")
     print("Total cost: ${v:,.0f}".format(v=value(m.SystemCost)))
 
-
     # TODO:
     # maybe calculate prices for the next round here and attach them to the
     # model, so they can be reported as final prices (currently we don't
     # report the final prices, only the prices prior to the final model run)
 
-    SystemCost = value(m.SystemCost)    # calculate once to save time
-    print("prev_SystemCost={}, SystemCost={}, ratio={}".format(
-        m.prev_SystemCost, SystemCost,
-        None if m.prev_SystemCost is None else SystemCost/m.prev_SystemCost
-    ))
+    SystemCost = value(m.SystemCost)  # calculate once to save time
+    print(
+        "prev_SystemCost={}, SystemCost={}, ratio={}".format(
+            m.prev_SystemCost,
+            SystemCost,
+            None if m.prev_SystemCost is None else SystemCost / m.prev_SystemCost,
+        )
+    )
 
     tag = m.options.scenario_name
     outputs_dir = m.options.outputs_dir
@@ -296,12 +356,23 @@ def post_iterate(m):
         util.create_table(
             output_file=os.path.join(outputs_dir, "bid_{t}.csv".format(t=tag)),
             headings=(
-                "bid_num", "load_zone", "timeseries", "timepoint", "marginal_cost", "price",
-                "bid_load", "wtp", "base_price", "base_load"
-            )
+                "bid_num",
+                "load_zone",
+                "timeseries",
+                "timepoint",
+                "marginal_cost",
+                "price",
+                "bid_load",
+                "wtp",
+                "base_price",
+                "base_load",
+            ),
         )
-    b = m.DR_BID_LIST.last()    # current bid
-    util.append_table(m, m.LOAD_ZONES, m.TIMEPOINTS,
+    b = m.DR_BID_LIST.last()  # current bid
+    util.append_table(
+        m,
+        m.LOAD_ZONES,
+        m.TIMEPOINTS,
         output_file=os.path.join(outputs_dir, "bid_{t}.csv".format(t=tag)),
         values=lambda m, z, tp: (
             b,
@@ -314,18 +385,28 @@ def post_iterate(m):
             m.dr_bid_benefit[b, z, m.tp_ts[tp]],
             m.base_data_dict[z, tp][1],
             m.base_data_dict[z, tp][0],
-        )
+        ),
     )
 
     # store the current bid weights for future reference
     if m.iteration_number == 0:
         util.create_table(
             output_file=os.path.join(outputs_dir, "bid_weights_{t}.csv".format(t=tag)),
-            headings=("iteration", "load_zone", "timeseries", "bid_num", "weight")
+            headings=("iteration", "load_zone", "timeseries", "bid_num", "weight"),
         )
-    util.append_table(m, m.LOAD_ZONES, m.TIMESERIES, m.DR_BID_LIST,
+    util.append_table(
+        m,
+        m.LOAD_ZONES,
+        m.TIMESERIES,
+        m.DR_BID_LIST,
         output_file=os.path.join(outputs_dir, "bid_weights_{t}.csv".format(t=tag)),
-        values=lambda m, z, ts, b: (len(m.DR_BID_LIST), z, ts, b, m.DRBidWeight[b, z, ts])
+        values=lambda m, z, ts, b: (
+            len(m.DR_BID_LIST),
+            z,
+            ts,
+            b,
+            m.DRBidWeight[b, z, ts],
+        ),
     )
 
     # report the dual costs
@@ -346,24 +427,28 @@ def update_demand(m):
     and marginal costs to calibrate the demand system, and then replaces the fixed
     demand with the flexible demand system.
     """
-    first_run = (m.base_data is None)
+    first_run = m.base_data is None
 
     print("attaching new demand bid to model")
     if first_run:
         calibrate_model(m)
 
-    else:   # not first run
+    else:  # not first run
         # print "m.DRBidWeight (first day):"
         # print [(b, z, ts, value(m.DRBidWeight[b, z, ts]))
         #     for b in m.DR_BID_LIST
         #     for z in m.LOAD_ZONES
         #     for ts in m.TIMESERIES]
         print("m.DRBidWeight:")
-        pprint([(z, ts, [(b, value(m.DRBidWeight[b, z, ts])) for b in m.DR_BID_LIST])
-            for z in m.LOAD_ZONES
-            for ts in m.TIMESERIES])
-        #print "DR_Convex_Bid_Weight:"
-        #m.DR_Convex_Bid_Weight.pprint()
+        pprint(
+            [
+                (z, ts, [(b, value(m.DRBidWeight[b, z, ts])) for b in m.DR_BID_LIST])
+                for z in m.LOAD_ZONES
+                for ts in m.TIMESERIES
+            ]
+        )
+        # print "DR_Convex_Bid_Weight:"
+        # m.DR_Convex_Bid_Weight.pprint()
 
     # get new bids from the demand system at the current prices
     bids = get_bids(m)
@@ -402,26 +487,34 @@ def total_direct_costs_per_year(m, period):
     in each zone.)
     """
     return value(
-        sum(getattr(m, annual_cost)[period] for annual_cost in m.Cost_Components_Per_Period)
+        sum(
+            getattr(m, annual_cost)[period]
+            for annual_cost in m.Cost_Components_Per_Period
+        )
         + sum(
             getattr(m, tp_cost)[t] * m.tp_weight_in_year[t]
             for t in m.TPS_IN_PERIOD[period]
-                for tp_cost in m.Cost_Components_Per_TP
-                    if tp_cost != "DR_Welfare_Cost"
+            for tp_cost in m.Cost_Components_Per_TP
+            if tp_cost != "DR_Welfare_Cost"
         )
     )
 
+
 def electricity_marginal_cost(m, z, tp):
     """Return marginal cost of production per MWh in load_zone z during timepoint tp."""
-    return m.dual[m.Energy_Balance[z, tp]]/m.bring_timepoint_costs_to_base_year[tp]
+    return m.dual[m.Energy_Balance[z, tp]] / m.bring_timepoint_costs_to_base_year[tp]
+
 
 def electricity_demand(m, z, tp):
     """Return total electricity consumption by customers in load_zone z during timepoint tp."""
-    return value(sum(
-        getattr(m, component)[z, tp]
-            for component in ('zone_demand_mw', 'FlexibleDemand')
-                if component in m.Zone_Power_Withdrawals
-    ))
+    return value(
+        sum(
+            getattr(m, component)[z, tp]
+            for component in ("zone_demand_mw", "FlexibleDemand")
+            if component in m.Zone_Power_Withdrawals
+        )
+    )
+
 
 def make_prices(m):
     """Calculate hourly prices for customers, based on the current model configuration.
@@ -434,20 +527,20 @@ def make_prices(m):
         # calculate the ratio between potential revenue
         # at marginal-cost pricing and total costs for each period
         mc_annual_revenue = {
-            (z, p):
-            sum(
+            (z, p): sum(
                 electricity_demand(m, z, tp)
                 * electricity_marginal_cost(m, z, tp)
                 * m.tp_weight_in_year[tp]
                 for tp in m.TPS_IN_PERIOD[p]
             )
-            for z in m.LOAD_ZONES for p in m.PERIODS
+            for z in m.LOAD_ZONES
+            for p in m.PERIODS
         }
         # note: it would be nice to do this on a zonal basis, but production costs
         # are only available model-wide.
         price_scalar = {
             p: total_direct_costs_per_year(m, p)
-                / sum(mc_annual_revenue[z, p] for z in m.LOAD_ZONES)
+            / sum(mc_annual_revenue[z, p] for z in m.LOAD_ZONES)
             for p in m.PERIODS
         }
     else:
@@ -457,41 +550,43 @@ def make_prices(m):
     # calculate hourly prices
     hourly_prices = {
         (z, tp): price_scalar[m.tp_period[tp]] * electricity_marginal_cost(m, z, tp)
-            for z in m.LOAD_ZONES for tp in m.TIMEPOINTS
+        for z in m.LOAD_ZONES
+        for tp in m.TIMEPOINTS
     }
 
     if m.options.dr_flat_pricing:
         # use flat prices each year
         # calculate annual average prices (total revenue / total kWh)
         average_prices = {
-            (z, p):
-            sum(
+            (z, p): sum(
                 hourly_prices[z, tp]
                 * electricity_demand(m, z, tp)
                 * m.tp_weight_in_year[tp]
                 for tp in m.TPS_IN_PERIOD[p]
             )
-            /
-            sum(
-                electricity_demand(m, z, tp)
-                * m.tp_weight_in_year[tp]
+            / sum(
+                electricity_demand(m, z, tp) * m.tp_weight_in_year[tp]
                 for tp in m.TPS_IN_PERIOD[p]
             )
-            for z in m.LOAD_ZONES for p in m.PERIODS
+            for z in m.LOAD_ZONES
+            for p in m.PERIODS
         }
         prices = {
             (z, tp): average_prices[z, m.tp_period[tp]]
-            for z in m.LOAD_ZONES for tp in m.TIMEPOINTS
+            for z in m.LOAD_ZONES
+            for tp in m.TIMEPOINTS
         }
     else:
         prices = hourly_prices
 
     return prices
 
+
 annual_revenue = None
 
+
 def calibrate_model(m):
-    global annual_revenue   # save a copy for debugging later
+    global annual_revenue  # save a copy for debugging later
     """
     Calibrate the demand system and add it to the model.
     Also calculate other_costs (utility costs not modeled by Switch).
@@ -510,26 +605,31 @@ def calibrate_model(m):
     # For now, we just assume the base price was $180/MWh, which is HECO's average price in
     # 2007 according to EIA form 826.
     # TODO: add in something for the fixed costs, to make marginal cost commensurate with the base_price
-    #baseCosts = [m.dual[m.EnergyBalance[z, tp]] for z in m.LOAD_ZONES for tp in m.TIMEPOINTS]
+    # baseCosts = [m.dual[m.EnergyBalance[z, tp]] for z in m.LOAD_ZONES for tp in m.TIMEPOINTS]
     base_price = 180  # average retail price for 2007 ($/MWh)
-    m.base_data = [(
-        z,
-        ts,
-        [m.zone_demand_mw[z, tp] for tp in m.TPS_IN_TS[ts]],
-        [base_price] * len(m.TPS_IN_TS[ts])
-    ) for z in m.LOAD_ZONES for ts in m.TIMESERIES]
+    m.base_data = [
+        (
+            z,
+            ts,
+            [m.zone_demand_mw[z, tp] for tp in m.TPS_IN_TS[ts]],
+            [base_price] * len(m.TPS_IN_TS[ts]),
+        )
+        for z in m.LOAD_ZONES
+        for ts in m.TIMESERIES
+    ]
 
     # make a dict of base_data, indexed by load_zone and timepoint, for later reference
     m.base_data_dict = {
         (z, tp): (m.zone_demand_mw[z, tp], base_price)
-            for z in m.LOAD_ZONES for tp in m.TIMEPOINTS
+        for z in m.LOAD_ZONES
+        for tp in m.TIMEPOINTS
     }
 
     # calculate costs that are included in the base prices but not reflected in Switch.
     # note: during the first iteration, other_costs = 0, so this calculates a value for
     # other_costs that will bring total_direct_costs_per_year() up to the baseline
     # annual_revenue level.
-    annual_revenue = dict(zip(list(m.PERIODS), [0.0]*len(m.PERIODS)))
+    annual_revenue = dict(zip(list(m.PERIODS), [0.0] * len(m.PERIODS)))
     for (z, tp), (load, price) in utilities.iteritems(m.base_data_dict):
         annual_revenue[m.tp_period[tp]] += load * prices * m.tp_weight_in_year[tp]
     for p in m.PERIODS:
@@ -538,7 +638,7 @@ def calibrate_model(m):
         m.other_costs[p] = 0.0
 
     # calibrate the demand module
-    #demand_module.calibrate(m.base_data, m.options.dr_elasticity_scenario)
+    # demand_module.calibrate(m.base_data, m.options.dr_elasticity_scenario)
     demand_module.calibrate(m, m.base_data)
 
 
@@ -555,7 +655,6 @@ def get_bids(m):
         all_prices = make_prices(m)
         # TODO: change make_prices to use base_price in iteration 0,
         # instead of doing it below
-
 
     for i, (z, ts, base_load, base_price) in enumerate(m.base_data):
 
@@ -613,8 +712,8 @@ def add_bids(m, bids):
             # print "timepoints[i+1]: "+str(timepoints[i+1])
             # note: demand is a python list or array, which uses 0-based indexing, but
             # timepoints is a pyomo set, which uses 1-based indexing, so we have to shift the index by 1.
-            m.dr_bid[b, z, timepoints[i+1]] = d
-            m.dr_price[b, z, timepoints[i+1]] = prices[i]
+            m.dr_bid[b, z, timepoints[i + 1]] = d
+            m.dr_price[b, z, timepoints[i + 1]] = prices[i]
 
     print("len(m.DR_BID_LIST): {l}".format(l=len(m.DR_BID_LIST)))
     print("m.DR_BID_LIST: {b}".format(b=[x for x in m.DR_BID_LIST]))
@@ -633,6 +732,7 @@ def add_bids(m, bids):
     reconstruct_energy_balance(m)
     m.SystemCostPerPeriod.reconstruct()
     m.SystemCost.reconstruct()
+
 
 def reconstruct_energy_balance(m):
     """Reconstruct Energy_Balance constraint, preserving dual values (if present)."""
@@ -661,28 +761,34 @@ def write_batch_results(m):
 
     util.append_table(m, output_file=output_file, values=lambda m: summary_values(m))
 
+
 def summary_headers(m):
     return (
         ("tag", "iteration", "total_cost")
-        +tuple('total_direct_costs_per_year_'+str(p) for p in m.PERIODS)
-        +tuple('other_costs_'+str(p) for p in m.PERIODS)
-        +tuple('DR_Welfare_Cost_'+str(p) for p in m.PERIODS)
-        +tuple('customer_payments_'+str(p) for p in m.PERIODS)
-        +tuple('MWh_sold_'+str(p) for p in m.PERIODS)
+        + tuple("total_direct_costs_per_year_" + str(p) for p in m.PERIODS)
+        + tuple("other_costs_" + str(p) for p in m.PERIODS)
+        + tuple("DR_Welfare_Cost_" + str(p) for p in m.PERIODS)
+        + tuple("customer_payments_" + str(p) for p in m.PERIODS)
+        + tuple("MWh_sold_" + str(p) for p in m.PERIODS)
     )
+
 
 def summary_values(m):
     demand_components = [
-        c for c in ('zone_demand_mw', 'ShiftDemand', 'ChargeEVs', 'FlexibleDemand') if hasattr(m, c)
+        c
+        for c in ("zone_demand_mw", "ShiftDemand", "ChargeEVs", "FlexibleDemand")
+        if hasattr(m, c)
     ]
     values = []
 
     # tag (configuration)
-    values.extend([
-        m.options.scenario_name,
-        m.iteration_number,
-        m.SystemCost  # total cost (all periods)
-    ])
+    values.extend(
+        [
+            m.options.scenario_name,
+            m.iteration_number,
+            m.SystemCost,  # total cost (all periods)
+        ]
+    )
 
     # direct costs (including "other")
     values.extend([total_direct_costs_per_year(m, p) for p in m.PERIODS])
@@ -691,10 +797,15 @@ def summary_values(m):
     values.extend([m.other_costs[p] for p in m.PERIODS])
 
     # DR_Welfare_Cost
-    values.extend([
-        sum(m.DR_Welfare_Cost[t] * m.tp_weight_in_year[t] for t in m.TPS_IN_PERIOD[p])
-        for p in m.PERIODS
-    ])
+    values.extend(
+        [
+            sum(
+                m.DR_Welfare_Cost[t] * m.tp_weight_in_year[t]
+                for t in m.TPS_IN_PERIOD[p]
+            )
+            for p in m.PERIODS
+        ]
+    )
 
     # payments by customers ([expected load] * [gice offered for that load])
     # TODO: this uses the price from just _before_ the final solution.
@@ -704,77 +815,102 @@ def summary_values(m):
     if m.iteration_number == 0:
         values.extend([None for p in m.PERIODS])
     else:
-        values.extend([
-            sum(
-                electricity_demand(m, z, tp) * m.dr_price[last_bid, z, tp] * m.tp_weight_in_year[tp]
-                for z in m.LOAD_ZONES for tp in m.TPS_IN_PERIOD[p]
-            )
-            for p in m.PERIODS
-        ])
+        values.extend(
+            [
+                sum(
+                    electricity_demand(m, z, tp)
+                    * m.dr_price[last_bid, z, tp]
+                    * m.tp_weight_in_year[tp]
+                    for z in m.LOAD_ZONES
+                    for tp in m.TPS_IN_PERIOD[p]
+                )
+                for p in m.PERIODS
+            ]
+        )
 
     # total MWh delivered each year
-    values.extend([
-        sum(
-            electricity_demand(m, z, tp) * m.tp_weight_in_year[tp]
-            for z in m.LOAD_ZONES for tp in m.TPS_IN_PERIOD[p]
-        )
-        for p in m.PERIODS
-    ])
+    values.extend(
+        [
+            sum(
+                electricity_demand(m, z, tp) * m.tp_weight_in_year[tp]
+                for z in m.LOAD_ZONES
+                for tp in m.TPS_IN_PERIOD[p]
+            )
+            for p in m.PERIODS
+        ]
+    )
 
     return values
+
 
 def write_results(m):
     outputs_dir = m.options.outputs_dir
     tag = filename_tag(m)
 
-    avg_ts_scale = float(sum(m.ts_scale_to_year[ts] for ts in m.TIMESERIES))/len(m.TIMESERIES)
+    avg_ts_scale = float(sum(m.ts_scale_to_year[ts] for ts in m.TIMESERIES)) / len(
+        m.TIMESERIES
+    )
     last_bid = m.DR_BID_LIST.last()
 
     util.write_table(
-        m, m.LOAD_ZONES, m.TIMEPOINTS,
+        m,
+        m.LOAD_ZONES,
+        m.TIMEPOINTS,
         output_file=os.path.join(outputs_dir, "energy_sources{t}.csv".format(t=tag)),
-        headings=
-            ("load_zone", "period", "timepoint_label")
-            +tuple(m.FUELS)
-            +tuple(m.NON_FUEL_ENERGY_SOURCES)
-            +tuple("curtail_"+s for s in m.NON_FUEL_ENERGY_SOURCES)
-            +tuple(m.Zone_Power_Injections)
-            +tuple(m.Zone_Power_Withdrawals)
-            +("marginal_cost","final_marginal_cost","price","bid_load","peak_day","base_load","base_price"),
-        values=lambda m, z, t:
-            (z, m.tp_period[t], m.tp_timestamp[t])
-            +tuple(
-                sum(get(m.DispatchGenByFuel, (p, t, f), 0.0) for p in m.GENS_BY_FUEL[f])
-                for f in m.FUELS
+        headings=("load_zone", "period", "timepoint_label")
+        + tuple(m.FUELS)
+        + tuple(m.NON_FUEL_ENERGY_SOURCES)
+        + tuple("curtail_" + s for s in m.NON_FUEL_ENERGY_SOURCES)
+        + tuple(m.Zone_Power_Injections)
+        + tuple(m.Zone_Power_Withdrawals)
+        + (
+            "marginal_cost",
+            "final_marginal_cost",
+            "price",
+            "bid_load",
+            "peak_day",
+            "base_load",
+            "base_price",
+        ),
+        values=lambda m, z, t: (z, m.tp_period[t], m.tp_timestamp[t])
+        + tuple(
+            sum(get(m.DispatchGenByFuel, (p, t, f), 0.0) for p in m.GENS_BY_FUEL[f])
+            for f in m.FUELS
+        )
+        + tuple(
+            sum(
+                get(m.DispatchGen, (p, t), 0.0)
+                for p in m.GENS_BY_NON_FUEL_ENERGY_SOURCE[s]
             )
-            +tuple(
-                sum(get(m.DispatchGen, (p, t), 0.0) for p in m.GENS_BY_NON_FUEL_ENERGY_SOURCE[s])
-                for s in m.NON_FUEL_ENERGY_SOURCES
+            for s in m.NON_FUEL_ENERGY_SOURCES
+        )
+        + tuple(
+            sum(
+                get(m.DispatchUpperLimit, (p, t), 0.0) - get(m.DispatchGen, (p, t), 0.0)
+                for p in m.GENS_BY_NON_FUEL_ENERGY_SOURCE[s]
             )
-            +tuple(
-                sum(
-                    get(m.DispatchUpperLimit, (p, t), 0.0) - get(m.DispatchGen, (p, t), 0.0)
-                    for p in m.GENS_BY_NON_FUEL_ENERGY_SOURCE[s]
-                )
-                for s in m.NON_FUEL_ENERGY_SOURCES
-            )
-            +tuple(getattr(m, component)[z, t] for component in m.Zone_Power_Injections)
-            +tuple(getattr(m, component)[z, t] for component in m.Zone_Power_Withdrawals)
-            +(
-                m.prev_marginal_cost[z, t],
-                electricity_marginal_cost(m, z, t),
-                m.dr_price[last_bid, z, t],
-                m.dr_bid[last_bid, z, t],
-                'peak' if m.ts_scale_to_year[m.tp_ts[t]] < 0.5*avg_ts_scale else 'typical',
-                m.base_data_dict[z, t][0],
-                m.base_data_dict[z, t][1],
-            )
+            for s in m.NON_FUEL_ENERGY_SOURCES
+        )
+        + tuple(getattr(m, component)[z, t] for component in m.Zone_Power_Injections)
+        + tuple(getattr(m, component)[z, t] for component in m.Zone_Power_Withdrawals)
+        + (
+            m.prev_marginal_cost[z, t],
+            electricity_marginal_cost(m, z, t),
+            m.dr_price[last_bid, z, t],
+            m.dr_bid[last_bid, z, t],
+            "peak"
+            if m.ts_scale_to_year[m.tp_ts[t]] < 0.5 * avg_ts_scale
+            else "typical",
+            m.base_data_dict[z, t][0],
+            m.base_data_dict[z, t][1],
+        ),
     )
 
     # import pprint
     # b=[(g, pe, value(m.BuildGen[g, pe]), m.gen_tech[g], m.gen_overnight_cost[g, pe]) for (g, pe) in m.BuildGen if value(m.BuildGen[g, pe]) > 0]
     # bt=set(x[3] for x in b) # technologies
     # pprint([(t, sum(x[2] for x in b if x[3]==t), sum(x[4] for x in b if x[3]==t)/sum(1.0 for x in b if x[3]==t)) for t in bt])
+
 
 def write_dual_costs(m):
     outputs_dir = m.options.outputs_dir
@@ -796,7 +932,7 @@ def write_dual_costs(m):
     outfile = os.path.join(outputs_dir, "dual_costs{t}.csv".format(t=tag))
     dual_data = []
     start_time = time.time()
-    print("Writing {} ... ".format(outfile), end=' ')
+    print("Writing {} ... ".format(outfile), end=" ")
 
     def add_dual(const, lbound, ubound, duals):
         if const in duals:
@@ -810,12 +946,17 @@ def write_dual_costs(m):
             if bound is None:
                 # Variable is unbounded; dual should be 0.0 or possibly a tiny non-zero value.
                 if not (-1e-5 < dual < 1e-5):
-                    raise ValueError("{} has no {} bound but has a non-zero dual value {}.".format(
-                        const.cname(), "lower" if dual > 0 else "upper", dual))
+                    raise ValueError(
+                        "{} has no {} bound but has a non-zero dual value {}.".format(
+                            const.cname(), "lower" if dual > 0 else "upper", dual
+                        )
+                    )
             else:
                 total_cost = dual * bound
                 if total_cost != 0.0:
-                    dual_data.append((const.cname(), direction, bound, dual, total_cost))
+                    dual_data.append(
+                        (const.cname(), direction, bound, dual, total_cost)
+                    )
 
     for comp in m.component_objects(ctype=Var):
         for idx in comp:
@@ -826,12 +967,15 @@ def write_dual_costs(m):
             constr = comp[idx]
             add_dual(constr, value(constr.lower), value(constr.upper), m.dual)
 
-    dual_data.sort(key=lambda r: (not r[0].startswith('DR_Convex_'), r[3] >= 0)+r)
+    dual_data.sort(key=lambda r: (not r[0].startswith("DR_Convex_"), r[3] >= 0) + r)
 
-    with open(outfile, 'w') as f:
-        f.write(','.join(['constraint', 'direction', 'bound', 'dual', 'total_cost']) + '\n')
-        f.writelines(','.join(map(str, r)) + '\n' for r in dual_data)
-    print("time taken: {dur:.2f}s".format(dur=time.time()-start_time))
+    with open(outfile, "w") as f:
+        f.write(
+            ",".join(["constraint", "direction", "bound", "dual", "total_cost"]) + "\n"
+        )
+        f.writelines(",".join(map(str, r)) + "\n" for r in dual_data)
+    print("time taken: {dur:.2f}s".format(dur=time.time() - start_time))
+
 
 def filename_tag(m):
     if m.options.scenario_name:

--- a/switch_model/hawaii/demand_response_simple.py
+++ b/switch_model/hawaii/demand_response_simple.py
@@ -3,23 +3,35 @@ import os
 from pyomo.environ import *
 from switch_model.financials import capital_recovery_factor as crf
 
-from switch_model.balancing.demand_response.iterative import register_demand_response_reserves
+from switch_model.balancing.demand_response.iterative import (
+    register_demand_response_reserves,
+)
+
 
 def define_arguments(argparser):
-    argparser.add_argument('--demand-response-share', type=float, default=0.30,
-        help="Fraction of hourly load that can be shifted to other times of day (default=0.30)")
-    argparser.add_argument('--demand-response-reserve-types', nargs='+', default=[],
-        help=
-            "Type(s) of reserves to provide from demand response (e.g., 'contingency' or 'regulation'). "
-            "Specify 'none' to disable. Default is 'spinning' if an operating reserve module is used, "
-            "otherwise it is 'none'."
+    argparser.add_argument(
+        "--demand-response-share",
+        type=float,
+        default=0.30,
+        help="Fraction of hourly load that can be shifted to other times of day (default=0.30)",
     )
+    argparser.add_argument(
+        "--demand-response-reserve-types",
+        nargs="+",
+        default=[],
+        help="Type(s) of reserves to provide from demand response (e.g., 'contingency' or 'regulation'). "
+        "Specify 'none' to disable. Default is 'spinning' if an operating reserve module is used, "
+        "otherwise it is 'none'.",
+    )
+
 
 def define_components(m):
 
     # maximum share of hourly load that can be rescheduled
     # this is mutable so various values can be tested
-    m.demand_response_max_share = Param(default=m.options.demand_response_share, mutable=True)
+    m.demand_response_max_share = Param(
+        default=m.options.demand_response_share, mutable=True
+    )
 
     # maximum amount of load that can be _added_ each hour; we assume
     # it is 8x the maximum reduction, which is roughly equivalent to
@@ -34,38 +46,43 @@ def define_components(m):
 
     # adjustment to demand during each hour (positive = higher demand)
     m.ShiftDemand = Var(
-        m.LOAD_ZONES, m.TIMEPOINTS, within=Reals,
-        bounds=lambda m, z, t:
-            (
-                (-1.0) * m.demand_response_max_share * m.zone_demand_mw[z, t],
-                m.demand_response_max_increase * m.zone_demand_mw[z, t]
-            )
+        m.LOAD_ZONES,
+        m.TIMEPOINTS,
+        within=Reals,
+        bounds=lambda m, z, t: (
+            (-1.0) * m.demand_response_max_share * m.zone_demand_mw[z, t],
+            m.demand_response_max_increase * m.zone_demand_mw[z, t],
+        ),
     )
 
     # all changes to demand must balance out over the course of the day
-    m.Demand_Response_Net_Zero = Constraint(m.LOAD_ZONES, m.TIMESERIES, rule=lambda m, z, ts:
-        sum(m.ShiftDemand[z, tp] for tp in m.TPS_IN_TS[ts]) == 0.0
+    m.Demand_Response_Net_Zero = Constraint(
+        m.LOAD_ZONES,
+        m.TIMESERIES,
+        rule=lambda m, z, ts: sum(m.ShiftDemand[z, tp] for tp in m.TPS_IN_TS[ts])
+        == 0.0,
     )
 
     # add demand response to the zonal energy balance
-    m.Zone_Power_Withdrawals.append('ShiftDemand')
+    m.Zone_Power_Withdrawals.append("ShiftDemand")
 
-
-    if hasattr(m, 'ZONES_IN_BALANCING_AREA'):
+    if hasattr(m, "ZONES_IN_BALANCING_AREA"):
         # calculate available slack from demand response
         # (from supply perspective, so "up" means less load)
-        m.DemandResponseSlackUp = Expression(m.BALANCING_AREA_TIMEPOINTS, rule=lambda m, b, t:
-            sum(
-                m.ShiftDemand[z, t] -  m.ShiftDemand[z, t].lb
+        m.DemandResponseSlackUp = Expression(
+            m.BALANCING_AREA_TIMEPOINTS,
+            rule=lambda m, b, t: sum(
+                m.ShiftDemand[z, t] - m.ShiftDemand[z, t].lb
                 for z in m.ZONES_IN_BALANCING_AREA[b]
-            )
+            ),
         )
-        m.DemandResponseSlackDown = Expression(m.BALANCING_AREA_TIMEPOINTS, rule=lambda m, b, tp:
-            sum(
+        m.DemandResponseSlackDown = Expression(
+            m.BALANCING_AREA_TIMEPOINTS,
+            rule=lambda m, b, tp: sum(
                 # difference between scheduled load and max allowed
                 m.demand_response_max_increase * m.zone_demand_mw[z, tp]
                 - m.ShiftDemand[z, tp]
                 for z in m.ZONES_IN_BALANCING_AREA[b]
-            )
+            ),
         )
     register_demand_response_reserves(m)

--- a/switch_model/hawaii/emission_rules.py
+++ b/switch_model/hawaii/emission_rules.py
@@ -1,21 +1,27 @@
 from pyomo.environ import *
 
+
 def define_components(m):
     """
     prevent non-cogen plants from burning pure LSFO after 2017 due to MATS emission restrictions
     """
 
     # TODO: move this set into a parameter list in fuels.csv, e.g, 'banned_after', which can be a year or NULL
-    m.FUEL_BANS = Set(dimen=2, initialize=[('LSFO', 2017)])
+    m.FUEL_BANS = Set(dimen=2, initialize=[("LSFO", 2017)])
 
-    m.BANNED_FUEL_DISPATCH_POINTS = Set(dimen=3, initialize=lambda m:
-        [(g, tp, f)
+    m.BANNED_FUEL_DISPATCH_POINTS = Set(
+        dimen=3,
+        initialize=lambda m: [
+            (g, tp, f)
             for (f, y) in m.FUEL_BANS
-                for g in m.GENS_BY_FUEL[f] # if not m.gen_is_cogen[g]
-                    for pe in m.PERIODS if m.period_end[pe] >= y
-                        for tp in m.TPS_IN_PERIOD[pe] if (g, tp) in m.GEN_TPS
-        ]
+            for g in m.GENS_BY_FUEL[f]  # if not m.gen_is_cogen[g]
+            for pe in m.PERIODS
+            if m.period_end[pe] >= y
+            for tp in m.TPS_IN_PERIOD[pe]
+            if (g, tp) in m.GEN_TPS
+        ],
     )
-    m.ENFORCE_FUEL_BANS = Constraint(m.BANNED_FUEL_DISPATCH_POINTS, rule = lambda m, g, tp, f:
-        m.DispatchGenByFuel[g, tp, f] == 0
+    m.ENFORCE_FUEL_BANS = Constraint(
+        m.BANNED_FUEL_DISPATCH_POINTS,
+        rule=lambda m, g, tp, f: m.DispatchGenByFuel[g, tp, f] == 0,
     )

--- a/switch_model/hawaii/ev.py
+++ b/switch_model/hawaii/ev.py
@@ -4,55 +4,81 @@ import os
 from pyomo.environ import *
 from switch_model import timescales
 
+
 def define_arguments(argparser):
     argparser.add_argument(
-        "--ev-timing", default=['optimal'], nargs='+',
-        help=
-            "Rule(s) for when to charge EVs -- bau=business-as-usual (upon arrival), "
-            "flat=around the clock, or optimal (default). You may also specify "
-            "multiple options in the form --ev-timing bau=0.32 optimal=0.68 to "
-            "use more than one mode. Modes without shares assigned will receive "
-            "equal fractions of the unallocated charging."
+        "--ev-timing",
+        default=["optimal"],
+        nargs="+",
+        help="Rule(s) for when to charge EVs -- bau=business-as-usual (upon arrival), "
+        "flat=around the clock, or optimal (default). You may also specify "
+        "multiple options in the form --ev-timing bau=0.32 optimal=0.68 to "
+        "use more than one mode. Modes without shares assigned will receive "
+        "equal fractions of the unallocated charging.",
     )
-    argparser.add_argument('--ev-reserve-types', nargs='+', default=['spinning'],
-        help=
-            "Type(s) of reserves to provide from electric-vehicle charging (e.g., 'contingency' or 'regulation')."
-            "Default is generic 'spinning'. Specify 'none' to disable. Only takes effect with '--ev-timing optimal'."
+    argparser.add_argument(
+        "--ev-reserve-types",
+        nargs="+",
+        default=["spinning"],
+        help="Type(s) of reserves to provide from electric-vehicle charging (e.g., 'contingency' or 'regulation')."
+        "Default is generic 'spinning'. Specify 'none' to disable. Only takes effect with '--ev-timing optimal'.",
     )
+
 
 def define_components(m):
     # setup various parameters describing the EV and ICE fleet each year
-    for p in ["ev_share", "ice_miles_per_gallon", "ev_miles_per_kwh", "ev_extra_cost_per_vehicle_year", "n_all_vehicles", "vmt_per_vehicle"]:
+    for p in [
+        "ev_share",
+        "ice_miles_per_gallon",
+        "ev_miles_per_kwh",
+        "ev_extra_cost_per_vehicle_year",
+        "n_all_vehicles",
+        "vmt_per_vehicle",
+    ]:
         setattr(m, p, Param(m.LOAD_ZONES, m.PERIODS))
 
     m.ev_bau_mw = Param(m.LOAD_ZONES, m.TIMEPOINTS)
 
     # calculate the extra annual cost (non-fuel) of having EVs, relative to ICEs (mostly for batteries, could also be chargers)
-    m.ev_extra_annual_cost = Param(m.PERIODS, initialize=lambda m, p:
-        sum(m.ev_extra_cost_per_vehicle_year[z, p] * m.ev_share[z, p] * m.n_all_vehicles[z, p] for z in m.LOAD_ZONES)
+    m.ev_extra_annual_cost = Param(
+        m.PERIODS,
+        initialize=lambda m, p: sum(
+            m.ev_extra_cost_per_vehicle_year[z, p]
+            * m.ev_share[z, p]
+            * m.n_all_vehicles[z, p]
+            for z in m.LOAD_ZONES
+        ),
     )
 
     # calculate total fuel cost for ICE (non-EV) VMTs
     if hasattr(m, "rfm_supply_tier_cost"):
         # using fuel_costs.markets
-        ice_fuel_cost_func = lambda m, z, p: m.rfm_supply_tier_cost['Hawaii_Motor_Gasoline', p, 'base']
-    elif hasattr(m, 'ZONE_FUEL_PERIODS'):
+        ice_fuel_cost_func = lambda m, z, p: m.rfm_supply_tier_cost[
+            "Hawaii_Motor_Gasoline", p, "base"
+        ]
+    elif hasattr(m, "ZONE_FUEL_PERIODS"):
         # using fuel_costs.simple
-        ice_fuel_cost_func = lambda m, z, p: m.fuel_cost[z, 'Motor_Gasoline', p]
-    elif hasattr(m, 'ZONE_FUEL_TIMEPOINTS'):
+        ice_fuel_cost_func = lambda m, z, p: m.fuel_cost[z, "Motor_Gasoline", p]
+    elif hasattr(m, "ZONE_FUEL_TIMEPOINTS"):
         # using fuel_costs.simple_per_timepoint
-        ice_fuel_cost_func = lambda m, z, p: sum(
-            m.tp_weight[t] * m.fuel_cost_per_timepoint[z, 'Motor_Gasoline', t]
-            for t in m.TPS_IN_PERIOD[p]
-        ) / m.period_length_hours[p]
-    m.ice_annual_fuel_cost = Param(m.PERIODS, initialize=lambda m, p:
-        sum(
-            (1.0 - m.ev_share[z, p]) * m.n_all_vehicles[z, p] * m.vmt_per_vehicle[z, p]
-            / m.ice_miles_per_gallon[z, p]
-            * 0.114   # 0.114 MBtu/gal gasoline
-            * ice_fuel_cost_func(m, z, p)
-                for z in m.LOAD_ZONES
+        ice_fuel_cost_func = (
+            lambda m, z, p: sum(
+                m.tp_weight[t] * m.fuel_cost_per_timepoint[z, "Motor_Gasoline", t]
+                for t in m.TPS_IN_PERIOD[p]
+            )
+            / m.period_length_hours[p]
         )
+    m.ice_annual_fuel_cost = Param(
+        m.PERIODS,
+        initialize=lambda m, p: sum(
+            (1.0 - m.ev_share[z, p])
+            * m.n_all_vehicles[z, p]
+            * m.vmt_per_vehicle[z, p]
+            / m.ice_miles_per_gallon[z, p]
+            * 0.114  # 0.114 MBtu/gal gasoline
+            * ice_fuel_cost_func(m, z, p)
+            for z in m.LOAD_ZONES
+        ),
     )
 
     # add cost components to account for the vehicle miles traveled via EV or ICE
@@ -61,8 +87,11 @@ def define_components(m):
     # m.Cost_Components_Per_Period.append('ice_annual_fuel_cost')
 
     # calculate the amount of energy used during each timeseries under business-as-usual charging
-    m.ev_mwh_ts = Param(m.LOAD_ZONES, m.TIMESERIES, initialize=lambda m, z, ts:
-        sum(m.ev_bau_mw[z, tp] for tp in m.TPS_IN_TS[ts]) * m.ts_duration_of_tp[ts]
+    m.ev_mwh_ts = Param(
+        m.LOAD_ZONES,
+        m.TIMESERIES,
+        initialize=lambda m, z, ts: sum(m.ev_bau_mw[z, tp] for tp in m.TPS_IN_TS[ts])
+        * m.ts_duration_of_tp[ts],
     )
 
     # decide when to provide the EV energy
@@ -71,22 +100,24 @@ def define_components(m):
     # make sure to charge all EVs at some point during the day
     # (they must always consume the same amount per day as under business-as-usual,
     # but there may be some room to reschedule it.)
-    m.ChargeEVs_min = Constraint(m.LOAD_ZONES, m.TIMESERIES, rule=lambda m, z, ts:
-        sum(m.ChargeEVs[z, tp] for tp in m.TPS_IN_TS[ts]) * m.ts_duration_of_tp[ts]
-        == m.ev_mwh_ts[z, ts]
+    m.ChargeEVs_min = Constraint(
+        m.LOAD_ZONES,
+        m.TIMESERIES,
+        rule=lambda m, z, ts: sum(m.ChargeEVs[z, tp] for tp in m.TPS_IN_TS[ts])
+        * m.ts_duration_of_tp[ts]
+        == m.ev_mwh_ts[z, ts],
     )
 
     # set rules for when to charge EVs
-    mode_shares = {'optimal': 0.0, 'flat': 0.0, 'bau': 0.0}
+    mode_shares = {"optimal": 0.0, "flat": 0.0, "bau": 0.0}
     for tag in m.options.ev_timing:
         try:
-            mode, share = tag.split('=', 2)
+            mode, share = tag.split("=", 2)
             try:
                 share = float(share)
             except:
                 print(
-                    '\nInvalid share for EV charging mode {}: ({}).'
-                    .format(mode, share)
+                    "\nInvalid share for EV charging mode {}: ({}).".format(mode, share)
                 )
                 raise
         except ValueError:
@@ -96,31 +127,32 @@ def define_components(m):
             mode_shares[mode] = share
         else:
             raise ValueError(
-                'Invalid EV charging mode specified for --ev-timing: {}'
-                .format(mode)
+                "Invalid EV charging mode specified for --ev-timing: {}".format(mode)
             )
     fillers = [mode for (mode, share) in mode_shares.items() if share is None]
     allocated_shares = sum(share for share in mode_shares.values() if share is not None)
     if allocated_shares >= 1.00001:
         raise ValueError(
-            'Shares assigned with --ev-timing flag add up to {}. '
-            'They must sum to 1.0 (or less if a catch-all mode is specified).'
-            .format(allocated_shares)
+            "Shares assigned with --ev-timing flag add up to {}. "
+            "They must sum to 1.0 (or less if a catch-all mode is specified).".format(
+                allocated_shares
+            )
         )
     if allocated_shares <= 0.99999 and not fillers:
         raise ValueError(
-            'Shares assigned with --ev-timing flag add up to {}. '
-            'They must sum to 1.0 if no catch-all mode is specified.'
-            .format(allocated_shares)
+            "Shares assigned with --ev-timing flag add up to {}. "
+            "They must sum to 1.0 if no catch-all mode is specified.".format(
+                allocated_shares
+            )
         )
     for mode in fillers:
         mode_shares[mode] = (1 - allocated_shares) / len(fillers)
 
     if m.options.verbose:
         for mode, tag in [
-                ('optimal', 'at best time each day'),
-                ('flat', 'round the clock each day'),
-                ('bau', 'at business-as-usual times each day')
+            ("optimal", "at best time each day"),
+            ("flat", "round the clock each day"),
+            ("bau", "at business-as-usual times each day"),
         ]:
             if mode_shares[mode] > 0:
                 print("Charging {:.1%} of EVs {}.".format(mode_shares[mode], tag))
@@ -128,22 +160,26 @@ def define_components(m):
     # force the minimum amount of charging required for the bau and flat modes;
     # all other charging will be allocated optimally among hours
     m.Min_EV_Charging = Expression(
-        m.LOAD_ZONES, m.TIMEPOINTS,
-        rule=lambda m, z, tp:
-            mode_shares['flat'] * (m.ev_mwh_ts[z, m.tp_ts[tp]] / m.ts_duration_hrs[m.tp_ts[tp]])
-            + mode_shares['bau'] * m.ev_bau_mw[z, tp]
+        m.LOAD_ZONES,
+        m.TIMEPOINTS,
+        rule=lambda m, z, tp: mode_shares["flat"]
+        * (m.ev_mwh_ts[z, m.tp_ts[tp]] / m.ts_duration_hrs[m.tp_ts[tp]])
+        + mode_shares["bau"] * m.ev_bau_mw[z, tp],
     )
     m.Enforce_EV_Charging_Modes = Constraint(
-        m.LOAD_ZONES, m.TIMEPOINTS,
-        rule=lambda m, z, tp: m.ChargeEVs[z, tp] >= m.Min_EV_Charging[z, tp]
+        m.LOAD_ZONES,
+        m.TIMEPOINTS,
+        rule=lambda m, z, tp: m.ChargeEVs[z, tp] >= m.Min_EV_Charging[z, tp],
     )
 
     # add the EV load to the model's energy balance
-    m.Zone_Power_Withdrawals.append('ChargeEVs')
+    m.Zone_Power_Withdrawals.append("ChargeEVs")
 
     # Register with spinning reserves if it is available and any optimal EV charging is enabled.
-    if [rt.lower() for rt in m.options.ev_reserve_types] != ['none'] and mode_shares["optimal"] > 0:
-        if hasattr(m, 'Spinning_Reserve_Up_Provisions'):
+    if [rt.lower() for rt in m.options.ev_reserve_types] != ["none"] and mode_shares[
+        "optimal"
+    ] > 0:
+        if hasattr(m, "Spinning_Reserve_Up_Provisions"):
             # calculate available slack from EV charging
             # (from supply perspective, so "up" means less load)
             m.EVSlackUp = Expression(
@@ -151,42 +187,40 @@ def define_components(m):
                 rule=lambda m, b, t: sum(
                     m.ChargeEVs[z, t] - m.Min_EV_Charging[z, t]
                     for z in m.ZONES_IN_BALANCING_AREA[b]
-                )
+                ),
             )
             # note: we currently ignore down-reserves (option of increasing consumption)
             # from EVs since it's not clear how high they could go; we could revisit this if
             # down-reserves have a positive price at equilibrium (probabably won't)
             # print("\n\nNeed to define Spinning_Reserve_Down_Provisions for EVs.\n")
             # import time; time.sleep(3)
-            if hasattr(m, 'GEN_SPINNING_RESERVE_TYPES'):
+            if hasattr(m, "GEN_SPINNING_RESERVE_TYPES"):
                 # using advanced formulation, index by reserve type, balancing area, timepoint
                 # define variables for each type of reserves to be provided
                 # choose how to allocate the slack between the different reserve products
-                m.EV_SPINNING_RESERVE_TYPES = Set(
-                    initialize=m.options.ev_reserve_types
-                )
+                m.EV_SPINNING_RESERVE_TYPES = Set(initialize=m.options.ev_reserve_types)
                 m.EVSpinningReserveUp = Var(
-                    m.EV_SPINNING_RESERVE_TYPES, m.BALANCING_AREA_TIMEPOINTS,
-                    within=NonNegativeReals
+                    m.EV_SPINNING_RESERVE_TYPES,
+                    m.BALANCING_AREA_TIMEPOINTS,
+                    within=NonNegativeReals,
                 )
                 # constrain reserve provision within available slack
                 m.Limit_EVSpinningReserveUp = Constraint(
                     m.BALANCING_AREA_TIMEPOINTS,
-                    rule=lambda m, ba, tp:
-                        sum(
-                            m.EVSpinningReserveUp[rt, ba, tp]
-                            for rt in m.EV_SPINNING_RESERVE_TYPES
-                        ) <= m.EVSlackUp[ba, tp]
+                    rule=lambda m, ba, tp: sum(
+                        m.EVSpinningReserveUp[rt, ba, tp]
+                        for rt in m.EV_SPINNING_RESERVE_TYPES
+                    )
+                    <= m.EVSlackUp[ba, tp],
                 )
-                m.Spinning_Reserve_Up_Provisions.append('EVSpinningReserveUp')
+                m.Spinning_Reserve_Up_Provisions.append("EVSpinningReserveUp")
             else:
                 # using older formulation, only one type of spinning reserves, indexed by balancing area, timepoint
-                if m.options.ev_reserve_types != ['spinning']:
+                if m.options.ev_reserve_types != ["spinning"]:
                     raise ValueError(
                         'Unable to use reserve types other than "spinning" with simple spinning reserves module.'
                     )
-                m.Spinning_Reserve_Up_Provisions.append('EVSlackUp')
-
+                m.Spinning_Reserve_Up_Provisions.append("EVSlackUp")
 
 
 def load_inputs(m, switch_data, inputs_dir):
@@ -194,16 +228,21 @@ def load_inputs(m, switch_data, inputs_dir):
     Import ev data from .csv files.
     """
     switch_data.load_aug(
-        filename=os.path.join(inputs_dir, 'ev_fleet_info.csv'),
+        filename=os.path.join(inputs_dir, "ev_fleet_info.csv"),
         param=[
             getattr(m, p)
-                for p in
-                ["ev_share", "ice_miles_per_gallon", "ev_miles_per_kwh", "ev_extra_cost_per_vehicle_year", "n_all_vehicles", "vmt_per_vehicle"]
-        ]
+            for p in [
+                "ev_share",
+                "ice_miles_per_gallon",
+                "ev_miles_per_kwh",
+                "ev_extra_cost_per_vehicle_year",
+                "n_all_vehicles",
+                "vmt_per_vehicle",
+            ]
+        ],
     )
     # print "loading ev_bau_load.csv"
     # import pdb; pdb.set_trace()
     switch_data.load_aug(
-        filename=os.path.join(inputs_dir, 'ev_bau_load.csv'),
-        param=m.ev_bau_mw
+        filename=os.path.join(inputs_dir, "ev_bau_load.csv"), param=m.ev_bau_mw
     )

--- a/switch_model/hawaii/ev_advanced.py
+++ b/switch_model/hawaii/ev_advanced.py
@@ -2,33 +2,48 @@ from __future__ import print_function
 import os
 from pyomo.environ import *
 
+
 def define_arguments(argparser):
-    argparser.add_argument("--ev-timing", choices=['bau', 'optimal'], default='optimal',
-        help="Rule for when to charge EVs -- business-as-usual (upon arrival), flat around the clock, or optimal (default).")
-    argparser.add_argument('--ev-reserve-types', nargs='+', default=['spinning'],
-        help=
-            "Type(s) of reserves to provide from electric-vehicle charging (e.g., 'contingency' or 'regulation')."
-            "Default is generic 'spinning'. Specify 'none' to disable. Only takes effect with '--ev-timing optimal'."
+    argparser.add_argument(
+        "--ev-timing",
+        choices=["bau", "optimal"],
+        default="optimal",
+        help="Rule for when to charge EVs -- business-as-usual (upon arrival), flat around the clock, or optimal (default).",
     )
+    argparser.add_argument(
+        "--ev-reserve-types",
+        nargs="+",
+        default=["spinning"],
+        help="Type(s) of reserves to provide from electric-vehicle charging (e.g., 'contingency' or 'regulation')."
+        "Default is generic 'spinning'. Specify 'none' to disable. Only takes effect with '--ev-timing optimal'.",
+    )
+
 
 # parameters describing the EV and ICE fleet each year, all indexed by zone,
 # vehicle type and period
 ev_zone_type_period_params = [
     "n_vehicles",
-    "ice_gals_per_year", "ice_fuel", "ev_kwh_per_year",
-    "ev_extra_cost_per_vehicle_year"
+    "ice_gals_per_year",
+    "ice_fuel",
+    "ev_kwh_per_year",
+    "ev_extra_cost_per_vehicle_year",
 ]
+
 
 def define_components(m):
 
     # indexing set for EV bids, decomposed to get sets of EV bid numbers and EV types
-    m.EV_ZONE_TYPE_BID_TP = Set(dimen=4)  # load zone, vehicle type, bid number, timepoint
+    m.EV_ZONE_TYPE_BID_TP = Set(
+        dimen=4
+    )  # load zone, vehicle type, bid number, timepoint
+
     def rule(m):
         bids = m.EV_BID_NUMS_set = set()
         types = m.EV_TYPES_set = set()
         for z, t, n, tp in m.EV_ZONE_TYPE_BID_TP:
             bids.add(n)
             types.add(t)
+
     m.Split_EV_Sets = BuildAction(rule=rule)
     m.EV_BID_NUMS = Set(initialize=lambda m: m.EV_BID_NUMS_set)
     m.EV_TYPES = Set(initialize=lambda m: m.EV_TYPES_set)
@@ -44,49 +59,54 @@ def define_components(m):
     # calculate the extra annual cost (non-fuel) of having EVs, relative to ICEs,
     # for batteries and chargers
     m.ev_extra_annual_cost = Param(
-        m.PERIODS, initialize=lambda m, p:
-        sum(
+        m.PERIODS,
+        initialize=lambda m, p: sum(
             m.ev_share[z, p]
             * m.n_vehicles[z, t, p]
             * m.ev_extra_cost_per_vehicle_year[z, t, p]
             for z in m.LOAD_ZONES
             for t in m.EV_TYPES
-        )
+        ),
     )
 
     # calculate total fuel usage, cost and emissions for ICE (non-EV) vehicles
     motor_fuel_mmbtu_per_gallon = {
         # from https://www.eia.gov/Energyexplained/?page=about_energy_units
         "Motor_Gasoline": 0.120476,
-        "Motor_Diesel":   0.137452
+        "Motor_Diesel": 0.137452,
     }
     m.ice_annual_fuel_mmbtu = Param(
-        m.LOAD_ZONES, m.EV_TYPES, m.PERIODS,
-        initialize=lambda m, z, evt, p:
-            (1.0 - m.ev_share[z, p])
-            * m.n_vehicles[z, evt, p]
-            * m.ice_gals_per_year[z, evt, p]
-            * motor_fuel_mmbtu_per_gallon[m.ice_fuel[z, evt, p]]
+        m.LOAD_ZONES,
+        m.EV_TYPES,
+        m.PERIODS,
+        initialize=lambda m, z, evt, p: (1.0 - m.ev_share[z, p])
+        * m.n_vehicles[z, evt, p]
+        * m.ice_gals_per_year[z, evt, p]
+        * motor_fuel_mmbtu_per_gallon[m.ice_fuel[z, evt, p]],
     )
     # non-EV fuel cost
     if hasattr(m, "rfm_supply_tier_cost"):
-        ice_fuel_cost_func = lambda m, z, p, f: m.rfm_supply_tier_cost[m.zone_fuel_rfm[z, f], p, 'base']
+        ice_fuel_cost_func = lambda m, z, p, f: m.rfm_supply_tier_cost[
+            m.zone_fuel_rfm[z, f], p, "base"
+        ]
     else:
         ice_fuel_cost_func = lambda m, z, p, f: m.fuel_cost[z, f, p]
-    m.ice_annual_fuel_cost = Param(m.PERIODS, initialize=lambda m, p:
-        sum(
+    m.ice_annual_fuel_cost = Param(
+        m.PERIODS,
+        initialize=lambda m, p: sum(
             m.ice_annual_fuel_mmbtu[z, evt, p]
             * ice_fuel_cost_func(m, z, p, m.ice_fuel[z, evt, p])
             for z in m.LOAD_ZONES
             for evt in m.EV_TYPES
-        )
+        ),
     )
     # non-EV annual emissions (currently only used for reporting via
     # --save-expression ice_annual_emissions
     # TODO: find a way to add this to the AnnualEmissions expression (maybe);
     # at present, this doesn't affect the system emissions or emission cost
-    m.ice_annual_emissions = Param(m.PERIODS, initialize = lambda m, p:
-        sum(
+    m.ice_annual_emissions = Param(
+        m.PERIODS,
+        initialize=lambda m, p: sum(
             m.ice_annual_fuel_mmbtu[z, evt, p]
             * (
                 m.f_co2_intensity[m.ice_fuel[z, evt, p]]
@@ -94,13 +114,13 @@ def define_components(m):
             )
             for z in m.LOAD_ZONES
             for evt in m.EV_TYPES
-        )
+        ),
     )
 
     # add cost components to account for the vehicle miles traveled via EV or ICE
     # (not used because it interferes with calculation of cost per kWh for electricity)
-    m.Cost_Components_Per_Period.append('ev_extra_annual_cost')
-    m.Cost_Components_Per_Period.append('ice_annual_fuel_cost')
+    m.Cost_Components_Per_Period.append("ev_extra_annual_cost")
+    m.Cost_Components_Per_Period.append("ice_annual_fuel_cost")
 
     # EV bid data -- total MW used by 100% EV fleet, for each zone, veh type,
     # bid number, timepoint
@@ -108,40 +128,47 @@ def define_components(m):
 
     # aggregate across vehicle types (types are only needed for reporting)
     m.ev_bid_mw = Param(
-        m.LOAD_ZONES, m.EV_BID_NUMS, m.TIMEPOINTS,
-        initialize=lambda m, z, n, tp:
-            sum(m.ev_bid_by_type[z, t, n, tp] for t in m.EV_TYPES)
+        m.LOAD_ZONES,
+        m.EV_BID_NUMS,
+        m.TIMEPOINTS,
+        initialize=lambda m, z, n, tp: sum(
+            m.ev_bid_by_type[z, t, n, tp] for t in m.EV_TYPES
+        ),
     )
 
     # find lowest and highest possible charging in each timepoint, used for reserve calcs
     m.ev_charge_min = Param(
-        m.LOAD_ZONES, m.TIMEPOINTS,
-        initialize=lambda m, z, tp:
-            m.ev_share[z, m.tp_period[tp]]
-            * min(m.ev_bid_mw[z, n, tp] for n in m.EV_BID_NUMS)
+        m.LOAD_ZONES,
+        m.TIMEPOINTS,
+        initialize=lambda m, z, tp: m.ev_share[z, m.tp_period[tp]]
+        * min(m.ev_bid_mw[z, n, tp] for n in m.EV_BID_NUMS),
     )
     m.ev_charge_max = Param(
-        m.LOAD_ZONES, m.TIMEPOINTS,
-        initialize=lambda m, z, tp:
-            m.ev_share[z, m.tp_period[tp]]
-            * max(m.ev_bid_mw[z, n, tp] for n in m.EV_BID_NUMS)
+        m.LOAD_ZONES,
+        m.TIMEPOINTS,
+        initialize=lambda m, z, tp: m.ev_share[z, m.tp_period[tp]]
+        * max(m.ev_bid_mw[z, n, tp] for n in m.EV_BID_NUMS),
     )
 
     # decide which share of the fleet to allocate to each charging bid
-    m.EVBidWeight = Var(m.LOAD_ZONES, m.TIMESERIES, m.EV_BID_NUMS, within=PercentFraction)
+    m.EVBidWeight = Var(
+        m.LOAD_ZONES, m.TIMESERIES, m.EV_BID_NUMS, within=PercentFraction
+    )
     m.Charge_Enough_EVs = Constraint(
-        m.LOAD_ZONES, m.TIMESERIES,
-        rule=lambda m, z, ts:
-            sum(m.EVBidWeight[z, ts, n] for n in m.EV_BID_NUMS) == m.ev_share[z, m.ts_period[ts]]
+        m.LOAD_ZONES,
+        m.TIMESERIES,
+        rule=lambda m, z, ts: sum(m.EVBidWeight[z, ts, n] for n in m.EV_BID_NUMS)
+        == m.ev_share[z, m.ts_period[ts]],
     )
 
     # calculate total EV charging
     m.ChargeEVs = Expression(
-        m.LOAD_ZONES, m.TIMEPOINTS,
+        m.LOAD_ZONES,
+        m.TIMEPOINTS,
         rule=lambda m, z, tp: sum(
             m.EVBidWeight[z, m.tp_ts[tp], n] * m.ev_bid_mw[z, n, tp]
             for n in m.EV_BID_NUMS
-        )
+        ),
     )
 
     # set rules for when to charge EVs
@@ -155,22 +182,30 @@ def define_components(m):
             print("Charging EVs at business-as-usual times of day.")
         # give full weight to BAU bid (number 0)
         m.ChargeEVs_bau = Constraint(
-            m.LOAD_ZONES, m.EV_BID_NUMS, m.TIMESERIES,
+            m.LOAD_ZONES,
+            m.EV_BID_NUMS,
+            m.TIMESERIES,
             rule=lambda m, z, n, ts: (
                 m.EVBidWeight[z, ts, n]
                 == (m.ev_share[z, m.ts_period[ts]] if n == 0 else 0)
-            )
+            ),
         )
     else:
         # should never happen
-        raise ValueError("Invalid value specified for --ev-timing: {}".format(str(m.options.ev_timing)))
+        raise ValueError(
+            "Invalid value specified for --ev-timing: {}".format(
+                str(m.options.ev_timing)
+            )
+        )
 
     # add the EV load to the model's energy balance
-    m.Zone_Power_Withdrawals.append('ChargeEVs')
+    m.Zone_Power_Withdrawals.append("ChargeEVs")
 
     # Register with spinning reserves if it is available and optimal EV charging is enabled.
-    if [rt.lower() for rt in m.options.ev_reserve_types] != ['none'] and m.options.ev_timing == "optimal":
-        if hasattr(m, 'Spinning_Reserve_Up_Provisions'):
+    if [rt.lower() for rt in m.options.ev_reserve_types] != [
+        "none"
+    ] and m.options.ev_timing == "optimal":
+        if hasattr(m, "Spinning_Reserve_Up_Provisions"):
             # calculate available slack from EV charging
             # (from supply perspective, so "up" means less load)
             m.EVSlackUp = Expression(
@@ -178,57 +213,57 @@ def define_components(m):
                 rule=lambda m, b, t: sum(
                     m.ChargeEVs[z, t] - m.ev_charge_min[z, t]
                     for z in m.ZONES_IN_BALANCING_AREA[b]
-                )
+                ),
             )
             m.EVSlackDown = Expression(
                 m.BALANCING_AREA_TIMEPOINTS,
                 rule=lambda m, b, t: sum(
                     m.ev_charge_max[z, t] - m.ChargeEVs[z, t]
                     for z in m.ZONES_IN_BALANCING_AREA[b]
-                )
+                ),
             )
-            if hasattr(m, 'GEN_SPINNING_RESERVE_TYPES'):
+            if hasattr(m, "GEN_SPINNING_RESERVE_TYPES"):
                 # using advanced formulation, index by reserve type, balancing area, timepoint.
                 # define variables for each type of reserves to be provided
                 # choose how to allocate the slack between the different reserve products
-                m.EV_SPINNING_RESERVE_TYPES = Set(
-                    initialize=m.options.ev_reserve_types
-                )
+                m.EV_SPINNING_RESERVE_TYPES = Set(initialize=m.options.ev_reserve_types)
                 m.EVSpinningReserveUp = Var(
-                    m.EV_SPINNING_RESERVE_TYPES, m.BALANCING_AREA_TIMEPOINTS,
-                    within=NonNegativeReals
+                    m.EV_SPINNING_RESERVE_TYPES,
+                    m.BALANCING_AREA_TIMEPOINTS,
+                    within=NonNegativeReals,
                 )
                 m.EVSpinningReserveDown = Var(
-                    m.EV_SPINNING_RESERVE_TYPES, m.BALANCING_AREA_TIMEPOINTS,
-                    within=NonNegativeReals
+                    m.EV_SPINNING_RESERVE_TYPES,
+                    m.BALANCING_AREA_TIMEPOINTS,
+                    within=NonNegativeReals,
                 )
                 # constrain reserve provision within available slack
                 m.Limit_EVSpinningReserveUp = Constraint(
                     m.BALANCING_AREA_TIMEPOINTS,
-                    rule=lambda m, ba, tp:
-                        sum(
-                            m.EVSpinningReserveUp[rt, ba, tp]
-                            for rt in m.EV_SPINNING_RESERVE_TYPES
-                        ) <= m.EVSlackUp[ba, tp]
+                    rule=lambda m, ba, tp: sum(
+                        m.EVSpinningReserveUp[rt, ba, tp]
+                        for rt in m.EV_SPINNING_RESERVE_TYPES
+                    )
+                    <= m.EVSlackUp[ba, tp],
                 )
                 m.Limit_EVSpinningReserveDown = Constraint(
                     m.BALANCING_AREA_TIMEPOINTS,
-                    rule=lambda m, ba, tp:
-                        sum(
-                            m.EVSpinningReserveDown[rt, ba, tp]
-                            for rt in m.EV_SPINNING_RESERVE_TYPES
-                        ) <= m.EVSlackDown[ba, tp]
+                    rule=lambda m, ba, tp: sum(
+                        m.EVSpinningReserveDown[rt, ba, tp]
+                        for rt in m.EV_SPINNING_RESERVE_TYPES
+                    )
+                    <= m.EVSlackDown[ba, tp],
                 )
-                m.Spinning_Reserve_Up_Provisions.append('EVSpinningReserveUp')
-                m.Spinning_Reserve_Down_Provisions.append('EVSpinningReserveDown')
+                m.Spinning_Reserve_Up_Provisions.append("EVSpinningReserveUp")
+                m.Spinning_Reserve_Down_Provisions.append("EVSpinningReserveDown")
             else:
                 # using older formulation, only one type of spinning reserves, indexed by balancing area, timepoint
-                if m.options.ev_reserve_types != ['spinning']:
+                if m.options.ev_reserve_types != ["spinning"]:
                     raise ValueError(
                         'Unable to use reserve types other than "spinning" with simple spinning reserves module.'
                     )
-                m.Spinning_Reserve_Up_Provisions.append('EVSlackUp')
-                m.Spinning_Reserve_Down_Provisions.append('EVSlacDown')
+                m.Spinning_Reserve_Up_Provisions.append("EVSlackUp")
+                m.Spinning_Reserve_Down_Provisions.append("EVSlacDown")
 
 
 def load_inputs(m, switch_data, inputs_dir):
@@ -236,15 +271,14 @@ def load_inputs(m, switch_data, inputs_dir):
     Import ev data from .csv files.
     """
     switch_data.load_aug(
-        filename=os.path.join(inputs_dir, 'ev_share.csv'),
-        param=m.ev_share
+        filename=os.path.join(inputs_dir, "ev_share.csv"), param=m.ev_share
     )
     switch_data.load_aug(
-        filename=os.path.join(inputs_dir, 'ev_fleet_info_advanced.csv'),
-        param=[getattr(m, p) for p in ev_zone_type_period_params]
+        filename=os.path.join(inputs_dir, "ev_fleet_info_advanced.csv"),
+        param=[getattr(m, p) for p in ev_zone_type_period_params],
     )
     switch_data.load_aug(
-        filename=os.path.join(inputs_dir, 'ev_charging_bids.csv'),
+        filename=os.path.join(inputs_dir, "ev_charging_bids.csv"),
         param=m.ev_bid_by_type,
-        index=m.EV_ZONE_TYPE_BID_TP
+        index=m.EV_ZONE_TYPE_BID_TP,
     )

--- a/switch_model/hawaii/fed_subsidies.py
+++ b/switch_model/hawaii/fed_subsidies.py
@@ -4,12 +4,17 @@ from pyomo.environ import *
 from .util import get
 import time
 
+
 def define_components(m):
     """
     incorporate the effect of federal subsidies
     """
 
-    m.logger.warning("WARNING: {} module does not account for storage attached to renewable projects.".format(__name__))
+    m.logger.warning(
+        "WARNING: {} module does not account for storage attached to renewable projects.".format(
+            __name__
+        )
+    )
 
     # note: wind/solar/geothermal production tax credit expires in 2017-2019,
     # so we ignore that (http://programs.dsireusa.org/system/program/detail/734)
@@ -17,43 +22,35 @@ def define_components(m):
     # TODO: move these values into data files
     itc_rates = {
         # DistPV from http://programs.dsireusa.org/system/program/detail/1235
-        (2018, 'DistPV'): 0.3,
-        (2019, 'DistPV'): 0.3,
-        (2020, 'DistPV'): 0.26,
-        (2021, 'DistPV'): 0.22,
+        (2018, "DistPV"): 0.3,
+        (2019, "DistPV"): 0.3,
+        (2020, "DistPV"): 0.26,
+        (2021, "DistPV"): 0.22,
         # Wind, Solar and Geothermal ITC from
         # http://programs.dsireusa.org/system/program/detail/658
-        (2018, 'CentralTrackingPV'): 0.3,
-        (2019, 'CentralTrackingPV'): 0.3,
-        (2020, 'CentralTrackingPV'): 0.26,
-        (2021, 'CentralTrackingPV'): 0.22,
-        (2022, 'CentralTrackingPV'): 0.10,
-        (2018, 'OnshoreWind'): 0.22,
-        (2019, 'OnshoreWind'): 0.12,
-        (2018, 'OffshoreWind'): 0.22,
-        (2019, 'OffshoreWind'): 0.12,
+        (2018, "CentralTrackingPV"): 0.3,
+        (2019, "CentralTrackingPV"): 0.3,
+        (2020, "CentralTrackingPV"): 0.26,
+        (2021, "CentralTrackingPV"): 0.22,
+        (2022, "CentralTrackingPV"): 0.10,
+        (2018, "OnshoreWind"): 0.22,
+        (2019, "OnshoreWind"): 0.12,
+        (2018, "OffshoreWind"): 0.22,
+        (2019, "OffshoreWind"): 0.12,
     }
-    itc_rates.update({
-        (y, 'CentralTrackingPV'): 0.1
-        for y in range(2023, 2051)
-    })
-    itc_rates.update({
-        (y, 'Geothermal'): 0.1
-        for y in range(2018, 2051)
-    })
+    itc_rates.update({(y, "CentralTrackingPV"): 0.1 for y in range(2023, 2051)})
+    itc_rates.update({(y, "Geothermal"): 0.1 for y in range(2018, 2051)})
 
     # clone entries for similar technologies
     clones = [
-        ('DistPV', 'FlatDistPV'),
-        ('DistPV', 'SlopedDistPV'),
-        ('CentralTrackingPV', 'CentralFixedPV')
+        ("DistPV", "FlatDistPV"),
+        ("DistPV", "SlopedDistPV"),
+        ("CentralTrackingPV", "CentralFixedPV"),
     ]
     for src, dest in clones:
-        itc_rates.update({
-            (y, dest): rate
-            for (y, tech), rate in itc_rates.items()
-            if tech == src
-        })
+        itc_rates.update(
+            {(y, dest): rate for (y, tech), rate in itc_rates.items() if tech == src}
+        )
 
     def rule(m):
         subsidized_techs = {k for (y, k) in itc_rates}
@@ -61,27 +58,27 @@ def define_components(m):
             t
             for t in m.GENERATION_TECHNOLOGIES
             if (
-                any(x in t.lower() for x in ['pv', 'solar', 'wind', 'geo'])
+                any(x in t.lower() for x in ["pv", "solar", "wind", "geo"])
                 and t not in subsidized_techs
             )
         ]
         if missing_techs:
             print("")
-            print("="*80)
+            print("=" * 80)
             print(
                 "WARNING: these technologies are not listed in {}\n"
                 "but may need to be: \n"
-                "{}"
-                .format(__name__, ', '.join(missing_techs))
+                "{}".format(__name__, ", ".join(missing_techs))
             )
-            print("="*80)
+            print("=" * 80)
             print("")
             time.sleep(3)
+
     m.fed_subsidies_check_techs = BuildAction(rule=rule)
 
     m.gen_investment_subsidy_fraction = Param(
         m.GEN_BLD_YRS,
-        rule=lambda m, g, bld_yr: itc_rates.get((bld_yr, m.gen_tech[g]), 0.0)
+        rule=lambda m, g, bld_yr: itc_rates.get((bld_yr, m.gen_tech[g]), 0.0),
     )
     # model the renewable investment tax credit as simply prorating the
     # annual capital cost (done per generator to simplify reporting)
@@ -93,13 +90,13 @@ def define_components(m):
             * m.BuildGen[g, bld_yr]
             * m.gen_capital_cost_annual[g, bld_yr]
             for bld_yr in m.BLD_YRS_FOR_GEN_PERIOD[g, p]
-        )
+        ),
     )
 
     m.TotalGenCapitalCostsSubsidy = Expression(
         m.PERIODS,
         rule=lambda m, p: sum(
             m.GenCapitalCostsSubsidy[g, p] for g in m.GENS_IN_PERIOD[p]
-        )
+        ),
     )
-    m.Cost_Components_Per_Period.append('TotalGenCapitalCostsSubsidy')
+    m.Cost_Components_Per_Period.append("TotalGenCapitalCostsSubsidy")

--- a/switch_model/hawaii/fuel_markets_expansion.py
+++ b/switch_model/hawaii/fuel_markets_expansion.py
@@ -11,7 +11,8 @@
 import os
 from pyomo.environ import *
 
-inf = float('inf')
+inf = float("inf")
+
 
 def define_components(m):
 
@@ -23,15 +24,20 @@ def define_components(m):
     # are generators (fuel-based or intermittent), and some are storage), fuel-supply projects,
     # transmission lines, etc.
 
-
     # fixed cost (per mmBtu/year of capacity) of having each tier in service during each period
     # note: this must be zero if a tier has unlimited capacity, to avoid having infinite cost
-    m.rfm_supply_tier_fixed_cost = Param(m.RFM_SUPPLY_TIERS, default=0.0,
-        validate=lambda m, v, r, p, st: v == 0.0 or m.rfm_supply_tier_limit[r, p, st] < inf)
+    m.rfm_supply_tier_fixed_cost = Param(
+        m.RFM_SUPPLY_TIERS,
+        default=0.0,
+        validate=lambda m, v, r, p, st: v == 0.0
+        or m.rfm_supply_tier_limit[r, p, st] < inf,
+    )
 
     # lifetime for each tier, once it is placed in service
     # (default is one period)
-    m.rfm_supply_tier_max_age = Param(m.RFM_SUPPLY_TIERS, default=lambda m, r, p, st: m.period_length_years[p])
+    m.rfm_supply_tier_max_age = Param(
+        m.RFM_SUPPLY_TIERS, default=lambda m, r, p, st: m.period_length_years[p]
+    )
 
     # Note: in large regions, a tier represents a block of expandable capacity,
     # so this could be continuous, but then you could just lump the fixed cost
@@ -42,23 +48,27 @@ def define_components(m):
     m.RFMSupplyTierActivate = Var(m.RFM_SUPPLY_TIERS, within=PercentFraction)
 
     # force activation to match build decision
-    m.RFM_Build_Activate_Consistency = Constraint(m.RFM_SUPPLY_TIERS, rule=lambda m, r, p, st:
-        m.RFMSupplyTierActivate[r, p, st]
-        ==
-        sum(
+    m.RFM_Build_Activate_Consistency = Constraint(
+        m.RFM_SUPPLY_TIERS,
+        rule=lambda m, r, p, st: m.RFMSupplyTierActivate[r, p, st]
+        == sum(
             m.RFMBuildSupplyTier[r, vintage, st]
-                for vintage in m.PERIODS
-                    if vintage < m.period_start[p] + m.period_length_years[p]                        # starts before end of current period
-                        and vintage + m.rfm_supply_tier_max_age[r, vintage, st] > m.period_start[p]  # ends after start of current period
-        )
+            for vintage in m.PERIODS
+            if vintage
+            < m.period_start[p]
+            + m.period_length_years[p]  # starts before end of current period
+            and vintage + m.rfm_supply_tier_max_age[r, vintage, st]
+            > m.period_start[p]  # ends after start of current period
+        ),
     )
 
     # force all unlimited tiers to be activated (since they must have no cost,
     # and to avoid a limit of 0.0 * inf in the constraint below)
-    m.Force_Activate_Unlimited_RFM_Supply_Tier = Constraint(m.RFM_SUPPLY_TIERS,
-        rule=lambda m, r, p, st:
-            (m.RFMSupplyTierActivate[r, p, st] == 1) if (m.rfm_supply_tier_limit[r, p, st] == inf)
-            else Constraint.Skip
+    m.Force_Activate_Unlimited_RFM_Supply_Tier = Constraint(
+        m.RFM_SUPPLY_TIERS,
+        rule=lambda m, r, p, st: (m.RFMSupplyTierActivate[r, p, st] == 1)
+        if (m.rfm_supply_tier_limit[r, p, st] == inf)
+        else Constraint.Skip,
     )
 
     # only allow delivery from activated tiers
@@ -66,12 +76,12 @@ def define_components(m):
     # note: this could be merged with the previous constraint, since they are complementary
     m.Enforce_RFM_Supply_Tier_Activated = Constraint(
         m.RFM_SUPPLY_TIERS,
-        rule=lambda m, r, p, st:
-            (
-                m.ConsumeFuelTier[r, p, st]
-                <=
-                m.RFMSupplyTierActivate[r, p, st] * m.rfm_supply_tier_limit[r, p, st]
-            ) if m.rfm_supply_tier_limit[r, p, st] < inf else Constraint.Skip
+        rule=lambda m, r, p, st: (
+            m.ConsumeFuelTier[r, p, st]
+            <= m.RFMSupplyTierActivate[r, p, st] * m.rfm_supply_tier_limit[r, p, st]
+        )
+        if m.rfm_supply_tier_limit[r, p, st] < inf
+        else Constraint.Skip,
     )
 
     # Eventually, when we add capital costs for capacity expansion, we will need a
@@ -87,18 +97,24 @@ def define_components(m):
         rule=lambda m, p: sum(
             (
                 # note: we dance around projects with unlimited supply and 0.0 fixed cost
-                0.0 if m.rfm_supply_tier_fixed_cost[rfm_st] == 0.0
+                0.0
+                if m.rfm_supply_tier_fixed_cost[rfm_st] == 0.0
                 else m.rfm_supply_tier_fixed_cost[rfm_st]
-                    * m.RFMSupplyTierActivate[rfm_st] * m.rfm_supply_tier_limit[rfm_st]
+                * m.RFMSupplyTierActivate[rfm_st]
+                * m.rfm_supply_tier_limit[rfm_st]
             )
             for r in m.REGIONAL_FUEL_MARKETS
-                for rfm_st in m.SUPPLY_TIERS_FOR_RFM_PERIOD[r, p]))
+            for rfm_st in m.SUPPLY_TIERS_FOR_RFM_PERIOD[r, p]
+        ),
+    )
 
-    m.Cost_Components_Per_Period.append('RFM_Fixed_Costs_Annual')
+    m.Cost_Components_Per_Period.append("RFM_Fixed_Costs_Annual")
+
 
 def load_inputs(m, switch_data, inputs_dir):
     switch_data.load_aug(
         optional=True,
-        filename=os.path.join(inputs_dir, 'fuel_supply_curves.csv'),
-        select=('regional_fuel_market', 'period', 'tier', 'fixed_cost', 'max_age'),
-        param=(m.rfm_supply_tier_fixed_cost,m.rfm_supply_tier_max_age))
+        filename=os.path.join(inputs_dir, "fuel_supply_curves.csv"),
+        select=("regional_fuel_market", "period", "tier", "fixed_cost", "max_age"),
+        param=(m.rfm_supply_tier_fixed_cost, m.rfm_supply_tier_max_age),
+    )

--- a/switch_model/hawaii/heco_outlook_2020_06.py
+++ b/switch_model/hawaii/heco_outlook_2020_06.py
@@ -14,8 +14,10 @@ import time
 # realistic. The forecasts HECO used for their modeling at this time are in
 # heco_plan_2020_06.py
 
+
 def TODO(note):
     raise NotImplementedError(dedent(note).strip())
+
 
 def NOTE(note):
     print("=" * 80)
@@ -25,28 +27,60 @@ def NOTE(note):
     print()
     # time.sleep(2)
 
-def define_arguments(argparser):
-    argparser.add_argument('--psip-force', action='store_true', default=False,
-        help="Force following of PSIP plans (building exact amounts of certain technologies).")
-    argparser.add_argument('--psip-relax', dest='psip_force', action='store_false',
-        help="Relax PSIP plans, to find a more optimal strategy.")
-    argparser.add_argument('--psip-minimal-renewables', action='store_true', default=False,
-        help="Use only the amount of renewables shown in PSIP plans, and no more (should be combined with --psip-relax).")
-    argparser.add_argument('--force-build', nargs=3, default=None,
-        help="Force construction of at least a certain quantity of a particular technology during certain years. Space-separated list of year, technology and quantity.")
-    argparser.add_argument('--psip-relax-after', type=float, default=None,
-        help="Follow the PSIP plan up to and including the specified year, then optimize construction in later years. Should be combined with --psip-force.")
 
-    argparser.add_argument('--psip-allow-more-solar-2025', action='store_true', default=False,
-        help="Treat 2025 target for LargePV as lower limit, not exact target.")
-    argparser.add_argument('--psip-no-additional-onshore-wind', action='store_true', default=False,
-        help="Don't allow construction of any onshore wind beyond the current plan.")
+def define_arguments(argparser):
+    argparser.add_argument(
+        "--psip-force",
+        action="store_true",
+        default=False,
+        help="Force following of PSIP plans (building exact amounts of certain technologies).",
+    )
+    argparser.add_argument(
+        "--psip-relax",
+        dest="psip_force",
+        action="store_false",
+        help="Relax PSIP plans, to find a more optimal strategy.",
+    )
+    argparser.add_argument(
+        "--psip-minimal-renewables",
+        action="store_true",
+        default=False,
+        help="Use only the amount of renewables shown in PSIP plans, and no more (should be combined with --psip-relax).",
+    )
+    argparser.add_argument(
+        "--force-build",
+        nargs=3,
+        default=None,
+        help="Force construction of at least a certain quantity of a particular technology during certain years. Space-separated list of year, technology and quantity.",
+    )
+    argparser.add_argument(
+        "--psip-relax-after",
+        type=float,
+        default=None,
+        help="Follow the PSIP plan up to and including the specified year, then optimize construction in later years. Should be combined with --psip-force.",
+    )
+
+    argparser.add_argument(
+        "--psip-allow-more-solar-2025",
+        action="store_true",
+        default=False,
+        help="Treat 2025 target for LargePV as lower limit, not exact target.",
+    )
+    argparser.add_argument(
+        "--psip-no-additional-onshore-wind",
+        action="store_true",
+        default=False,
+        help="Don't allow construction of any onshore wind beyond the current plan.",
+    )
 
 
 def is_renewable(tech):
     return any(txt in tech for txt in ("PV", "Wind", "Solar"))
+
+
 def is_battery(tech):
-    return 'battery' in tech.lower()
+    return "battery" in tech.lower()
+
 
 def define_components(m):
     ###################
@@ -57,7 +91,7 @@ def define_components(m):
     # decide whether to enforce the PSIP preferred plan
     # if an environment variable is set, that takes precedence
     # (e.g., on a cluster to override options.txt)
-    psip_env_var = os.environ.get('USE_PSIP_PLAN')
+    psip_env_var = os.environ.get("USE_PSIP_PLAN")
     if psip_env_var is None:
         # no environment variable; use the --psip-relax flag
         psip = m.options.psip_force
@@ -66,22 +100,28 @@ def define_components(m):
     elif psip_env_var.lower() in ["0", "false", "n", "no", "off"]:
         psip = False
     else:
-        raise ValueError('Unrecognized value for environment variable USE_PSIP_PLAN={} (should be 0 or 1)'.format(psip_env_var))
+        raise ValueError(
+            "Unrecognized value for environment variable USE_PSIP_PLAN={} (should be 0 or 1)".format(
+                psip_env_var
+            )
+        )
 
     if m.options.verbose:
         if psip:
             print("Using PSIP construction plan.")
         else:
-            print("Relaxing PSIP construction plan (optimizing around forecasted adoption).")
+            print(
+                "Relaxing PSIP construction plan (optimizing around forecasted adoption)."
+            )
 
     # make sure LNG is turned off
     if (
         psip
-        and 'LNG' in m.FUELS
+        and "LNG" in m.FUELS
         and getattr(m.options, "force_lng_tier", []) != ["none"]
     ):
         raise RuntimeError(
-            'To match the PSIP with LNG available, you must use the lng_conversion '
+            "To match the PSIP with LNG available, you must use the lng_conversion "
             'module and set "--force-lng-tier none".'
         )
 
@@ -133,7 +173,6 @@ def define_components(m):
     #       * could handle that by moving the predetermined part into a separate project, but then project definitions
     #         must depend on tech_forecast_scenario
 
-
     # NOTE: RESOLVE used different wind and solar profiles from Switch.
     # Switch profiles seem to be more accurate, so we optimize against them
     # and show that this may give (small) savings vs. the RESOLVE plan.
@@ -165,14 +204,16 @@ def define_components(m):
     #     model AC limit and allow unlimited DC on back side. Then use this to
     #     model RFP PV+BESS and forecasted DGPV+DESS.
     # """)
-    NOTE("""
+    NOTE(
+        """
         ***** For future work, use the newer start-of-year existing PV capacity
         ***** in Existing Plants.xlsx and smooth the transition from the
         ***** actual value at start of 2020 (674) to the 2020 forecast (562).
         ***** Maybe do the same for large solar, i.e., shift everything that was
         ***** online at start of 2020 into the "existing" category and/or make
         ***** the first optimized year 2021.
-    """)
+    """
+    )
     tech_group_targets_definite = [
         # HECO June 2018 forecast, saved on shared drive in PBR docket
         # See the following:
@@ -186,61 +227,60 @@ def define_components(m):
         # Clay at Ulupono that day), but we don't use it because it seems
         # unrealistic. (See email from Murray Clay (Ulupono) 2020-04-14 13:58
         # and  /s/data/Generator Info/HECO Dist PV Forecast 2018-03-17.xlsx)
-        (2020, 'DistPV', 15.336, 'DER forecast'), # net of 547 in existing capacity
-        (2021, 'DistPV', 29.51, 'DER forecast'),
-        (2022, 'DistPV', 22.835, 'DER forecast'),
-        (2023, 'DistPV', 19.168, 'DER forecast'),
-        (2024, 'DistPV', 23.087, 'DER forecast'),
-        (2025, 'DistPV', 24.322, 'DER forecast'),
-        (2026, 'DistPV', 25.888, 'DER forecast'),
-        (2027, 'DistPV', 27.24, 'DER forecast'),
-        (2028, 'DistPV', 28.387, 'DER forecast'),
-        (2029, 'DistPV', 29.693, 'DER forecast'),
-        (2030, 'DistPV', 30.522, 'DER forecast'),
-        (2031, 'DistPV', 31.32, 'DER forecast'),
-        (2032, 'DistPV', 32.234, 'DER forecast'),
-        (2033, 'DistPV', 32.42, 'DER forecast'),
-        (2034, 'DistPV', 32.98, 'DER forecast'),
-        (2035, 'DistPV', 33.219, 'DER forecast'),
-        (2036, 'DistPV', 32.785, 'DER forecast'),
-        (2037, 'DistPV', 33.175, 'DER forecast'),
-        (2038, 'DistPV', 33.011, 'DER forecast'),
-        (2039, 'DistPV', 33.101, 'DER forecast'),
-        (2040, 'DistPV', 33.262, 'DER forecast'),
-        (2041, 'DistPV', 33.457, 'DER forecast'),
-        (2042, 'DistPV', 33.343, 'DER forecast'),
-        (2043, 'DistPV', 34.072, 'DER forecast'),
-        (2044, 'DistPV', 34.386, 'DER forecast'),
-        (2045, 'DistPV', 35.038, 'DER forecast'),
+        (2020, "DistPV", 15.336, "DER forecast"),  # net of 547 in existing capacity
+        (2021, "DistPV", 29.51, "DER forecast"),
+        (2022, "DistPV", 22.835, "DER forecast"),
+        (2023, "DistPV", 19.168, "DER forecast"),
+        (2024, "DistPV", 23.087, "DER forecast"),
+        (2025, "DistPV", 24.322, "DER forecast"),
+        (2026, "DistPV", 25.888, "DER forecast"),
+        (2027, "DistPV", 27.24, "DER forecast"),
+        (2028, "DistPV", 28.387, "DER forecast"),
+        (2029, "DistPV", 29.693, "DER forecast"),
+        (2030, "DistPV", 30.522, "DER forecast"),
+        (2031, "DistPV", 31.32, "DER forecast"),
+        (2032, "DistPV", 32.234, "DER forecast"),
+        (2033, "DistPV", 32.42, "DER forecast"),
+        (2034, "DistPV", 32.98, "DER forecast"),
+        (2035, "DistPV", 33.219, "DER forecast"),
+        (2036, "DistPV", 32.785, "DER forecast"),
+        (2037, "DistPV", 33.175, "DER forecast"),
+        (2038, "DistPV", 33.011, "DER forecast"),
+        (2039, "DistPV", 33.101, "DER forecast"),
+        (2040, "DistPV", 33.262, "DER forecast"),
+        (2041, "DistPV", 33.457, "DER forecast"),
+        (2042, "DistPV", 33.343, "DER forecast"),
+        (2043, "DistPV", 34.072, "DER forecast"),
+        (2044, "DistPV", 34.386, "DER forecast"),
+        (2045, "DistPV", 35.038, "DER forecast"),
         # note: HECO provides a MWh forecast; we assume inverters are large
         # enough to charge in 4h
-        (2020, 'DistBattery', (31.941, 4), 'DER forecast'),
-        (2021, 'DistBattery', (12.968, 4), 'DER forecast'),
-        (2022, 'DistBattery', (9.693, 4), 'DER forecast'),
-        (2023, 'DistBattery', (3.135, 4), 'DER forecast'),
-        (2024, 'DistBattery', (3.732, 4), 'DER forecast'),
-        (2025, 'DistBattery', (4.542, 4), 'DER forecast'),
-        (2026, 'DistBattery', (5.324, 4), 'DER forecast'),
-        (2027, 'DistBattery', (6.115, 4), 'DER forecast'),
-        (2028, 'DistBattery', (6.719, 4), 'DER forecast'),
-        (2029, 'DistBattery', (7.316, 4), 'DER forecast'),
-        (2030, 'DistBattery', (7.913, 4), 'DER forecast'),
-        (2031, 'DistBattery', (8.355, 4), 'DER forecast'),
-        (2032, 'DistBattery', (8.723, 4), 'DER forecast'),
-        (2033, 'DistBattery', (9.006, 4), 'DER forecast'),
-        (2034, 'DistBattery', (9.315, 4), 'DER forecast'),
-        (2035, 'DistBattery', (9.49, 4), 'DER forecast'),
-        (2036, 'DistBattery', (9.556, 4), 'DER forecast'),
-        (2037, 'DistBattery', (9.688, 4), 'DER forecast'),
-        (2038, 'DistBattery', (9.777, 4), 'DER forecast'),
-        (2039, 'DistBattery', (9.827, 4), 'DER forecast'),
-        (2040, 'DistBattery', (9.874, 4), 'DER forecast'),
-        (2041, 'DistBattery', (9.939, 4), 'DER forecast'),
-        (2042, 'DistBattery', (10.098, 4), 'DER forecast'),
-        (2043, 'DistBattery', (10.238, 4), 'DER forecast'),
-        (2044, 'DistBattery', (10.37, 4), 'DER forecast'),
-        (2045, 'DistBattery', (10.478, 4), 'DER forecast'),
-
+        (2020, "DistBattery", (31.941, 4), "DER forecast"),
+        (2021, "DistBattery", (12.968, 4), "DER forecast"),
+        (2022, "DistBattery", (9.693, 4), "DER forecast"),
+        (2023, "DistBattery", (3.135, 4), "DER forecast"),
+        (2024, "DistBattery", (3.732, 4), "DER forecast"),
+        (2025, "DistBattery", (4.542, 4), "DER forecast"),
+        (2026, "DistBattery", (5.324, 4), "DER forecast"),
+        (2027, "DistBattery", (6.115, 4), "DER forecast"),
+        (2028, "DistBattery", (6.719, 4), "DER forecast"),
+        (2029, "DistBattery", (7.316, 4), "DER forecast"),
+        (2030, "DistBattery", (7.913, 4), "DER forecast"),
+        (2031, "DistBattery", (8.355, 4), "DER forecast"),
+        (2032, "DistBattery", (8.723, 4), "DER forecast"),
+        (2033, "DistBattery", (9.006, 4), "DER forecast"),
+        (2034, "DistBattery", (9.315, 4), "DER forecast"),
+        (2035, "DistBattery", (9.49, 4), "DER forecast"),
+        (2036, "DistBattery", (9.556, 4), "DER forecast"),
+        (2037, "DistBattery", (9.688, 4), "DER forecast"),
+        (2038, "DistBattery", (9.777, 4), "DER forecast"),
+        (2039, "DistBattery", (9.827, 4), "DER forecast"),
+        (2040, "DistBattery", (9.874, 4), "DER forecast"),
+        (2041, "DistBattery", (9.939, 4), "DER forecast"),
+        (2042, "DistBattery", (10.098, 4), "DER forecast"),
+        (2043, "DistBattery", (10.238, 4), "DER forecast"),
+        (2044, "DistBattery", (10.37, 4), "DER forecast"),
+        (2045, "DistBattery", (10.478, 4), "DER forecast"),
         # HECO feed-in tariff (FIT) projects under construction as of 10/22/19, from
         # https://www.hawaiianelectric.com/clean-energy-hawaii/our-clean-energy-portfolio/renewable-project-status-board
         # NOTE: PSIP Figure J-10 says these are in addition to the customer DGPV
@@ -253,22 +293,24 @@ def define_components(m):
         # existing projects because (a) they don't reduce available roof
         # inventory and (b) counting them as existing but built in 2020 would
         # block construction of additional large PV in 2020.
-        (2020, 'LargePV', 5, 'Aloha Solar II'), # Aloha Solar Energy Fund II, online 4/2/20
-        (2021, 'LargePV', 3.5, 'Mauka FIT 1'), # Mauka FIT 1
-
+        (
+            2020,
+            "LargePV",
+            5,
+            "Aloha Solar II",
+        ),  # Aloha Solar Energy Fund II, online 4/2/20
+        (2021, "LargePV", 3.5, "Mauka FIT 1"),  # Mauka FIT 1
         # note: Mauka FIT 1 and Na Pua Makani (below) are scheduled to come online
         # in 2020, but they are not online yet as of 6/4/2020, so we model them
         # as starting 1/1/2021.
-
         # Na Pua Makani (NPM) wind
         # 2018/24 MW in PSIP, but still under construction in late 2019;
         # Reported as 24 MW to be online in 2020 in
         # https://www.hawaiianelectric.com/clean-energy-hawaii/our-clean-energy-portfolio/renewable-project-status-board (accessed 10/22/19)
         # Listed as 27 MW with operation beginning by summer 2020 on https://www.napuamakanihawaii.org/fact-sheet/
         # TODO: Is Na Pua Makani 24 MW or 27 MW?
-        (2021, 'OnshoreWind', 24, 'Na Pua Makani'),
+        (2021, "OnshoreWind", 24, "Na Pua Makani"),
         # PSIP 2016: (2018, 'OnshoreWind', 24),
-
         # CBRE wind and PV
         # Final order given allowing HECO to proceed with standardized contracts
         # in June 2018: https://cca.hawaii.gov/dca/files/2018/07/Order-No-35560-HECO-CBRE.pdf
@@ -292,8 +334,7 @@ def define_components(m):
         # in Q3 of 2021.". In heco_outlook_2019 we broke these up into
         # installations in 2019, 2020 and 2021, but in "HECO construction plan 2020-03-17.docx"
         # they treat them all as being installed in 2020, so we do that now.
-        (2020, 'LargePV', 5, 'CBRE Phase 1'),  # CBRE Phase 1
-
+        (2020, "LargePV", 5, "CBRE Phase 1"),  # CBRE Phase 1
         # Original CBRE program design had only 72 MW in phase 1 and 2 (leaving
         # 64 MW for phase 2), but HECO suggested increasing this to 235 MW over
         # 5 years. HECO said this was because of projected shortfalls in DER
@@ -309,7 +350,6 @@ def define_components(m):
         # In this version, we switch to 43.5 in 2025, as shown in "HECO construction plan 2020-03-17.docx"
         # This is in addition to RFPs noted below.
         # (2025, 'LargePV', 43.5),  # CBRE Phase 2
-
         # According to Murray Clay email 4/14/20, PUC Order No. 37070 in Docket
         # 2015-0389 specified Oahu Phase 2 as 170 MW. "In tranche 1 there is an
         # RFP process for 75 MW and 15 MW through an expedited (small project
@@ -320,10 +360,19 @@ def define_components(m):
         # takes a lot of time to be deployed...
         # Based on this and later discussion with Ulupono (Samantha Ruiz email
         # 2020-05-26 23:15), we adopted the CBRE phase 2 forecast below:
-        (2023, 'LargePV', 15, 'CBRE phase 2, small'), # small, expedited procurement in order
-        (2024, 'LargePV', 5, 'CBRE phase 2, small'),  # small, expedited procurement in order
-        (2025, 'LargePV', 150, 'CBRE phase 2'),  # larger, slower
-
+        (
+            2023,
+            "LargePV",
+            15,
+            "CBRE phase 2, small",
+        ),  # small, expedited procurement in order
+        (
+            2024,
+            "LargePV",
+            5,
+            "CBRE phase 2, small",
+        ),  # small, expedited procurement in order
+        (2025, "LargePV", 150, "CBRE phase 2"),  # larger, slower
         # 2018-2019 RFPs (docket 2017-0352)
         # These replace large PV and bulk batteries reported in PSIP for 2020 and 2022.
         # TODO: maybe move these to existing plants tables
@@ -338,7 +387,6 @@ def define_components(m):
         # -- https://dms.puc.hawaii.gov/dms/DocumentViewer?pid=A1001001A19H21B03929E00301
         # -- https://www.hawaiianelectric.com/puc-approves-grid-scale-solar-project-in-west-oahu
         # As of 10/22/19, 8th project, 15 MW/60 MWh solar+storage on Maui, is still under review (docket 2018-0433)
-
         # Status of all approved projects and in-service data are listed at
         # https://www.hawaiianelectric.com/clean-energy-hawaii/our-clean-energy-portfolio/renewable-project-status-board
         # They are also shown in "HECO construction plan 2020-03-17.docx".
@@ -351,48 +399,43 @@ def define_components(m):
         # Clay (Ulupono) recommended they counting them as coming online at
         # start of 2022, not end. Taking account of all this, we set them all
         # to start in 2022.
-        (2022, 'LargePV', 12.5, 'RFP stage 1'), # AES West Oahu Solar
-        (2022, 'LargePV', 52, 'RFP stage 1'), # Hoohana Solar 1
-        (2022, 'LargePV', 39, 'RFP stage 1'), # Mililani I Solar
-        (2022, 'LargePV', 36, 'RFP stage 1'), # Waiawa Solar
+        (2022, "LargePV", 12.5, "RFP stage 1"),  # AES West Oahu Solar
+        (2022, "LargePV", 52, "RFP stage 1"),  # Hoohana Solar 1
+        (2022, "LargePV", 39, "RFP stage 1"),  # Mililani I Solar
+        (2022, "LargePV", 36, "RFP stage 1"),  # Waiawa Solar
         # storage associated with large PV projects; we assume this will be used
         # efficiently, so we model it along with other large-scale storage.
-        (2022, 'Battery_Bulk', (12.5, 4), 'RFP stage 1'), # AES West Oahu Solar
-        (2022, 'Battery_Bulk', (52, 4), 'RFP stage 1'), # Hoohana Solar 1
-        (2022, 'Battery_Bulk', (39, 4), 'RFP stage 1'), # Mililani I Solar
-        (2022, 'Battery_Bulk', (36, 4), 'RFP stage 1'), # Waiawa Solar
-
+        (2022, "Battery_Bulk", (12.5, 4), "RFP stage 1"),  # AES West Oahu Solar
+        (2022, "Battery_Bulk", (52, 4), "RFP stage 1"),  # Hoohana Solar 1
+        (2022, "Battery_Bulk", (39, 4), "RFP stage 1"),  # Mililani I Solar
+        (2022, "Battery_Bulk", (36, 4), "RFP stage 1"),  # Waiawa Solar
         # Oahu RFP Stage 2 projects, retrieved 2020-06-04 from
         # https://www.hawaiianelectric.com/clean-energy-hawaii/our-clean-energy-portfolio/renewable-project-status-board
         # We assume they come online at _end_ of year (start of next year).
         # See "data/Generator Info/HECO RFP Stage 2 summary.xlsx" to generate this code.
         # Also see https://www.hawaiianelectric.com/hawaiian-electric-selects-16-projects-in-largest-quest-for-renewable-energy-energy-storage-for-3-islands
-
-        (2023, 'LargePV', 6, 'RFP stage 2'), # Kaukonahua Solar
-        (2023, 'LargePV', 60, 'RFP stage 2'), # Kupehau Solar
-        (2023, 'LargePV', 42, 'RFP stage 2'), # Kupono Solar
-        (2023, 'LargePV', 6.6, 'RFP stage 2'), # Mehana Solar
-        (2024, 'LargePV', 15, 'RFP stage 2'), # Barbers Point Solar
-        (2024, 'LargePV', 120, 'RFP stage 2'), # Mahi Solar
-        (2024, 'LargePV', 7, 'RFP stage 2'), # Mountain View Solar
-        (2024, 'LargePV', 30, 'RFP stage 2'), # Waiawa Phase 2 Solar
-
-        (2023, 'Battery_Bulk', (185, 3.054), 'RFP stage 2'), # Kapolei Energy Storage
-        (2023, 'Battery_Bulk', (6, 4.233), 'RFP stage 2'), # Kaukonahua Solar
-        (2023, 'Battery_Bulk', (60, 4), 'RFP stage 2'), # Kupehau Solar
-        (2023, 'Battery_Bulk', (42, 4), 'RFP stage 2'), # Kupono Solar
-        (2023, 'Battery_Bulk', (6.6, 4), 'RFP stage 2'), # Mehana Solar
-        (2024, 'Battery_Bulk', (15, 4), 'RFP stage 2'), # Barbers Point Solar
-        (2024, 'Battery_Bulk', (120, 4), 'RFP stage 2'), # Mahi Solar
-        (2024, 'Battery_Bulk', (7, 5), 'RFP stage 2'), # Mountain View Solar
-        (2024, 'Battery_Bulk', (30, 8), 'RFP stage 2'), # Waiawa Phase 2 Solar
-
+        (2023, "LargePV", 6, "RFP stage 2"),  # Kaukonahua Solar
+        (2023, "LargePV", 60, "RFP stage 2"),  # Kupehau Solar
+        (2023, "LargePV", 42, "RFP stage 2"),  # Kupono Solar
+        (2023, "LargePV", 6.6, "RFP stage 2"),  # Mehana Solar
+        (2024, "LargePV", 15, "RFP stage 2"),  # Barbers Point Solar
+        (2024, "LargePV", 120, "RFP stage 2"),  # Mahi Solar
+        (2024, "LargePV", 7, "RFP stage 2"),  # Mountain View Solar
+        (2024, "LargePV", 30, "RFP stage 2"),  # Waiawa Phase 2 Solar
+        (2023, "Battery_Bulk", (185, 3.054), "RFP stage 2"),  # Kapolei Energy Storage
+        (2023, "Battery_Bulk", (6, 4.233), "RFP stage 2"),  # Kaukonahua Solar
+        (2023, "Battery_Bulk", (60, 4), "RFP stage 2"),  # Kupehau Solar
+        (2023, "Battery_Bulk", (42, 4), "RFP stage 2"),  # Kupono Solar
+        (2023, "Battery_Bulk", (6.6, 4), "RFP stage 2"),  # Mehana Solar
+        (2024, "Battery_Bulk", (15, 4), "RFP stage 2"),  # Barbers Point Solar
+        (2024, "Battery_Bulk", (120, 4), "RFP stage 2"),  # Mahi Solar
+        (2024, "Battery_Bulk", (7, 5), "RFP stage 2"),  # Mountain View Solar
+        (2024, "Battery_Bulk", (30, 8), "RFP stage 2"),  # Waiawa Phase 2 Solar
         # NOTE: Samantha Ruiz (Ulupono) email 2020-05-21 and 5/26/20 14:36 says
         # PUC directed HECO  to install these by 2022, but she thinks 2023-24 is
         # more likely. In email to Ulupono 5/23/20, Rod Aoki (HECO) said all RFP
         # 2 projects would come online at end of 2025 (forwarded by Murray Clay,
         # Ulupono, 5/23/20).
-
         # Note: HECO said in "HECO construction plan 2020-03-17.docx" that RFP 2
         # would add 1,300 GWh/year in 2025; their renewable project status board
         # (10/2019-5/2020) says the same amount in 2022-25. (Proposals were due
@@ -402,13 +445,11 @@ def define_components(m):
         # That is larger than what they ended up procuring. Original plan could
         # also have been a mix of wind and solar, but final procurement was only
         # solar.
-
         # avg. cap factor for 560 MW starting after 390 best MW have been installed
         # (existing projects + FIT + CBRE 1 + half of CBRE 2 + RFP 1) is 26.6%; see
         # "select site, max_capacity, avg(cap_factor) from cap_factor natural join project where technology = 'CentralTrackingPV' group by 1, 2 order by 3 desc;"
         # and (120*.271+247*.265+193*.264)/(120+247+193)
         # Then (1,300,000 MWh/y)/(.266 * 8766 h/y) = 558 MW
-
         # Apply an extra chunk of PV in 2025. This could be done for either of
         # two reasons:
         # (a) If there is no forecast for 2025,  then Switch would build a lot
@@ -420,7 +461,6 @@ def define_components(m):
         # leaves a weird gap that we want to fill. (For now, we handle that case
         # by potentially interpolating back from 2030 to 2025 instead of 2026.)
         # (2025, 'LargePV', 50),
-
         # PSIP 2016-12-23 Table 4-1 included 90 MW of contingency battery in 2019
         # and https://www.hawaiianelectric.com/documents/clean_energy_hawaii/selling_power_to_the_utility/competitive_bidding/20190207_tri_company_future_procurement.pdf
         # says the 2016-12 plan was to do 70 MW contingency in 2019 and more contingency/regulation in 2020
@@ -432,23 +472,27 @@ def define_components(m):
         # (we need some forecast to avoid picking winners between large PV
         # and dist PV, and forecasting continuous increases in distpv would
         # be redundant with already adequate large-renewables)
-        (y, t, 0.0, 'late freeze')
+        (y, t, 0.0, "late freeze")
         for y in range(2046, 2060)
-        for t in ['DistPV', 'DistBattery']
+        for t in ["DistPV", "DistBattery"]
     ]
     # No new generation in early years beyond what's shown above
     # (this will also block construction of these techs in all years if the
     # --psip-force flag is set)
     tech_group_targets_definite += [
-        (y, t, 0.0, 'early freeze')
+        (y, t, 0.0, "early freeze")
         for techs, years in [
-            (('OnshoreWind', 'OffshoreWind', 'LargePV'), range(2020, 2025+1)),
+            (("OnshoreWind", "OffshoreWind", "LargePV"), range(2020, 2025 + 1)),
             (
                 (
-                    'IC_Barge', 'IC_MCBH', 'IC_Schofield', 'CC_152',
-                    'Battery_Conting', 'Battery_Reg'
+                    "IC_Barge",
+                    "IC_MCBH",
+                    "IC_Schofield",
+                    "CC_152",
+                    "Battery_Conting",
+                    "Battery_Reg",
                 ),
-                range(2020, 2023+1)
+                range(2020, 2023 + 1),
             ),
         ]
         for t in techs
@@ -457,8 +501,7 @@ def define_components(m):
 
     if m.options.psip_no_additional_onshore_wind:
         tech_group_targets_definite += [
-            (y, 'OnshoreWind', 0.0, 'block onshore wind')
-            for y in range(2020, 2056)
+            (y, "OnshoreWind", 0.0, "block onshore wind") for y in range(2020, 2056)
         ]
 
     # add targets specified on the command line
@@ -466,28 +509,32 @@ def define_components(m):
     if m.options.force_build is not None:
         b = list(m.options.force_build)
         build = (
-            int(b[0]),   # year
-            b[1],        # tech
+            int(b[0]),  # year
+            b[1],  # tech
             # quantity
             float(b[2]) if len(b) == 3 else (float(b[2]), float(b[3])),
-            'manual override'
+            "manual override",
         )
         print("Forcing build: {}".format(build))
         tech_group_targets_definite.append(build)
 
     # technologies proposed in "HECO construction plan 2020-03-17.docx" but which may not be built if a better plan is found.
     tech_group_targets_psip = [
-        (2026, 'CC_152', 150.586, 'HECO plan 3/17/20'),
-        (2028, 'CC_152', 150.586, 'HECO plan 3/17/20'),
-        (2030, 'Battery_Bulk', (165, 4), 'HECO plan 3/17/20'),
-        (2032, 'CC_152', 2*150.586, 'HECO plan 3/17/20'),
-        (2035, 'Battery_Bulk', (168, 4), 'HECO plan 3/17/20'),
-        (2040, 'LargePV', 280, 'HECO plan 3/17/20'),
-        (2040, 'Battery_Bulk', (420, 4), 'HECO plan 3/17/20'),
-        (2045, 'LargePV', 1180, 'HECO plan 3/17/20'),
-        (2045, 'Battery_Bulk', (1525, 4), 'HECO plan 3/17/20'),
-        (2045, 'IC_Barge', 4*16.786392, 'HECO plan 3/17/20'), # proxy for 4*17 MW of generic ICE capacity
-
+        (2026, "CC_152", 150.586, "HECO plan 3/17/20"),
+        (2028, "CC_152", 150.586, "HECO plan 3/17/20"),
+        (2030, "Battery_Bulk", (165, 4), "HECO plan 3/17/20"),
+        (2032, "CC_152", 2 * 150.586, "HECO plan 3/17/20"),
+        (2035, "Battery_Bulk", (168, 4), "HECO plan 3/17/20"),
+        (2040, "LargePV", 280, "HECO plan 3/17/20"),
+        (2040, "Battery_Bulk", (420, 4), "HECO plan 3/17/20"),
+        (2045, "LargePV", 1180, "HECO plan 3/17/20"),
+        (2045, "Battery_Bulk", (1525, 4), "HECO plan 3/17/20"),
+        (
+            2045,
+            "IC_Barge",
+            4 * 16.786392,
+            "HECO plan 3/17/20",
+        ),  # proxy for 4*17 MW of generic ICE capacity
         # RESOLVE modeled 4-hour batteries as being capable of providing reserves,
         # and didn't model contingency batteries (see data/HECO Plans/PSIP-WebDAV/2017-01-31 Response to Parties IRs/CA-IR-1/Input
         # and Output Files by Case/E3 and Company Defined Cases/Market DGPV (Reference)/OA_NOLNG/technologies.tab).
@@ -508,7 +555,9 @@ def define_components(m):
         if m.options.psip_relax_after is not None:
             # NOTE: this could be moved later, if we want this flag to relax
             # both the definite and psip targets
-            psip_targets = [t for t in tech_group_targets_psip if t[0] <= m.options.psip_relax_after]
+            psip_targets = [
+                t for t in tech_group_targets_psip if t[0] <= m.options.psip_relax_after
+            ]
         else:
             psip_targets = tech_group_targets_psip.copy()
         tech_group_targets = tech_group_targets_definite + psip_targets
@@ -520,13 +569,12 @@ def define_components(m):
     # Show which technologies can contribute to the target for each technology
     # group and which group each technology contributes to
     techs_for_tech_group = {
-        'DistPV': ['DistPV', 'SlopedDistPV', 'FlatDistPV'],
-        'LargePV': ['CentralTrackingPV', 'CentralFixedPV'],
+        "DistPV": ["DistPV", "SlopedDistPV", "FlatDistPV"],
+        "LargePV": ["CentralTrackingPV", "CentralFixedPV"],
     }
     # use the rest as-is
-    missing_techs = (
-        {t for y, t, s, l in tech_group_targets}
-        .difference(techs_for_tech_group.keys())
+    missing_techs = {t for y, t, s, l in tech_group_targets}.difference(
+        techs_for_tech_group.keys()
     )
     techs_for_tech_group.update({t: [t] for t in missing_techs})
     # create a reverse mapping
@@ -553,25 +601,32 @@ def define_components(m):
     # show max battery capacity equal to sum of all prior additions
 
     # m = lambda: 3; m.options = m; m.options.inputs_dir = '/Users/matthias/Dropbox/Research/Ulupono/Enovation Model/pbr_scenario/inputs'
-    gen_info = pd.read_csv(os.path.join(m.options.inputs_dir, 'generation_projects_info.csv'))
-    gen_info['tech_group'] = gen_info['gen_tech'].map(tech_tech_group)
-    gen_info = gen_info[gen_info['tech_group'].notna()]
+    gen_info = pd.read_csv(
+        os.path.join(m.options.inputs_dir, "generation_projects_info.csv")
+    )
+    gen_info["tech_group"] = gen_info["gen_tech"].map(tech_tech_group)
+    gen_info = gen_info[gen_info["tech_group"].notna()]
     # existing technologies are also subject to rebuilding
     existing_techs = (
-        pd.read_csv(os.path.join(m.options.inputs_dir, 'gen_build_predetermined.csv'))
-        .merge(gen_info, how='inner')
-        .groupby(['build_year', 'tech_group'])['gen_predetermined_cap'].sum()
+        pd.read_csv(os.path.join(m.options.inputs_dir, "gen_build_predetermined.csv"))
+        .merge(gen_info, how="inner")
+        .groupby(["build_year", "tech_group"])["gen_predetermined_cap"]
+        .sum()
         .reset_index()
     )
-    assert not any(is_battery(t) for i, y, t, q in existing_techs.itertuples()), "Must update {} to handle pre-existing batteries.".format(__name__)
-    ages = gen_info.groupby('tech_group')['gen_max_age'].agg(['min', 'max', 'mean'])
-    assert all(ages['min'] == ages['max']), "Some psip technologies have mixed ages."
-    last_period = pd.read_csv(os.path.join(m.options.inputs_dir, 'periods.csv')).iloc[-1, 0]
+    assert not any(
+        is_battery(t) for i, y, t, q in existing_techs.itertuples()
+    ), "Must update {} to handle pre-existing batteries.".format(__name__)
+    ages = gen_info.groupby("tech_group")["gen_max_age"].agg(["min", "max", "mean"])
+    assert all(ages["min"] == ages["max"]), "Some psip technologies have mixed ages."
+    last_period = pd.read_csv(os.path.join(m.options.inputs_dir, "periods.csv")).iloc[
+        -1, 0
+    ]
 
     # rebuild all renewables and batteries in place before the start of the study,
     # plus any technologies with targets specified here
     rebuildable_targets = [
-        (y, t, q, 'existing')
+        (y, t, q, "existing")
         for i, y, t, q in existing_techs.itertuples()
         if is_renewable(t) or is_battery(t)
     ] + tech_group_targets
@@ -579,15 +634,16 @@ def define_components(m):
     for build_year, tech_group, cap, label in rebuildable_targets:
         if tech_group not in ages.index:
             raise ValueError(
-                'A target has been specified for {} but there are no matching '
-                'technologies in generation_projects_info.csv.'
-                .format(tech_group)
+                "A target has been specified for {} but there are no matching "
+                "technologies in generation_projects_info.csv.".format(tech_group)
             )
-        max_age = ages.loc[tech_group, 'mean']
+        max_age = ages.loc[tech_group, "mean"]
         tech_life[tech_group] = max_age
         rebuild_year = build_year + max_age
         while rebuild_year <= last_period:
-            tech_group_targets.append((rebuild_year, tech_group, cap, 'rebuild '+label))
+            tech_group_targets.append(
+                (rebuild_year, tech_group, cap, "rebuild " + label)
+            )
             rebuild_year += max_age
     del gen_info, existing_techs, ages, rebuildable_targets
 
@@ -597,19 +653,21 @@ def define_components(m):
         for y, t, q, l in tech_group_targets
     ]
     tech_group_energy_targets = [
-        (int(y), t, float(q[0]*q[1]), l)
-        for y, t, q, l in tech_group_targets if type(q) is tuple
+        (int(y), t, float(q[0] * q[1]), l)
+        for y, t, q, l in tech_group_targets
+        if type(q) is tuple
     ]
 
     m.FORECASTED_TECH_GROUPS = Set(initialize=techs_for_tech_group.keys())
-    m.FORECASTED_TECH_GROUP_TECHS = Set(m.FORECASTED_TECH_GROUPS, initialize=techs_for_tech_group)
+    m.FORECASTED_TECH_GROUP_TECHS = Set(
+        m.FORECASTED_TECH_GROUPS, initialize=techs_for_tech_group
+    )
     m.FORECASTED_TECHS = Set(initialize=tech_tech_group.keys())
     m.tech_tech_group = Param(m.FORECASTED_TECHS, initialize=tech_tech_group)
 
     # make a list of renewable technologies
     m.RENEWABLE_TECH_GROUPS = Set(
-        initialize=m.FORECASTED_TECH_GROUPS,
-        filter=lambda m, tg: is_renewable(tg)
+        initialize=m.FORECASTED_TECH_GROUPS, filter=lambda m, tg: is_renewable(tg)
     )
 
     def tech_group_target(m, per, tech, targets):
@@ -619,20 +677,28 @@ def define_components(m):
         start = 0 if per == m.PERIODS.first() else m.PERIODS.prev(per)
         end = per
         target = sum(
-            q for (tyear, ttech, q, l) in targets
+            q
+            for (tyear, ttech, q, l) in targets
             if ttech == tech
-                and start < tyear and tyear <= end
-                and tyear + tech_life[ttech] > end
+            and start < tyear
+            and tyear <= end
+            and tyear + tech_life[ttech] > end
         )
         return target
 
     def rule(m, per, tech):
         return tech_group_target(m, per, tech, tech_group_power_targets)
-    m.tech_group_power_target = Param(m.PERIODS, m.FORECASTED_TECH_GROUPS, initialize=rule)
+
+    m.tech_group_power_target = Param(
+        m.PERIODS, m.FORECASTED_TECH_GROUPS, initialize=rule
+    )
 
     def rule(m, per, tech):
         return tech_group_target(m, per, tech, tech_group_energy_targets)
-    m.tech_group_energy_target = Param(m.PERIODS, m.FORECASTED_TECH_GROUPS, initialize=rule)
+
+    m.tech_group_energy_target = Param(
+        m.PERIODS, m.FORECASTED_TECH_GROUPS, initialize=rule
+    )
 
     def MakeTechGroupDicts_rule(m):
         # get unit sizes of all technologies
@@ -643,7 +709,9 @@ def define_components(m):
                 tech_group = m.tech_tech_group[tech]
                 if tech_group in unit_sizes:
                     if unit_sizes[tech_group] != unit_size:
-                        raise ValueError("Generation technology {} uses different unit sizes for different projects.")
+                        raise ValueError(
+                            "Generation technology {} uses different unit sizes for different projects."
+                        )
                 else:
                     unit_sizes[tech_group] = unit_size
         # get predetermined capacity for all technologies
@@ -665,8 +733,11 @@ def define_components(m):
                 # a way to provide predetermined power and energy params, so we
                 # watch out for that here.
                 if m.gen_storage_energy_to_power_ratio[g] == float("inf"):
-                    TODO("Need to lookup predetermined energy capacity for storage technologies.")
+                    TODO(
+                        "Need to lookup predetermined energy capacity for storage technologies."
+                    )
                     # m.tech_group_predetermined_energy_cap_dict[tech_group, per] += <predetermined energy cap>
+
     m.MakeTechGroupDicts = BuildAction(rule=MakeTechGroupDicts_rule)
 
     # Find last date for which a definite target was specified for each tech group.
@@ -682,15 +753,20 @@ def define_components(m):
 
     # Save targets and group definitions for future reference
     import json
+
     os.makedirs(m.options.outputs_dir, exist_ok=True)  # avoid errors with new dir
-    with open(os.path.join(m.options.outputs_dir, 'heco_outlook.json'), 'w') as f:
-        json.dump({
-            'tech_group_power_targets': tech_group_power_targets,
-            'tech_group_energy_targets': tech_group_energy_targets,
-            'techs_for_tech_group': techs_for_tech_group,
-            'tech_tech_group': tech_tech_group,
-            'last_definite_target': last_definite_target,
-        }, f, indent=4)
+    with open(os.path.join(m.options.outputs_dir, "heco_outlook.json"), "w") as f:
+        json.dump(
+            {
+                "tech_group_power_targets": tech_group_power_targets,
+                "tech_group_energy_targets": tech_group_energy_targets,
+                "techs_for_tech_group": techs_for_tech_group,
+                "tech_tech_group": tech_tech_group,
+                "last_definite_target": last_definite_target,
+            },
+            f,
+            indent=4,
+        )
 
     # def build_tech_group_in_period(m, tech_group, period):
     #     """
@@ -745,8 +821,8 @@ def define_components(m):
             build_var[g, per]
             for g in m.GENERATION_PROJECTS
             if m.gen_tech[g] in m.FORECASTED_TECHS
-                and m.tech_tech_group[m.gen_tech[g]] == tech_group
-                and (g, per) in build_var
+            and m.tech_tech_group[m.gen_tech[g]] == tech_group
+            and (g, per) in build_var
         )
 
         if build is 0:
@@ -755,46 +831,59 @@ def define_components(m):
                 return Constraint.Skip
             else:
                 raise ValueError(
-                    "Target was set for {} in {}, but no matching projects are available."
-                    .format(tech_group, per)
+                    "Target was set for {} in {}, but no matching projects are available.".format(
+                        tech_group, per
+                    )
                 )
 
-        if psip and (m.options.psip_relax_after is None or per <= m.options.psip_relax_after):
+        if psip and (
+            m.options.psip_relax_after is None or per <= m.options.psip_relax_after
+        ):
             # PSIP in effect: exactly match the target (possibly zero)
-            return (build == target)
+            return build == target
         elif per <= last_definite_target.get(tech_group, 0):
             # PSIP not in effect, but a definite target is
-            return (build == target)
-        elif m.options.psip_minimal_renewables and tech_group in m.RENEWABLE_TECH_GROUPS:
+            return build == target
+        elif (
+            m.options.psip_minimal_renewables and tech_group in m.RENEWABLE_TECH_GROUPS
+        ):
             # Only build the specified amount of renewables, no more.
             # This is used to apply the definite targets, but otherwise minimize renewable development.
-            return (build == target)
+            return build == target
         else:
             # treat the target as a lower bound
-            return (build >= target)
+            return build >= target
 
     def rule(m, per, tech_group):
         # get target, including any capacity specified in the predetermined builds,
         # so the target will be additional to those
-        target = m.tech_group_power_target[per, tech_group] + m.tech_group_predetermined_power_cap_dict[tech_group, per]
+        target = (
+            m.tech_group_power_target[per, tech_group]
+            + m.tech_group_predetermined_power_cap_dict[tech_group, per]
+        )
         return tech_group_target_rule(m, per, tech_group, m.BuildGen, target)
+
     m.Enforce_Tech_Group_Power_Target = Constraint(
         m.PERIODS, m.FORECASTED_TECH_GROUPS, rule=rule
     )
+
     def rule(m, per, tech_group):
         # get target, including any capacity specified in the predetermined builds,
         # so the target will be additional to those
-        target = m.tech_group_energy_target[per, tech_group] + m.tech_group_predetermined_energy_cap_dict[tech_group, per]
+        target = (
+            m.tech_group_energy_target[per, tech_group]
+            + m.tech_group_predetermined_energy_cap_dict[tech_group, per]
+        )
         return tech_group_target_rule(m, per, tech_group, m.BuildStorageEnergy, target)
+
     m.Enforce_Tech_Group_Energy_Target = Constraint(
         m.PERIODS, m.FORECASTED_TECH_GROUPS, rule=rule
     )
 
     if psip:
+
         def rule(m):
-            buildable_techs = set(
-                m.gen_tech[g] for (g, y) in m.NEW_GEN_BLD_YRS
-            )
+            buildable_techs = set(m.gen_tech[g] for (g, y) in m.NEW_GEN_BLD_YRS)
             if buildable_techs - set(m.FORECASTED_TECHS):
                 # TODO: automatically add zero-targets
                 m.logger.error(
@@ -805,19 +894,29 @@ def define_components(m):
                 return False
             else:
                 return True
+
         m.Check_For_Buildable_Techs_Under_PSIP = BuildCheck(rule=rule)
 
         # don't allow construction of other technologies (e.g., pumped hydro, fuel cells)
         advanced_tech_vars = [
-            "BuildPumpedHydroMW", "BuildAnyPumpedHydro",
-            "BuildElectrolyzerMW", "BuildLiquifierKgPerHour", "BuildLiquidHydrogenTankKg",
+            "BuildPumpedHydroMW",
+            "BuildAnyPumpedHydro",
+            "BuildElectrolyzerMW",
+            "BuildLiquifierKgPerHour",
+            "BuildLiquidHydrogenTankKg",
             "BuildFuelCellMW",
         ]
+
         def no_advanced_tech_rule_factory(v):
             return lambda m, *k: (getattr(m, v)[k] == 0)
+
         for v in advanced_tech_vars:
             try:
                 var = getattr(m, v)
-                setattr(m, "PSIP_No_"+v, Constraint(var._index, rule=no_advanced_tech_rule_factory(v)))
+                setattr(
+                    m,
+                    "PSIP_No_" + v,
+                    Constraint(var._index, rule=no_advanced_tech_rule_factory(v)),
+                )
             except AttributeError:
-                pass    # model doesn't have this var
+                pass  # model doesn't have this var

--- a/switch_model/hawaii/heco_outlook_2020_08.py
+++ b/switch_model/hawaii/heco_outlook_2020_08.py
@@ -15,8 +15,10 @@ import time
 # realistic. The forecasts HECO used for their modeling at this time are in
 # heco_plan_2020_08.py
 
+
 def TODO(note):
     raise NotImplementedError(dedent(note).strip())
+
 
 def NOTE(note):
     print("=" * 80)
@@ -26,28 +28,60 @@ def NOTE(note):
     print()
     # time.sleep(2)
 
-def define_arguments(argparser):
-    argparser.add_argument('--psip-force', action='store_true', default=False,
-        help="Force following of PSIP plans (building exact amounts of certain technologies).")
-    argparser.add_argument('--psip-relax', dest='psip_force', action='store_false',
-        help="Relax PSIP plans, to find a more optimal strategy.")
-    argparser.add_argument('--psip-minimal-renewables', action='store_true', default=False,
-        help="Use only the amount of renewables shown in PSIP plans, and no more (should be combined with --psip-relax).")
-    argparser.add_argument('--force-build', nargs=3, default=None,
-        help="Force construction of at least a certain quantity of a particular technology during certain years. Space-separated list of year, technology and quantity.")
-    argparser.add_argument('--psip-relax-after', type=float, default=None,
-        help="Follow the PSIP plan up to and including the specified year, then optimize construction in later years. Should be combined with --psip-force.")
 
-    argparser.add_argument('--psip-allow-more-solar-2025', action='store_true', default=False,
-        help="Treat 2025 target for LargePV as lower limit, not exact target.")
-    argparser.add_argument('--psip-no-additional-onshore-wind', action='store_true', default=False,
-        help="Don't allow construction of any onshore wind beyond the current plan.")
+def define_arguments(argparser):
+    argparser.add_argument(
+        "--psip-force",
+        action="store_true",
+        default=False,
+        help="Force following of PSIP plans (building exact amounts of certain technologies).",
+    )
+    argparser.add_argument(
+        "--psip-relax",
+        dest="psip_force",
+        action="store_false",
+        help="Relax PSIP plans, to find a more optimal strategy.",
+    )
+    argparser.add_argument(
+        "--psip-minimal-renewables",
+        action="store_true",
+        default=False,
+        help="Use only the amount of renewables shown in PSIP plans, and no more (should be combined with --psip-relax).",
+    )
+    argparser.add_argument(
+        "--force-build",
+        nargs=3,
+        default=None,
+        help="Force construction of at least a certain quantity of a particular technology during certain years. Space-separated list of year, technology and quantity.",
+    )
+    argparser.add_argument(
+        "--psip-relax-after",
+        type=float,
+        default=None,
+        help="Follow the PSIP plan up to and including the specified year, then optimize construction in later years. Should be combined with --psip-force.",
+    )
+
+    argparser.add_argument(
+        "--psip-allow-more-solar-2025",
+        action="store_true",
+        default=False,
+        help="Treat 2025 target for LargePV as lower limit, not exact target.",
+    )
+    argparser.add_argument(
+        "--psip-no-additional-onshore-wind",
+        action="store_true",
+        default=False,
+        help="Don't allow construction of any onshore wind beyond the current plan.",
+    )
 
 
 def is_renewable(tech):
     return any(txt in tech for txt in ("PV", "Wind", "Solar"))
+
+
 def is_battery(tech):
-    return 'battery' in tech.lower()
+    return "battery" in tech.lower()
+
 
 def define_components(m):
     ###################
@@ -58,7 +92,7 @@ def define_components(m):
     # decide whether to enforce the PSIP preferred plan
     # if an environment variable is set, that takes precedence
     # (e.g., on a cluster to override options.txt)
-    psip_env_var = os.environ.get('USE_PSIP_PLAN')
+    psip_env_var = os.environ.get("USE_PSIP_PLAN")
     if psip_env_var is None:
         # no environment variable; use the --psip-relax flag
         psip = m.options.psip_force
@@ -67,22 +101,28 @@ def define_components(m):
     elif psip_env_var.lower() in ["0", "false", "n", "no", "off"]:
         psip = False
     else:
-        raise ValueError('Unrecognized value for environment variable USE_PSIP_PLAN={} (should be 0 or 1)'.format(psip_env_var))
+        raise ValueError(
+            "Unrecognized value for environment variable USE_PSIP_PLAN={} (should be 0 or 1)".format(
+                psip_env_var
+            )
+        )
 
     if m.options.verbose:
         if psip:
             print("Using PSIP construction plan.")
         else:
-            print("Relaxing PSIP construction plan (optimizing around forecasted adoption).")
+            print(
+                "Relaxing PSIP construction plan (optimizing around forecasted adoption)."
+            )
 
     # make sure LNG is turned off
     if (
         psip
-        and 'LNG' in m.FUELS
+        and "LNG" in m.FUELS
         and getattr(m.options, "force_lng_tier", []) != ["none"]
     ):
         raise RuntimeError(
-            'To match the PSIP with LNG available, you must use the lng_conversion '
+            "To match the PSIP with LNG available, you must use the lng_conversion "
             'module and set "--force-lng-tier none".'
         )
 
@@ -134,7 +174,6 @@ def define_components(m):
     #       * could handle that by moving the predetermined part into a separate project, but then project definitions
     #         must depend on tech_forecast_scenario
 
-
     # NOTE: RESOLVE used different wind and solar profiles from Switch.
     # Switch profiles seem to be more accurate, so we optimize against them
     # and show that this may give (small) savings vs. the RESOLVE plan.
@@ -184,59 +223,58 @@ def define_components(m):
         # (in Existing Plant Data.xlsx); so we just apply the HECO additions on
         # top of the existing capacity, which gives total installed capacity
         # 112 MW (PV) and 6.1 MW (Battery) higher than the HECO forecast.
-        (2021, 'DistPV', 29.51, 'DER forecast'),
-        (2022, 'DistPV', 22.835, 'DER forecast'),
-        (2023, 'DistPV', 19.168, 'DER forecast'),
-        (2024, 'DistPV', 23.087, 'DER forecast'),
-        (2025, 'DistPV', 24.322, 'DER forecast'),
-        (2026, 'DistPV', 25.888, 'DER forecast'),
-        (2027, 'DistPV', 27.24, 'DER forecast'),
-        (2028, 'DistPV', 28.387, 'DER forecast'),
-        (2029, 'DistPV', 29.693, 'DER forecast'),
-        (2030, 'DistPV', 30.522, 'DER forecast'),
-        (2031, 'DistPV', 31.32, 'DER forecast'),
-        (2032, 'DistPV', 32.234, 'DER forecast'),
-        (2033, 'DistPV', 32.42, 'DER forecast'),
-        (2034, 'DistPV', 32.98, 'DER forecast'),
-        (2035, 'DistPV', 33.219, 'DER forecast'),
-        (2036, 'DistPV', 32.785, 'DER forecast'),
-        (2037, 'DistPV', 33.175, 'DER forecast'),
-        (2038, 'DistPV', 33.011, 'DER forecast'),
-        (2039, 'DistPV', 33.101, 'DER forecast'),
-        (2040, 'DistPV', 33.262, 'DER forecast'),
-        (2041, 'DistPV', 33.457, 'DER forecast'),
-        (2042, 'DistPV', 33.343, 'DER forecast'),
-        (2043, 'DistPV', 34.072, 'DER forecast'),
-        (2044, 'DistPV', 34.386, 'DER forecast'),
-        (2045, 'DistPV', 35.038, 'DER forecast'),
+        (2021, "DistPV", 29.51, "DER forecast"),
+        (2022, "DistPV", 22.835, "DER forecast"),
+        (2023, "DistPV", 19.168, "DER forecast"),
+        (2024, "DistPV", 23.087, "DER forecast"),
+        (2025, "DistPV", 24.322, "DER forecast"),
+        (2026, "DistPV", 25.888, "DER forecast"),
+        (2027, "DistPV", 27.24, "DER forecast"),
+        (2028, "DistPV", 28.387, "DER forecast"),
+        (2029, "DistPV", 29.693, "DER forecast"),
+        (2030, "DistPV", 30.522, "DER forecast"),
+        (2031, "DistPV", 31.32, "DER forecast"),
+        (2032, "DistPV", 32.234, "DER forecast"),
+        (2033, "DistPV", 32.42, "DER forecast"),
+        (2034, "DistPV", 32.98, "DER forecast"),
+        (2035, "DistPV", 33.219, "DER forecast"),
+        (2036, "DistPV", 32.785, "DER forecast"),
+        (2037, "DistPV", 33.175, "DER forecast"),
+        (2038, "DistPV", 33.011, "DER forecast"),
+        (2039, "DistPV", 33.101, "DER forecast"),
+        (2040, "DistPV", 33.262, "DER forecast"),
+        (2041, "DistPV", 33.457, "DER forecast"),
+        (2042, "DistPV", 33.343, "DER forecast"),
+        (2043, "DistPV", 34.072, "DER forecast"),
+        (2044, "DistPV", 34.386, "DER forecast"),
+        (2045, "DistPV", 35.038, "DER forecast"),
         # note: HECO provides a MWh forecast; we assume inverters are large
         # enough to charge in 4h
-        (2021, 'DistBattery', (12.968, 4), 'DER forecast'),
-        (2022, 'DistBattery', (9.693, 4), 'DER forecast'),
-        (2023, 'DistBattery', (3.135, 4), 'DER forecast'),
-        (2024, 'DistBattery', (3.732, 4), 'DER forecast'),
-        (2025, 'DistBattery', (4.542, 4), 'DER forecast'),
-        (2026, 'DistBattery', (5.324, 4), 'DER forecast'),
-        (2027, 'DistBattery', (6.115, 4), 'DER forecast'),
-        (2028, 'DistBattery', (6.719, 4), 'DER forecast'),
-        (2029, 'DistBattery', (7.316, 4), 'DER forecast'),
-        (2030, 'DistBattery', (7.913, 4), 'DER forecast'),
-        (2031, 'DistBattery', (8.355, 4), 'DER forecast'),
-        (2032, 'DistBattery', (8.723, 4), 'DER forecast'),
-        (2033, 'DistBattery', (9.006, 4), 'DER forecast'),
-        (2034, 'DistBattery', (9.315, 4), 'DER forecast'),
-        (2035, 'DistBattery', (9.49, 4), 'DER forecast'),
-        (2036, 'DistBattery', (9.556, 4), 'DER forecast'),
-        (2037, 'DistBattery', (9.688, 4), 'DER forecast'),
-        (2038, 'DistBattery', (9.777, 4), 'DER forecast'),
-        (2039, 'DistBattery', (9.827, 4), 'DER forecast'),
-        (2040, 'DistBattery', (9.874, 4), 'DER forecast'),
-        (2041, 'DistBattery', (9.939, 4), 'DER forecast'),
-        (2042, 'DistBattery', (10.098, 4), 'DER forecast'),
-        (2043, 'DistBattery', (10.238, 4), 'DER forecast'),
-        (2044, 'DistBattery', (10.37, 4), 'DER forecast'),
-        (2045, 'DistBattery', (10.478, 4), 'DER forecast'),
-
+        (2021, "DistBattery", (12.968, 4), "DER forecast"),
+        (2022, "DistBattery", (9.693, 4), "DER forecast"),
+        (2023, "DistBattery", (3.135, 4), "DER forecast"),
+        (2024, "DistBattery", (3.732, 4), "DER forecast"),
+        (2025, "DistBattery", (4.542, 4), "DER forecast"),
+        (2026, "DistBattery", (5.324, 4), "DER forecast"),
+        (2027, "DistBattery", (6.115, 4), "DER forecast"),
+        (2028, "DistBattery", (6.719, 4), "DER forecast"),
+        (2029, "DistBattery", (7.316, 4), "DER forecast"),
+        (2030, "DistBattery", (7.913, 4), "DER forecast"),
+        (2031, "DistBattery", (8.355, 4), "DER forecast"),
+        (2032, "DistBattery", (8.723, 4), "DER forecast"),
+        (2033, "DistBattery", (9.006, 4), "DER forecast"),
+        (2034, "DistBattery", (9.315, 4), "DER forecast"),
+        (2035, "DistBattery", (9.49, 4), "DER forecast"),
+        (2036, "DistBattery", (9.556, 4), "DER forecast"),
+        (2037, "DistBattery", (9.688, 4), "DER forecast"),
+        (2038, "DistBattery", (9.777, 4), "DER forecast"),
+        (2039, "DistBattery", (9.827, 4), "DER forecast"),
+        (2040, "DistBattery", (9.874, 4), "DER forecast"),
+        (2041, "DistBattery", (9.939, 4), "DER forecast"),
+        (2042, "DistBattery", (10.098, 4), "DER forecast"),
+        (2043, "DistBattery", (10.238, 4), "DER forecast"),
+        (2044, "DistBattery", (10.37, 4), "DER forecast"),
+        (2045, "DistBattery", (10.478, 4), "DER forecast"),
         # Mauka Fit 1 and Na Pua Makani are scheduled to come online in 2020 but
         # are still under construction as of 8/7/20 according to
         # https://www.hawaiianelectric.com/clean-energy-hawaii/our-clean-energy-portfolio/renewable-project-status-board
@@ -244,7 +282,6 @@ def define_components(m):
         # 1 is online in 2021 and Na Pua Makani and CBRE Phase 1 are online in
         # 2020. Since none of these are online by Aug. 2020, we model them as
         # starting 1/1/2021.
-
         # NOTE: PSIP Figure J-10 says FIT projects (Mauka FIT and Aloha Solar II (in Existing Plant Data) are in addition to the customer DGPV
         # adoption forecast, but they are not in "HECO construction plan 2020-03-17.docx".
         # Samantha Ruiz (Ulupono) recommended in email 5/26/20 to count them as
@@ -252,20 +289,17 @@ def define_components(m):
         # years. Note: these are probably fixed-axis rather than tracking (i.e.,
         # more like DistPV than LargePV), but we include them as LargePV because
         # they don't reduce available roof inventory.
-
         # NOTE: Mauka FIT and Na Pua Makani are at particular locations but we
         # include them here because  counting them as existing capacity in 2021
         # would block construction of additional generators in 2021.
-        (2021, 'LargePV', 3.5, 'Mauka FIT 1'), # Mauka FIT 1
-
+        (2021, "LargePV", 3.5, "Mauka FIT 1"),  # Mauka FIT 1
         # Na Pua Makani (NPM) wind
         # Reported as 24 MW in
         # https://www.hawaiianelectric.com/clean-energy-hawaii/our-clean-energy-portfolio/renewable-project-status-board
         # (accessed 10/22/19) but 27 MW on
         # https://www.napuamakanihawaii.org/fact-sheet/. HECO confirmed by email
         # that it is 24 MW.
-        (2021, 'OnshoreWind', 24, 'Na Pua Makani'),
-
+        (2021, "OnshoreWind", 24, "Na Pua Makani"),
         # CBRE wind and PV
         # Final order given allowing HECO to proceed with standardized contracts
         # in June 2018: https://cca.hawaii.gov/dca/files/2018/07/Order-No-35560-HECO-CBRE.pdf
@@ -297,8 +331,7 @@ def define_components(m):
         # We haven't found names, sizes or installation dates for individual
         # projects so we can't easily include them in Existing Capacity. So to
         # simplify modeling we move the online date to 2021.
-        (2021, 'LargePV', 5, 'CBRE Phase 1'),  # CBRE Phase 1
-
+        (2021, "LargePV", 5, "CBRE Phase 1"),  # CBRE Phase 1
         # Original CBRE program design had only 72 MW in phase 1 and 2 (leaving
         # 64 MW for phase 2), but HECO suggested increasing this to 235 MW over
         # 5 years. HECO said this was because of projected shortfalls in DER
@@ -314,7 +347,6 @@ def define_components(m):
         # In this version, we switch to 43.5 in 2025, as shown in "HECO construction plan 2020-03-17.docx"
         # This is in addition to RFPs noted below.
         # (2025, 'LargePV', 43.5),  # CBRE Phase 2
-
         # According to Murray Clay email 4/14/20, PUC Order No. 37070 in Docket
         # 2015-0389 specified Oahu Phase 2 as 170 MW. "In tranche 1 there is an
         # RFP process for 75 MW and 15 MW through an expedited (small project
@@ -325,10 +357,19 @@ def define_components(m):
         # takes a lot of time to be deployed...
         # Based on this and later discussion with Ulupono (Samantha Ruiz email
         # 2020-05-26 23:15), we adopted the CBRE phase 2 forecast below:
-        (2023, 'LargePV', 15, 'CBRE phase 2, small'), # small, expedited procurement in order
-        (2024, 'LargePV', 5, 'CBRE phase 2, small'),  # small, expedited procurement in order
-        (2025, 'LargePV', 150, 'CBRE phase 2'),  # larger, slower
-
+        (
+            2023,
+            "LargePV",
+            15,
+            "CBRE phase 2, small",
+        ),  # small, expedited procurement in order
+        (
+            2024,
+            "LargePV",
+            5,
+            "CBRE phase 2, small",
+        ),  # small, expedited procurement in order
+        (2025, "LargePV", 150, "CBRE phase 2"),  # larger, slower
         # 2018-2019 RFPs (docket 2017-0352)
         # These replace large PV and bulk batteries reported in PSIP for 2020 and 2022.
         # TODO: maybe move these to existing plants tables
@@ -343,7 +384,6 @@ def define_components(m):
         # -- https://dms.puc.hawaii.gov/dms/DocumentViewer?pid=A1001001A19H21B03929E00301
         # -- https://www.hawaiianelectric.com/puc-approves-grid-scale-solar-project-in-west-oahu
         # As of 10/22/19, 8th project, 15 MW/60 MWh solar+storage on Maui, is still under review (docket 2018-0433)
-
         # In an email to Ulupono May 23, 2020, Rod Aoki (HECO) said all RFP 1
         # projects would be online at the end of 2022. However, HECO project
         # status board
@@ -353,45 +393,40 @@ def define_components(m):
         # (https://dms.puc.hawaii.gov/dms/DocumentViewer?pid=A1001001A20F19A83157F00805)
         # sort of split the difference -- AES West Oahu online in 2021, others
         # in 2022. So we use that as the best estimate for modeling.
-        (2021, 'LargePV', 12.5, 'RFP stage 1'), # AES West Oahu Solar
-        (2022, 'LargePV', 52, 'RFP stage 1'), # Hoohana Solar 1
-        (2022, 'LargePV', 39, 'RFP stage 1'), # Mililani I Solar
-        (2022, 'LargePV', 36, 'RFP stage 1'), # Waiawa Solar
+        (2021, "LargePV", 12.5, "RFP stage 1"),  # AES West Oahu Solar
+        (2022, "LargePV", 52, "RFP stage 1"),  # Hoohana Solar 1
+        (2022, "LargePV", 39, "RFP stage 1"),  # Mililani I Solar
+        (2022, "LargePV", 36, "RFP stage 1"),  # Waiawa Solar
         # storage associated with large PV projects; we assume this will be used
         # efficiently, so we model it along with other large-scale storage.
-        (2021, 'Battery_Bulk', (12.5, 4), 'RFP stage 1'), # AES West Oahu Solar
-        (2022, 'Battery_Bulk', (52, 4), 'RFP stage 1'), # Hoohana Solar 1
-        (2022, 'Battery_Bulk', (39, 4), 'RFP stage 1'), # Mililani I Solar
-        (2022, 'Battery_Bulk', (36, 4), 'RFP stage 1'), # Waiawa Solar
-
+        (2021, "Battery_Bulk", (12.5, 4), "RFP stage 1"),  # AES West Oahu Solar
+        (2022, "Battery_Bulk", (52, 4), "RFP stage 1"),  # Hoohana Solar 1
+        (2022, "Battery_Bulk", (39, 4), "RFP stage 1"),  # Mililani I Solar
+        (2022, "Battery_Bulk", (36, 4), "RFP stage 1"),  # Waiawa Solar
         # Oahu RFP Stage 2 projects, retrieved 2020-08-06 from
         # https://www.hawaiianelectric.com/clean-energy-hawaii/our-clean-energy-portfolio/renewable-project-status-board
         # We assume they come online at _end_ of year (start of next year).
         # See "data/Generator Info/HECO RFP Stage 2 summary 2020-08-06.xlsx" to generate this code.
         # Also see https://www.hawaiianelectric.com/hawaiian-electric-selects-16-projects-in-largest-quest-for-renewable-energy-energy-storage-for-3-islands
         # (That included two more projects which were subsequently withdrawn.)
-
-        (2023, 'LargePV', 60, 'RFP stage 2'), # Kupehau Solar
-        (2023, 'LargePV', 42, 'RFP stage 2'), # Kupono Solar
-        (2024, 'LargePV', 15, 'RFP stage 2'), # Barbers Point Solar
-        (2024, 'LargePV', 120, 'RFP stage 2'), # Mahi Solar
-        (2024, 'LargePV', 7, 'RFP stage 2'), # Mountain View Solar
-        (2024, 'LargePV', 30, 'RFP stage 2'), # Waiawa Phase 2 Solar
-
-        (2023, 'Battery_Bulk', (185, 3.054), 'RFP stage 2'), # Kapolei Energy Storage
-        (2023, 'Battery_Bulk', (60, 4), 'RFP stage 2'), # Kupehau Solar
-        (2023, 'Battery_Bulk', (42, 4), 'RFP stage 2'), # Kupono Solar
-        (2024, 'Battery_Bulk', (15, 4), 'RFP stage 2'), # Barbers Point Solar
-        (2024, 'Battery_Bulk', (120, 4), 'RFP stage 2'), # Mahi Solar
-        (2024, 'Battery_Bulk', (7, 5), 'RFP stage 2'), # Mountain View Solar
-        (2024, 'Battery_Bulk', (30, 8), 'RFP stage 2'), # Waiawa Phase 2 Solar
-
+        (2023, "LargePV", 60, "RFP stage 2"),  # Kupehau Solar
+        (2023, "LargePV", 42, "RFP stage 2"),  # Kupono Solar
+        (2024, "LargePV", 15, "RFP stage 2"),  # Barbers Point Solar
+        (2024, "LargePV", 120, "RFP stage 2"),  # Mahi Solar
+        (2024, "LargePV", 7, "RFP stage 2"),  # Mountain View Solar
+        (2024, "LargePV", 30, "RFP stage 2"),  # Waiawa Phase 2 Solar
+        (2023, "Battery_Bulk", (185, 3.054), "RFP stage 2"),  # Kapolei Energy Storage
+        (2023, "Battery_Bulk", (60, 4), "RFP stage 2"),  # Kupehau Solar
+        (2023, "Battery_Bulk", (42, 4), "RFP stage 2"),  # Kupono Solar
+        (2024, "Battery_Bulk", (15, 4), "RFP stage 2"),  # Barbers Point Solar
+        (2024, "Battery_Bulk", (120, 4), "RFP stage 2"),  # Mahi Solar
+        (2024, "Battery_Bulk", (7, 5), "RFP stage 2"),  # Mountain View Solar
+        (2024, "Battery_Bulk", (30, 8), "RFP stage 2"),  # Waiawa Phase 2 Solar
         # NOTE: Samantha Ruiz (Ulupono) email 2020-05-21 and 5/26/20 14:36 says
         # PUC directed HECO  to install these by 2022, but she thinks 2023-24 is
         # more likely. In email to Ulupono 5/23/20, Rod Aoki (HECO) said all RFP
         # 2 projects would come online at end of 2025 (forwarded by Murray Clay,
         # Ulupono, 5/23/20).
-
         # Note: HECO said in "HECO construction plan 2020-03-17.docx" that RFP 2
         # would add 1,300 GWh/year in 2025; their renewable project status board
         # (10/2019-5/2020) says the same amount in 2022-25. (Proposals were due
@@ -401,13 +436,11 @@ def define_components(m):
         # That is larger than what they ended up procuring. Original plan could
         # also have been a mix of wind and solar, but final procurement was only
         # solar.
-
         # avg. cap factor for 560 MW starting after 390 best MW have been installed
         # (existing projects + FIT + CBRE 1 + half of CBRE 2 + RFP 1) is 26.6%; see
         # "select site, max_capacity, avg(cap_factor) from cap_factor natural join project where technology = 'CentralTrackingPV' group by 1, 2 order by 3 desc;"
         # and (120*.271+247*.265+193*.264)/(120+247+193)
         # Then (1,300,000 MWh/y)/(.266 * 8766 h/y) = 558 MW
-
         # Apply an extra chunk of PV in 2025. This could be done for either of
         # two reasons:
         # (a) If there is no forecast for 2025,  then Switch would build a lot
@@ -419,7 +452,6 @@ def define_components(m):
         # leaves a weird gap that we want to fill. (For now, we handle that case
         # by potentially interpolating back from 2030 to 2025 instead of 2026.)
         # (2025, 'LargePV', 50),
-
         # PSIP 2016-12-23 Table 4-1 included 90 MW of contingency battery in 2019
         # and https://www.hawaiianelectric.com/documents/clean_energy_hawaii/selling_power_to_the_utility/competitive_bidding/20190207_tri_company_future_procurement.pdf
         # says the 2016-12 plan was to do 70 MW contingency in 2019 and more contingency/regulation in 2020
@@ -431,23 +463,27 @@ def define_components(m):
         # (we need some forecast to avoid picking winners between large PV
         # and dist PV, and forecasting continuous increases in distpv would
         # be redundant with already adequate large-renewables)
-        (y, t, 0.0, 'late freeze')
+        (y, t, 0.0, "late freeze")
         for y in range(2046, 2060)
-        for t in ['DistPV', 'DistBattery']
+        for t in ["DistPV", "DistBattery"]
     ]
     # No new generation in early years beyond what's shown above
     # (this will also block construction of these techs in all years if the
     # --psip-force flag is set)
     tech_group_targets_definite += [
-        (y, t, 0.0, 'early freeze')
+        (y, t, 0.0, "early freeze")
         for techs, years in [
-            (('OnshoreWind', 'OffshoreWind', 'LargePV'), range(2020, 2025+1)),
+            (("OnshoreWind", "OffshoreWind", "LargePV"), range(2020, 2025 + 1)),
             (
                 (
-                    'IC_Barge', 'IC_MCBH', 'IC_Schofield', 'CC_152',
-                    'Battery_Conting', 'Battery_Reg'
+                    "IC_Barge",
+                    "IC_MCBH",
+                    "IC_Schofield",
+                    "CC_152",
+                    "Battery_Conting",
+                    "Battery_Reg",
                 ),
-                range(2020, 2023+1)
+                range(2020, 2023 + 1),
             ),
         ]
         for t in techs
@@ -456,8 +492,7 @@ def define_components(m):
 
     if m.options.psip_no_additional_onshore_wind:
         tech_group_targets_definite += [
-            (y, 'OnshoreWind', 0.0, 'block onshore wind')
-            for y in range(2020, 2056)
+            (y, "OnshoreWind", 0.0, "block onshore wind") for y in range(2020, 2056)
         ]
 
     # add targets specified on the command line
@@ -465,28 +500,32 @@ def define_components(m):
     if m.options.force_build is not None:
         b = list(m.options.force_build)
         build = (
-            int(b[0]),   # year
-            b[1],        # tech
+            int(b[0]),  # year
+            b[1],  # tech
             # quantity
             float(b[2]) if len(b) == 3 else (float(b[2]), float(b[3])),
-            'manual override'
+            "manual override",
         )
         print("Forcing build: {}".format(build))
         tech_group_targets_definite.append(build)
 
     # technologies proposed in "HECO construction plan 2020-03-17.docx" but which may not be built if a better plan is found.
     tech_group_targets_psip = [
-        (2026, 'CC_152', 150.586, 'HECO plan 3/17/20'),
-        (2028, 'CC_152', 150.586, 'HECO plan 3/17/20'),
-        (2030, 'Battery_Bulk', (165, 4), 'HECO plan 3/17/20'),
-        (2032, 'CC_152', 2*150.586, 'HECO plan 3/17/20'),
-        (2035, 'Battery_Bulk', (168, 4), 'HECO plan 3/17/20'),
-        (2040, 'LargePV', 280, 'HECO plan 3/17/20'),
-        (2040, 'Battery_Bulk', (420, 4), 'HECO plan 3/17/20'),
-        (2045, 'LargePV', 1180, 'HECO plan 3/17/20'),
-        (2045, 'Battery_Bulk', (1525, 4), 'HECO plan 3/17/20'),
-        (2045, 'IC_Barge', 4*16.786392, 'HECO plan 3/17/20'), # proxy for 4*17 MW of generic ICE capacity
-
+        (2026, "CC_152", 150.586, "HECO plan 3/17/20"),
+        (2028, "CC_152", 150.586, "HECO plan 3/17/20"),
+        (2030, "Battery_Bulk", (165, 4), "HECO plan 3/17/20"),
+        (2032, "CC_152", 2 * 150.586, "HECO plan 3/17/20"),
+        (2035, "Battery_Bulk", (168, 4), "HECO plan 3/17/20"),
+        (2040, "LargePV", 280, "HECO plan 3/17/20"),
+        (2040, "Battery_Bulk", (420, 4), "HECO plan 3/17/20"),
+        (2045, "LargePV", 1180, "HECO plan 3/17/20"),
+        (2045, "Battery_Bulk", (1525, 4), "HECO plan 3/17/20"),
+        (
+            2045,
+            "IC_Barge",
+            4 * 16.786392,
+            "HECO plan 3/17/20",
+        ),  # proxy for 4*17 MW of generic ICE capacity
         # RESOLVE modeled 4-hour batteries as being capable of providing reserves,
         # and didn't model contingency batteries (see data/HECO Plans/PSIP-WebDAV/2017-01-31 Response to Parties IRs/CA-IR-1/Input
         # and Output Files by Case/E3 and Company Defined Cases/Market DGPV (Reference)/OA_NOLNG/technologies.tab).
@@ -507,7 +546,9 @@ def define_components(m):
         if m.options.psip_relax_after is not None:
             # NOTE: this could be moved later, if we want this flag to relax
             # both the definite and psip targets
-            psip_targets = [t for t in tech_group_targets_psip if t[0] <= m.options.psip_relax_after]
+            psip_targets = [
+                t for t in tech_group_targets_psip if t[0] <= m.options.psip_relax_after
+            ]
         else:
             psip_targets = tech_group_targets_psip.copy()
         tech_group_targets = tech_group_targets_definite + psip_targets
@@ -519,13 +560,12 @@ def define_components(m):
     # Show which technologies can contribute to the target for each technology
     # group and which group each technology contributes to
     techs_for_tech_group = {
-        'DistPV': ['DistPV', 'SlopedDistPV', 'FlatDistPV'],
-        'LargePV': ['CentralTrackingPV', 'CentralFixedPV'],
+        "DistPV": ["DistPV", "SlopedDistPV", "FlatDistPV"],
+        "LargePV": ["CentralTrackingPV", "CentralFixedPV"],
     }
     # use the rest as-is
-    missing_techs = (
-        {t for y, t, s, l in tech_group_targets}
-        .difference(techs_for_tech_group.keys())
+    missing_techs = {t for y, t, s, l in tech_group_targets}.difference(
+        techs_for_tech_group.keys()
     )
     techs_for_tech_group.update({t: [t] for t in missing_techs})
     # create a reverse mapping
@@ -552,26 +592,34 @@ def define_components(m):
     # show max battery capacity equal to sum of all prior additions
 
     # m = lambda: 3; m.options = m; m.options.inputs_dir = '/Users/matthias/Dropbox/Research/Ulupono/Enovation Model/pbr_scenario/inputs'
-    gen_info = pd.read_csv(os.path.join(m.options.inputs_dir, 'generation_projects_info.csv'))
-    gen_info['tech_group'] = gen_info['gen_tech'].map(tech_tech_group)
-    gen_info = gen_info[gen_info['tech_group'].notna()]
+    gen_info = pd.read_csv(
+        os.path.join(m.options.inputs_dir, "generation_projects_info.csv")
+    )
+    gen_info["tech_group"] = gen_info["gen_tech"].map(tech_tech_group)
+    gen_info = gen_info[gen_info["tech_group"].notna()]
     # existing technologies are also subject to rebuilding
     existing_techs = (
-        pd.read_csv(os.path.join(m.options.inputs_dir, 'gen_build_predetermined.csv'), na_values=['.'])
-        .merge(gen_info, how='inner')
-        .groupby(['build_year', 'tech_group'])
-            [['gen_predetermined_cap', 'gen_predetermined_storage_energy_mwh']]
-            .agg(lambda x: x.sum(skipna=False))
+        pd.read_csv(
+            os.path.join(m.options.inputs_dir, "gen_build_predetermined.csv"),
+            na_values=["."],
+        )
+        .merge(gen_info, how="inner")
+        .groupby(["build_year", "tech_group"])[
+            ["gen_predetermined_cap", "gen_predetermined_storage_energy_mwh"]
+        ]
+        .agg(lambda x: x.sum(skipna=False))
         .reset_index()
     )
-    ages = gen_info.groupby('tech_group')['gen_max_age'].agg(['min', 'max', 'mean'])
-    assert all(ages['min'] == ages['max']), "Some psip technologies have mixed ages."
-    last_period = pd.read_csv(os.path.join(m.options.inputs_dir, 'periods.csv')).iloc[-1, 0]
+    ages = gen_info.groupby("tech_group")["gen_max_age"].agg(["min", "max", "mean"])
+    assert all(ages["min"] == ages["max"]), "Some psip technologies have mixed ages."
+    last_period = pd.read_csv(os.path.join(m.options.inputs_dir, "periods.csv")).iloc[
+        -1, 0
+    ]
 
     # rebuild all renewables and batteries in place before the start of the study,
     # plus any technologies with targets specified here
     rebuildable_targets = [
-        (y, t, (mw if isnan(mwh) else (mw, mwh/mw)), 'existing')
+        (y, t, (mw if isnan(mwh) else (mw, mwh / mw)), "existing")
         for i, y, t, mw, mwh in existing_techs.itertuples()
         if is_renewable(t) or is_battery(t)
     ] + tech_group_targets
@@ -579,15 +627,16 @@ def define_components(m):
     for build_year, tech_group, cap, label in rebuildable_targets:
         if tech_group not in ages.index:
             raise ValueError(
-                'A target has been specified for {} but there are no matching '
-                'technologies in generation_projects_info.csv.'
-                .format(tech_group)
+                "A target has been specified for {} but there are no matching "
+                "technologies in generation_projects_info.csv.".format(tech_group)
             )
-        max_age = ages.loc[tech_group, 'mean']
+        max_age = ages.loc[tech_group, "mean"]
         tech_life[tech_group] = max_age
         rebuild_year = build_year + max_age
         while rebuild_year <= last_period:
-            tech_group_targets.append((rebuild_year, tech_group, cap, 'rebuild '+label))
+            tech_group_targets.append(
+                (rebuild_year, tech_group, cap, "rebuild " + label)
+            )
             rebuild_year += max_age
     del gen_info, existing_techs, ages, rebuildable_targets
 
@@ -597,21 +646,23 @@ def define_components(m):
         for y, t, q, l in tech_group_targets
     ]
     tech_group_energy_targets = [
-        (int(y), t, float(q[0]*q[1]), l)
-        for y, t, q, l in tech_group_targets if type(q) is tuple
+        (int(y), t, float(q[0] * q[1]), l)
+        for y, t, q, l in tech_group_targets
+        if type(q) is tuple
     ]
 
     # import pdb; pdb.set_trace()
 
     m.FORECASTED_TECH_GROUPS = Set(initialize=techs_for_tech_group.keys())
-    m.FORECASTED_TECH_GROUP_TECHS = Set(m.FORECASTED_TECH_GROUPS, initialize=techs_for_tech_group)
+    m.FORECASTED_TECH_GROUP_TECHS = Set(
+        m.FORECASTED_TECH_GROUPS, initialize=techs_for_tech_group
+    )
     m.FORECASTED_TECHS = Set(initialize=tech_tech_group.keys())
     m.tech_tech_group = Param(m.FORECASTED_TECHS, initialize=tech_tech_group)
 
     # make a list of renewable technologies
     m.RENEWABLE_TECH_GROUPS = Set(
-        initialize=m.FORECASTED_TECH_GROUPS,
-        filter=lambda m, tg: is_renewable(tg)
+        initialize=m.FORECASTED_TECH_GROUPS, filter=lambda m, tg: is_renewable(tg)
     )
 
     def tech_group_target(m, per, tech, targets):
@@ -621,20 +672,28 @@ def define_components(m):
         start = 0 if per == m.PERIODS.first() else m.PERIODS.prev(per)
         end = per
         target = sum(
-            q for (tyear, ttech, q, l) in targets
+            q
+            for (tyear, ttech, q, l) in targets
             if ttech == tech
-                and start < tyear and tyear <= end
-                and tyear + tech_life[ttech] > end
+            and start < tyear
+            and tyear <= end
+            and tyear + tech_life[ttech] > end
         )
         return target
 
     def rule(m, per, tech):
         return tech_group_target(m, per, tech, tech_group_power_targets)
-    m.tech_group_power_target = Param(m.PERIODS, m.FORECASTED_TECH_GROUPS, initialize=rule)
+
+    m.tech_group_power_target = Param(
+        m.PERIODS, m.FORECASTED_TECH_GROUPS, initialize=rule
+    )
 
     def rule(m, per, tech):
         return tech_group_target(m, per, tech, tech_group_energy_targets)
-    m.tech_group_energy_target = Param(m.PERIODS, m.FORECASTED_TECH_GROUPS, initialize=rule)
+
+    m.tech_group_energy_target = Param(
+        m.PERIODS, m.FORECASTED_TECH_GROUPS, initialize=rule
+    )
 
     def MakeTechGroupDicts_rule(m):
         # get unit sizes of all technologies
@@ -645,7 +704,9 @@ def define_components(m):
                 tech_group = m.tech_tech_group[tech]
                 if tech_group in unit_sizes:
                     if unit_sizes[tech_group] != unit_size:
-                        raise ValueError("Generation technology {} uses different unit sizes for different projects.")
+                        raise ValueError(
+                            "Generation technology {} uses different unit sizes for different projects."
+                        )
                 else:
                     unit_sizes[tech_group] = unit_size
         # get predetermined capacity for all technologies
@@ -665,6 +726,7 @@ def define_components(m):
             ):
                 tech_group = m.tech_tech_group[tech]
                 m.tech_group_predetermined_energy_cap_dict[tech_group, per] += cap
+
     m.MakeTechGroupDicts = BuildAction(rule=MakeTechGroupDicts_rule)
 
     # Find last date for which a definite target was specified for each tech group.
@@ -680,15 +742,20 @@ def define_components(m):
 
     # Save targets and group definitions for future reference
     import json
+
     os.makedirs(m.options.outputs_dir, exist_ok=True)  # avoid errors with new dir
-    with open(os.path.join(m.options.outputs_dir, 'heco_outlook.json'), 'w') as f:
-        json.dump({
-            'tech_group_power_targets': tech_group_power_targets,
-            'tech_group_energy_targets': tech_group_energy_targets,
-            'techs_for_tech_group': techs_for_tech_group,
-            'tech_tech_group': tech_tech_group,
-            'last_definite_target': last_definite_target,
-        }, f, indent=4)
+    with open(os.path.join(m.options.outputs_dir, "heco_outlook.json"), "w") as f:
+        json.dump(
+            {
+                "tech_group_power_targets": tech_group_power_targets,
+                "tech_group_energy_targets": tech_group_energy_targets,
+                "techs_for_tech_group": techs_for_tech_group,
+                "tech_tech_group": tech_tech_group,
+                "last_definite_target": last_definite_target,
+            },
+            f,
+            indent=4,
+        )
 
     # def build_tech_group_in_period(m, tech_group, period):
     #     """
@@ -743,8 +810,8 @@ def define_components(m):
             build_var[g, per]
             for g in m.GENERATION_PROJECTS
             if m.gen_tech[g] in m.FORECASTED_TECHS
-                and m.tech_tech_group[m.gen_tech[g]] == tech_group
-                and (g, per) in build_var
+            and m.tech_tech_group[m.gen_tech[g]] == tech_group
+            and (g, per) in build_var
         )
 
         if build is 0:
@@ -753,46 +820,59 @@ def define_components(m):
                 return Constraint.Skip
             else:
                 raise ValueError(
-                    "Target was set for {} in {}, but no matching projects are available."
-                    .format(tech_group, per)
+                    "Target was set for {} in {}, but no matching projects are available.".format(
+                        tech_group, per
+                    )
                 )
 
-        if psip and (m.options.psip_relax_after is None or per <= m.options.psip_relax_after):
+        if psip and (
+            m.options.psip_relax_after is None or per <= m.options.psip_relax_after
+        ):
             # PSIP in effect: exactly match the target (possibly zero)
-            return (build == target)
+            return build == target
         elif per <= last_definite_target.get(tech_group, 0):
             # PSIP not in effect, but a definite target is
-            return (build == target)
-        elif m.options.psip_minimal_renewables and tech_group in m.RENEWABLE_TECH_GROUPS:
+            return build == target
+        elif (
+            m.options.psip_minimal_renewables and tech_group in m.RENEWABLE_TECH_GROUPS
+        ):
             # Only build the specified amount of renewables, no more.
             # This is used to apply the definite targets, but otherwise minimize renewable development.
-            return (build == target)
+            return build == target
         else:
             # treat the target as a lower bound
-            return (build >= target)
+            return build >= target
 
     def rule(m, per, tech_group):
         # get target, including any capacity specified in the predetermined builds,
         # so the target will be additional to those
-        target = m.tech_group_power_target[per, tech_group] + m.tech_group_predetermined_power_cap_dict[tech_group, per]
+        target = (
+            m.tech_group_power_target[per, tech_group]
+            + m.tech_group_predetermined_power_cap_dict[tech_group, per]
+        )
         return tech_group_target_rule(m, per, tech_group, m.BuildGen, target)
+
     m.Enforce_Tech_Group_Power_Target = Constraint(
         m.PERIODS, m.FORECASTED_TECH_GROUPS, rule=rule
     )
+
     def rule(m, per, tech_group):
         # get target, including any capacity specified in the predetermined builds,
         # so the target will be additional to those
-        target = m.tech_group_energy_target[per, tech_group] + m.tech_group_predetermined_energy_cap_dict[tech_group, per]
+        target = (
+            m.tech_group_energy_target[per, tech_group]
+            + m.tech_group_predetermined_energy_cap_dict[tech_group, per]
+        )
         return tech_group_target_rule(m, per, tech_group, m.BuildStorageEnergy, target)
+
     m.Enforce_Tech_Group_Energy_Target = Constraint(
         m.PERIODS, m.FORECASTED_TECH_GROUPS, rule=rule
     )
 
     if psip:
+
         def rule(m):
-            buildable_techs = set(
-                m.gen_tech[g] for (g, y) in m.NEW_GEN_BLD_YRS
-            )
+            buildable_techs = set(m.gen_tech[g] for (g, y) in m.NEW_GEN_BLD_YRS)
             if buildable_techs - set(m.FORECASTED_TECHS):
                 # TODO: automatically add zero-targets
                 m.logger.error(
@@ -803,19 +883,29 @@ def define_components(m):
                 return False
             else:
                 return True
+
         m.Check_For_Buildable_Techs_Under_PSIP = BuildCheck(rule=rule)
 
         # don't allow construction of other technologies (e.g., pumped hydro, fuel cells)
         advanced_tech_vars = [
-            "BuildPumpedHydroMW", "BuildAnyPumpedHydro",
-            "BuildElectrolyzerMW", "BuildLiquifierKgPerHour", "BuildLiquidHydrogenTankKg",
+            "BuildPumpedHydroMW",
+            "BuildAnyPumpedHydro",
+            "BuildElectrolyzerMW",
+            "BuildLiquifierKgPerHour",
+            "BuildLiquidHydrogenTankKg",
             "BuildFuelCellMW",
         ]
+
         def no_advanced_tech_rule_factory(v):
             return lambda m, *k: (getattr(m, v)[k] == 0)
+
         for v in advanced_tech_vars:
             try:
                 var = getattr(m, v)
-                setattr(m, "PSIP_No_"+v, Constraint(var._index, rule=no_advanced_tech_rule_factory(v)))
+                setattr(
+                    m,
+                    "PSIP_No_" + v,
+                    Constraint(var._index, rule=no_advanced_tech_rule_factory(v)),
+                )
             except AttributeError:
-                pass    # model doesn't have this var
+                pass  # model doesn't have this var

--- a/switch_model/hawaii/heco_plan_2020_08.py
+++ b/switch_model/hawaii/heco_plan_2020_08.py
@@ -14,8 +14,10 @@ import time
 
 # See psip_2016_12 and heco_outlook_2020_06 for documentation of general structure
 
+
 def TODO(note):
     raise NotImplementedError(dedent(note).strip())
+
 
 def NOTE(note):
     print("=" * 80)
@@ -25,35 +27,67 @@ def NOTE(note):
     print()
     # time.sleep(2)
 
-def define_arguments(argparser):
-    argparser.add_argument('--psip-force', action='store_true', default=False,
-        help="Force following of PSIP plans (building exact amounts of certain technologies).")
-    argparser.add_argument('--psip-relax', dest='psip_force', action='store_false',
-        help="Relax PSIP plans, to find a more optimal strategy.")
-    argparser.add_argument('--psip-minimal-renewables', action='store_true', default=False,
-        help="Use only the amount of renewables shown in PSIP plans, and no more (should be combined with --psip-relax).")
-    argparser.add_argument('--force-build', nargs=3, default=None,
-        help="Force construction of at least a certain quantity of a particular technology during certain years. Space-separated list of year, technology and quantity.")
-    argparser.add_argument('--psip-relax-after', type=float, default=None,
-        help="Follow the PSIP plan up to and including the specified year, then optimize construction in later years. Should be combined with --psip-force.")
 
-    argparser.add_argument('--psip-allow-more-solar-2025', action='store_true', default=False,
-        help="Treat 2025 target for LargePV as lower limit, not exact target.")
-    argparser.add_argument('--psip-no-additional-onshore-wind', action='store_true', default=False,
-        help="Don't allow construction of any onshore wind beyond the current plan.")
+def define_arguments(argparser):
+    argparser.add_argument(
+        "--psip-force",
+        action="store_true",
+        default=False,
+        help="Force following of PSIP plans (building exact amounts of certain technologies).",
+    )
+    argparser.add_argument(
+        "--psip-relax",
+        dest="psip_force",
+        action="store_false",
+        help="Relax PSIP plans, to find a more optimal strategy.",
+    )
+    argparser.add_argument(
+        "--psip-minimal-renewables",
+        action="store_true",
+        default=False,
+        help="Use only the amount of renewables shown in PSIP plans, and no more (should be combined with --psip-relax).",
+    )
+    argparser.add_argument(
+        "--force-build",
+        nargs=3,
+        default=None,
+        help="Force construction of at least a certain quantity of a particular technology during certain years. Space-separated list of year, technology and quantity.",
+    )
+    argparser.add_argument(
+        "--psip-relax-after",
+        type=float,
+        default=None,
+        help="Follow the PSIP plan up to and including the specified year, then optimize construction in later years. Should be combined with --psip-force.",
+    )
+
+    argparser.add_argument(
+        "--psip-allow-more-solar-2025",
+        action="store_true",
+        default=False,
+        help="Treat 2025 target for LargePV as lower limit, not exact target.",
+    )
+    argparser.add_argument(
+        "--psip-no-additional-onshore-wind",
+        action="store_true",
+        default=False,
+        help="Don't allow construction of any onshore wind beyond the current plan.",
+    )
 
 
 def is_renewable(tech):
     return any(txt in tech for txt in ("PV", "Wind", "Solar"))
+
+
 def is_battery(tech):
-    return 'battery' in tech.lower()
+    return "battery" in tech.lower()
+
 
 def define_components(m):
 
     # decide whether to enforce the PSIP preferred plan
     # if an environment variable is set, that takes precedence
     # (e.g., on a cluster to override options.txt)
-    psip_env_var = os.environ.get('USE_PSIP_PLAN')
+    psip_env_var = os.environ.get("USE_PSIP_PLAN")
     if psip_env_var is None:
         # no environment variable; use the --psip-relax flag
         psip = m.options.psip_force
@@ -62,22 +96,28 @@ def define_components(m):
     elif psip_env_var.lower() in ["0", "false", "n", "no", "off"]:
         psip = False
     else:
-        raise ValueError('Unrecognized value for environment variable USE_PSIP_PLAN={} (should be 0 or 1)'.format(psip_env_var))
+        raise ValueError(
+            "Unrecognized value for environment variable USE_PSIP_PLAN={} (should be 0 or 1)".format(
+                psip_env_var
+            )
+        )
 
     if m.options.verbose:
         if psip:
             print("Using PSIP construction plan.")
         else:
-            print("Relaxing PSIP construction plan (optimizing around forecasted adoption).")
+            print(
+                "Relaxing PSIP construction plan (optimizing around forecasted adoption)."
+            )
 
     # make sure LNG is turned off
     if (
         psip
-        and 'LNG' in m.FUELS
+        and "LNG" in m.FUELS
         and getattr(m.options, "force_lng_tier", []) != ["none"]
     ):
         raise RuntimeError(
-            'To match the PSIP with LNG available, you must use the lng_conversion '
+            "To match the PSIP with LNG available, you must use the lng_conversion "
             'module and set "--force-lng-tier none".'
         )
 
@@ -87,66 +127,63 @@ def define_components(m):
         # (2021, 'LargePV', -1, 'missing Pearl City Solar'),
         # Actually we don't, because it is uncancellable at this point; we just
         # assume they proceed with the additional solar installations they report, on top of this.
-
         # HECO March 2020 forecast
         # /s/data/Generator Info/HECO Dist PV Forecast 2020-03-17.xlsx
-
         # We assume all DistPV and DistBattery are used efficiently/optimally,
         # i.e., we do not attempt to model non-optimal pairing of DistPV with
         # DistBattery or curtailment on self-supply tariffs.
-        (2021, 'DistPV', 0, 'DER forecast'),
-        (2022, 'DistPV', 0, 'DER forecast'),
-        (2023, 'DistPV', 0, 'DER forecast'),
-        (2024, 'DistPV', 0, 'DER forecast'),
-        (2025, 'DistPV', 0, 'DER forecast'),
-        (2026, 'DistPV', 0, 'DER forecast'),
-        (2027, 'DistPV', 0, 'DER forecast'),
-        (2028, 'DistPV', 7.3, 'DER forecast'),
-        (2029, 'DistPV', 25.8, 'DER forecast'),
-        (2030, 'DistPV', 27.3, 'DER forecast'),
-        (2031, 'DistPV', 28.4, 'DER forecast'),
-        (2032, 'DistPV', 29.7, 'DER forecast'),
-        (2033, 'DistPV', 30.5, 'DER forecast'),
-        (2034, 'DistPV', 31.3, 'DER forecast'),
-        (2035, 'DistPV', 32.2, 'DER forecast'),
-        (2036, 'DistPV', 32.5, 'DER forecast'),
-        (2037, 'DistPV', 32.9, 'DER forecast'),
-        (2038, 'DistPV', 33.3, 'DER forecast'),
-        (2039, 'DistPV', 32.7, 'DER forecast'),
-        (2040, 'DistPV', 33.2, 'DER forecast'),
-        (2041, 'DistPV', 33, 'DER forecast'),
-        (2042, 'DistPV', 33.1, 'DER forecast'),
-        (2043, 'DistPV', 33.3, 'DER forecast'),
-        (2044, 'DistPV', 33.5, 'DER forecast'),
-        (2045, 'DistPV', 33.3, 'DER forecast'),
+        (2021, "DistPV", 0, "DER forecast"),
+        (2022, "DistPV", 0, "DER forecast"),
+        (2023, "DistPV", 0, "DER forecast"),
+        (2024, "DistPV", 0, "DER forecast"),
+        (2025, "DistPV", 0, "DER forecast"),
+        (2026, "DistPV", 0, "DER forecast"),
+        (2027, "DistPV", 0, "DER forecast"),
+        (2028, "DistPV", 7.3, "DER forecast"),
+        (2029, "DistPV", 25.8, "DER forecast"),
+        (2030, "DistPV", 27.3, "DER forecast"),
+        (2031, "DistPV", 28.4, "DER forecast"),
+        (2032, "DistPV", 29.7, "DER forecast"),
+        (2033, "DistPV", 30.5, "DER forecast"),
+        (2034, "DistPV", 31.3, "DER forecast"),
+        (2035, "DistPV", 32.2, "DER forecast"),
+        (2036, "DistPV", 32.5, "DER forecast"),
+        (2037, "DistPV", 32.9, "DER forecast"),
+        (2038, "DistPV", 33.3, "DER forecast"),
+        (2039, "DistPV", 32.7, "DER forecast"),
+        (2040, "DistPV", 33.2, "DER forecast"),
+        (2041, "DistPV", 33, "DER forecast"),
+        (2042, "DistPV", 33.1, "DER forecast"),
+        (2043, "DistPV", 33.3, "DER forecast"),
+        (2044, "DistPV", 33.5, "DER forecast"),
+        (2045, "DistPV", 33.3, "DER forecast"),
         # note: HECO provides a MWh forecast; we assume inverters are large
         # enough to charge in 4h
-        (2021, 'DistBattery', (0, 4), 'DER forecast'),
-        (2022, 'DistBattery', (0, 4), 'DER forecast'),
-        (2023, 'DistBattery', (0, 4), 'DER forecast'),
-        (2024, 'DistBattery', (6.812, 4), 'DER forecast'),
-        (2025, 'DistBattery', (9.693, 4), 'DER forecast'),
-        (2026, 'DistBattery', (3.135, 4), 'DER forecast'),
-        (2027, 'DistBattery', (3.732, 4), 'DER forecast'),
-        (2028, 'DistBattery', (4.542, 4), 'DER forecast'),
-        (2029, 'DistBattery', (5.324, 4), 'DER forecast'),
-        (2030, 'DistBattery', (6.115, 4), 'DER forecast'),
-        (2031, 'DistBattery', (6.719, 4), 'DER forecast'),
-        (2032, 'DistBattery', (7.316, 4), 'DER forecast'),
-        (2033, 'DistBattery', (7.913, 4), 'DER forecast'),
-        (2034, 'DistBattery', (8.355, 4), 'DER forecast'),
-        (2035, 'DistBattery', (8.723, 4), 'DER forecast'),
-        (2036, 'DistBattery', (9.006, 4), 'DER forecast'),
-        (2037, 'DistBattery', (9.315, 4), 'DER forecast'),
-        (2038, 'DistBattery', (9.49, 4), 'DER forecast'),
-        (2039, 'DistBattery', (9.556, 4), 'DER forecast'),
-        (2040, 'DistBattery', (9.688, 4), 'DER forecast'),
-        (2041, 'DistBattery', (9.777, 4), 'DER forecast'),
-        (2042, 'DistBattery', (9.827, 4), 'DER forecast'),
-        (2043, 'DistBattery', (9.874, 4), 'DER forecast'),
-        (2044, 'DistBattery', (9.939, 4), 'DER forecast'),
-        (2045, 'DistBattery', (10.098, 4), 'DER forecast'),
-
+        (2021, "DistBattery", (0, 4), "DER forecast"),
+        (2022, "DistBattery", (0, 4), "DER forecast"),
+        (2023, "DistBattery", (0, 4), "DER forecast"),
+        (2024, "DistBattery", (6.812, 4), "DER forecast"),
+        (2025, "DistBattery", (9.693, 4), "DER forecast"),
+        (2026, "DistBattery", (3.135, 4), "DER forecast"),
+        (2027, "DistBattery", (3.732, 4), "DER forecast"),
+        (2028, "DistBattery", (4.542, 4), "DER forecast"),
+        (2029, "DistBattery", (5.324, 4), "DER forecast"),
+        (2030, "DistBattery", (6.115, 4), "DER forecast"),
+        (2031, "DistBattery", (6.719, 4), "DER forecast"),
+        (2032, "DistBattery", (7.316, 4), "DER forecast"),
+        (2033, "DistBattery", (7.913, 4), "DER forecast"),
+        (2034, "DistBattery", (8.355, 4), "DER forecast"),
+        (2035, "DistBattery", (8.723, 4), "DER forecast"),
+        (2036, "DistBattery", (9.006, 4), "DER forecast"),
+        (2037, "DistBattery", (9.315, 4), "DER forecast"),
+        (2038, "DistBattery", (9.49, 4), "DER forecast"),
+        (2039, "DistBattery", (9.556, 4), "DER forecast"),
+        (2040, "DistBattery", (9.688, 4), "DER forecast"),
+        (2041, "DistBattery", (9.777, 4), "DER forecast"),
+        (2042, "DistBattery", (9.827, 4), "DER forecast"),
+        (2043, "DistBattery", (9.874, 4), "DER forecast"),
+        (2044, "DistBattery", (9.939, 4), "DER forecast"),
+        (2045, "DistBattery", (10.098, 4), "DER forecast"),
         # Mauka Fit 1 and Na Pua Makani are scheduled to come online in 2020 but
         # are still under construction as of 8/7/20 according to
         # https://www.hawaiianelectric.com/clean-energy-hawaii/our-clean-energy-portfolio/renewable-project-status-board
@@ -154,7 +191,6 @@ def define_components(m):
         # 1 is online in 2021 and Na Pua Makani and CBRE Phase 1 are online in
         # 2020. Since none of these are online by Aug. 2020, we model them as
         # starting 1/1/2021.
-
         # NOTE: PSIP Figure J-10 says FIT projects (Mauka FIT and Aloha Solar II (in Existing Plant Data) are in addition to the customer DGPV
         # adoption forecast, but they are not in "HECO construction plan 2020-03-17.docx".
         # Samantha Ruiz (Ulupono) recommended in email 5/26/20 to count them as
@@ -162,20 +198,17 @@ def define_components(m):
         # years. Note: these are probably fixed-axis rather than tracking (i.e.,
         # more like DistPV than LargePV), but we include them as LargePV because
         # they don't reduce available roof inventory.
-
         # NOTE: Mauka FIT and Na Pua Makani are at particular locations but we
         # include them here because  counting them as existing capacity in 2021
         # would block construction of additional generators in 2021.
-        (2021, 'LargePV', 3.5, 'Mauka FIT 1'), # Mauka FIT 1
-
+        (2021, "LargePV", 3.5, "Mauka FIT 1"),  # Mauka FIT 1
         # Na Pua Makani (NPM) wind
         # Reported as 24 MW in
         # https://www.hawaiianelectric.com/clean-energy-hawaii/our-clean-energy-portfolio/renewable-project-status-board
         # (accessed 10/22/19) but 27 MW on
         # https://www.napuamakanihawaii.org/fact-sheet/. HECO confirmed by email
         # that it is 24 MW.
-        (2021, 'OnshoreWind', 24, 'Na Pua Makani'),
-
+        (2021, "OnshoreWind", 24, "Na Pua Makani"),
         # CBRE wind and PV
         # Final order given allowing HECO to proceed with standardized contracts
         # in June 2018: https://cca.hawaii.gov/dca/files/2018/07/Order-No-35560-HECO-CBRE.pdf
@@ -199,8 +232,7 @@ def define_components(m):
         # in Q3 of 2021.". In heco_outlook_2019 we broke these up into
         # installations in 2019, 2020 and 2021, but in "HECO construction plan 2020-03-17.docx"
         # they treat them all as being installed in 2020, so we do that now.
-        (2021, 'LargePV', 5, 'CBRE Phase 1'),  # CBRE Phase 1
-
+        (2021, "LargePV", 5, "CBRE Phase 1"),  # CBRE Phase 1
         # Original CBRE program design had only 72 MW in phase 1 and 2 (leaving
         # 64 MW for phase 2), but HECO suggested increasing this to 235 MW over
         # 5 years. HECO said this was because of projected shortfalls in DER
@@ -216,9 +248,7 @@ def define_components(m):
         # In this version, we switch to 43.5 in 2025, as shown in "HECO construction plan 2020-03-17.docx"
         # This is in addition to RFPs noted below.
         # (2025, 'LargePV', 43.5),  # CBRE Phase 2
-
-        (2025, 'LargePV', 43.5, 'CBRE phase 2'),
-
+        (2025, "LargePV", 43.5, "CBRE phase 2"),
         # 2018-2019 RFPs (docket 2017-0352)
         # These replace large PV and bulk batteries reported in PSIP for 2020 and 2022.
         # TODO: maybe move these to existing plants tables
@@ -233,7 +263,6 @@ def define_components(m):
         # -- https://dms.puc.hawaii.gov/dms/DocumentViewer?pid=A1001001A19H21B03929E00301
         # -- https://www.hawaiianelectric.com/puc-approves-grid-scale-solar-project-in-west-oahu
         # As of 10/22/19, 8th project, 15 MW/60 MWh solar+storage on Maui, is still under review (docket 2018-0433)
-
         # Status of all approved projects and in-service data are listed at
         # https://www.hawaiianelectric.com/clean-energy-hawaii/our-clean-energy-portfolio/renewable-project-status-board
         # They are also shown in "HECO construction plan 2020-03-17.docx".
@@ -246,34 +275,30 @@ def define_components(m):
         # Clay (Ulupono) recommended they counting them as coming online at
         # start of 2022, not end. Taking account of all this, we set them all
         # to start in 2022.
-        (2021, 'LargePV', 12.5, 'RFP stage 1'), # AES West Oahu Solar
-        (2022, 'LargePV', 52, 'RFP stage 1'), # Hoohana Solar 1
-        (2022, 'LargePV', 39, 'RFP stage 1'), # Mililani I Solar
-        (2022, 'LargePV', 36, 'RFP stage 1'), # Waiawa Solar
+        (2021, "LargePV", 12.5, "RFP stage 1"),  # AES West Oahu Solar
+        (2022, "LargePV", 52, "RFP stage 1"),  # Hoohana Solar 1
+        (2022, "LargePV", 39, "RFP stage 1"),  # Mililani I Solar
+        (2022, "LargePV", 36, "RFP stage 1"),  # Waiawa Solar
         # storage associated with large PV projects; we assume this will be used
         # efficiently, so we model it along with other large-scale storage.
-        (2021, 'Battery_Bulk', (12.5, 4), 'RFP stage 1'), # AES West Oahu Solar
-        (2022, 'Battery_Bulk', (52, 4), 'RFP stage 1'), # Hoohana Solar 1
-        (2022, 'Battery_Bulk', (39, 4), 'RFP stage 1'), # Mililani I Solar
-        (2022, 'Battery_Bulk', (36, 4), 'RFP stage 1'), # Waiawa Solar
-
+        (2021, "Battery_Bulk", (12.5, 4), "RFP stage 1"),  # AES West Oahu Solar
+        (2022, "Battery_Bulk", (52, 4), "RFP stage 1"),  # Hoohana Solar 1
+        (2022, "Battery_Bulk", (39, 4), "RFP stage 1"),  # Mililani I Solar
+        (2022, "Battery_Bulk", (36, 4), "RFP stage 1"),  # Waiawa Solar
         # 200 MW / 6 hour BESS in HECO Phase 2 SOP Exhibit P2 Attachment 1
-        (2022, 'Battery_Bulk', (200, 6), 'HECO plan'),
-
+        (2022, "Battery_Bulk", (200, 6), "HECO plan"),
         # Note: HECO said in "HECO construction plan 2020-03-17.docx" that RFP 2
         # would add 1,300 GWh/year in 2025; their renewable project status board
         # (10/2019-5/2020) says the same amount in 2022-25.
         # PBR Phase 2 SOP Attachment 1 says this too.
         # We think this would be 560 MW, but they think it is 594 MW (see p. 9 of Exhibit A of Dkt 2018-0088 2020-06-18 HECO Phase 2 SOP.pdf)
         # We use 594 MW, because that meshes better with the total MW reported in their plan.
-        (2025, 'LargePV', 594, 'RFP stage 2'),
-
+        (2025, "LargePV", 594, "RFP stage 2"),
         # avg. cap factor for 560 MW starting after 390 best MW have been installed
         # (existing projects + FIT + CBRE 1 + half of CBRE 2 + RFP 1) is 26.6%; see
         # "select site, max_capacity, avg(cap_factor) from cap_factor natural join project where technology = 'CentralTrackingPV' group by 1, 2 order by 3 desc;"
         # and (120*.271+247*.265+193*.264)/(120+247+193)
         # Then (1,300,000 MWh/y)/(.266 * 8766 h/y) = 558 MW
-
         # PSIP 2016-12-23 Table 4-1 included 90 MW of contingency battery in 2019
         # and https://www.hawaiianelectric.com/documents/clean_energy_hawaii/selling_power_to_the_utility/competitive_bidding/20190207_tri_company_future_procurement.pdf
         # says the 2016-12 plan was to do 70 MW contingency in 2019 and more contingency/regulation in 2020
@@ -285,23 +310,27 @@ def define_components(m):
         # (we need some forecast to avoid picking winners between large PV
         # and dist PV, and forecasting continuous increases in distpv would
         # be redundant with already adequate large-renewables)
-        (y, t, 0.0, 'late freeze')
+        (y, t, 0.0, "late freeze")
         for y in range(2046, 2060)
-        for t in ['DistPV', 'DistBattery']
+        for t in ["DistPV", "DistBattery"]
     ]
     # No new generation in early years beyond what's shown above
     # (this will also block construction of these techs in all years if the
     # --psip-force flag is set)
     tech_group_targets_definite += [
-        (y, t, 0.0, 'early freeze')
+        (y, t, 0.0, "early freeze")
         for techs, years in [
-            (('OnshoreWind', 'OffshoreWind', 'LargePV'), range(2020, 2025+1)),
+            (("OnshoreWind", "OffshoreWind", "LargePV"), range(2020, 2025 + 1)),
             (
                 (
-                    'IC_Barge', 'IC_MCBH', 'IC_Schofield', 'CC_152',
-                    'Battery_Conting', 'Battery_Reg'
+                    "IC_Barge",
+                    "IC_MCBH",
+                    "IC_Schofield",
+                    "CC_152",
+                    "Battery_Conting",
+                    "Battery_Reg",
                 ),
-                range(2020, 2023+1)
+                range(2020, 2023 + 1),
             ),
         ]
         for t in techs
@@ -310,8 +339,7 @@ def define_components(m):
 
     if m.options.psip_no_additional_onshore_wind:
         tech_group_targets_definite += [
-            (y, 'OnshoreWind', 0.0, 'block onshore wind')
-            for y in range(2020, 2056)
+            (y, "OnshoreWind", 0.0, "block onshore wind") for y in range(2020, 2056)
         ]
 
     # add targets specified on the command line
@@ -319,28 +347,32 @@ def define_components(m):
     if m.options.force_build is not None:
         b = list(m.options.force_build)
         build = (
-            int(b[0]),   # year
-            b[1],        # tech
+            int(b[0]),  # year
+            b[1],  # tech
             # quantity
             float(b[2]) if len(b) == 3 else (float(b[2]), float(b[3])),
-            'manual override'
+            "manual override",
         )
         print("Forcing build: {}".format(build))
         tech_group_targets_definite.append(build)
 
     # technologies proposed in "HECO construction plan 2020-03-17.docx" but which may not be built if a better plan is found.
     tech_group_targets_psip = [
-        (2026, 'CC_152', 150.586, 'HECO plan 3/17/20'),
-        (2028, 'CC_152', 150.586, 'HECO plan 3/17/20'),
-        (2030, 'Battery_Bulk', (165, 4), 'HECO plan 3/17/20'),
-        (2032, 'CC_152', 2*150.586, 'HECO plan 3/17/20'),
-        (2035, 'Battery_Bulk', (168, 4), 'HECO plan 3/17/20'),
-        (2040, 'LargePV', 280, 'HECO plan 3/17/20'),
-        (2040, 'Battery_Bulk', (420, 4), 'HECO plan 3/17/20'),
-        (2045, 'LargePV', 1180, 'HECO plan 3/17/20'),
-        (2045, 'Battery_Bulk', (1525, 4), 'HECO plan 3/17/20'),
-        (2045, 'IC_Barge', 4*16.786392, 'HECO plan 3/17/20'), # proxy for 4*17 MW of generic ICE capacity
-
+        (2026, "CC_152", 150.586, "HECO plan 3/17/20"),
+        (2028, "CC_152", 150.586, "HECO plan 3/17/20"),
+        (2030, "Battery_Bulk", (165, 4), "HECO plan 3/17/20"),
+        (2032, "CC_152", 2 * 150.586, "HECO plan 3/17/20"),
+        (2035, "Battery_Bulk", (168, 4), "HECO plan 3/17/20"),
+        (2040, "LargePV", 280, "HECO plan 3/17/20"),
+        (2040, "Battery_Bulk", (420, 4), "HECO plan 3/17/20"),
+        (2045, "LargePV", 1180, "HECO plan 3/17/20"),
+        (2045, "Battery_Bulk", (1525, 4), "HECO plan 3/17/20"),
+        (
+            2045,
+            "IC_Barge",
+            4 * 16.786392,
+            "HECO plan 3/17/20",
+        ),  # proxy for 4*17 MW of generic ICE capacity
         # RESOLVE modeled 4-hour batteries as being capable of providing reserves,
         # and didn't model contingency batteries (see data/HECO Plans/PSIP-WebDAV/2017-01-31 Response to Parties IRs/CA-IR-1/Input
         # and Output Files by Case/E3 and Company Defined Cases/Market DGPV (Reference)/OA_NOLNG/technologies.tab).
@@ -361,7 +393,9 @@ def define_components(m):
         if m.options.psip_relax_after is not None:
             # NOTE: this could be moved later, if we want this flag to relax
             # both the definite and psip targets
-            psip_targets = [t for t in tech_group_targets_psip if t[0] <= m.options.psip_relax_after]
+            psip_targets = [
+                t for t in tech_group_targets_psip if t[0] <= m.options.psip_relax_after
+            ]
         else:
             psip_targets = tech_group_targets_psip.copy()
         tech_group_targets = tech_group_targets_definite + psip_targets
@@ -373,13 +407,12 @@ def define_components(m):
     # Show which technologies can contribute to the target for each technology
     # group and which group each technology contributes to
     techs_for_tech_group = {
-        'DistPV': ['DistPV', 'SlopedDistPV', 'FlatDistPV'],
-        'LargePV': ['CentralTrackingPV', 'CentralFixedPV'],
+        "DistPV": ["DistPV", "SlopedDistPV", "FlatDistPV"],
+        "LargePV": ["CentralTrackingPV", "CentralFixedPV"],
     }
     # use the rest as-is
-    missing_techs = (
-        {t for y, t, s, l in tech_group_targets}
-        .difference(techs_for_tech_group.keys())
+    missing_techs = {t for y, t, s, l in tech_group_targets}.difference(
+        techs_for_tech_group.keys()
     )
     techs_for_tech_group.update({t: [t] for t in missing_techs})
     # create a reverse mapping
@@ -406,26 +439,34 @@ def define_components(m):
     # show max battery capacity equal to sum of all prior additions
 
     # m = lambda: 3; m.options = m; m.options.inputs_dir = '/Users/matthias/Dropbox/Research/Ulupono/Enovation Model/pbr_scenario/inputs'
-    gen_info = pd.read_csv(os.path.join(m.options.inputs_dir, 'generation_projects_info.csv'))
-    gen_info['tech_group'] = gen_info['gen_tech'].map(tech_tech_group)
-    gen_info = gen_info[gen_info['tech_group'].notna()]
+    gen_info = pd.read_csv(
+        os.path.join(m.options.inputs_dir, "generation_projects_info.csv")
+    )
+    gen_info["tech_group"] = gen_info["gen_tech"].map(tech_tech_group)
+    gen_info = gen_info[gen_info["tech_group"].notna()]
     # existing technologies are also subject to rebuilding
     existing_techs = (
-        pd.read_csv(os.path.join(m.options.inputs_dir, 'gen_build_predetermined.csv'), na_values=['.'])
-        .merge(gen_info, how='inner')
-        .groupby(['build_year', 'tech_group'])
-            [['gen_predetermined_cap', 'gen_predetermined_storage_energy_mwh']]
-            .agg(lambda x: x.sum(skipna=False))
+        pd.read_csv(
+            os.path.join(m.options.inputs_dir, "gen_build_predetermined.csv"),
+            na_values=["."],
+        )
+        .merge(gen_info, how="inner")
+        .groupby(["build_year", "tech_group"])[
+            ["gen_predetermined_cap", "gen_predetermined_storage_energy_mwh"]
+        ]
+        .agg(lambda x: x.sum(skipna=False))
         .reset_index()
     )
-    ages = gen_info.groupby('tech_group')['gen_max_age'].agg(['min', 'max', 'mean'])
-    assert all(ages['min'] == ages['max']), "Some psip technologies have mixed ages."
-    last_period = pd.read_csv(os.path.join(m.options.inputs_dir, 'periods.csv')).iloc[-1, 0]
+    ages = gen_info.groupby("tech_group")["gen_max_age"].agg(["min", "max", "mean"])
+    assert all(ages["min"] == ages["max"]), "Some psip technologies have mixed ages."
+    last_period = pd.read_csv(os.path.join(m.options.inputs_dir, "periods.csv")).iloc[
+        -1, 0
+    ]
 
     # rebuild all renewables and batteries in place before the start of the study,
     # plus any technologies with targets specified here
     rebuildable_targets = [
-        (y, t, (mw if isnan(mwh) else (mw, mwh/mw)), 'existing')
+        (y, t, (mw if isnan(mwh) else (mw, mwh / mw)), "existing")
         for i, y, t, mw, mwh in existing_techs.itertuples()
         if is_renewable(t) or is_battery(t)
     ] + tech_group_targets
@@ -433,15 +474,16 @@ def define_components(m):
     for build_year, tech_group, cap, label in rebuildable_targets:
         if tech_group not in ages.index:
             raise ValueError(
-                'A target has been specified for {} but there are no matching '
-                'technologies in generation_projects_info.csv.'
-                .format(tech_group)
+                "A target has been specified for {} but there are no matching "
+                "technologies in generation_projects_info.csv.".format(tech_group)
             )
-        max_age = ages.loc[tech_group, 'mean']
+        max_age = ages.loc[tech_group, "mean"]
         tech_life[tech_group] = max_age
         rebuild_year = build_year + max_age
         while rebuild_year <= last_period:
-            tech_group_targets.append((rebuild_year, tech_group, cap, 'rebuild '+label))
+            tech_group_targets.append(
+                (rebuild_year, tech_group, cap, "rebuild " + label)
+            )
             rebuild_year += max_age
     del gen_info, existing_techs, ages, rebuildable_targets
 
@@ -451,21 +493,23 @@ def define_components(m):
         for y, t, q, l in tech_group_targets
     ]
     tech_group_energy_targets = [
-        (int(y), t, float(q[0]*q[1]), l)
-        for y, t, q, l in tech_group_targets if type(q) is tuple
+        (int(y), t, float(q[0] * q[1]), l)
+        for y, t, q, l in tech_group_targets
+        if type(q) is tuple
     ]
 
     # import pdb; pdb.set_trace()
 
     m.FORECASTED_TECH_GROUPS = Set(initialize=techs_for_tech_group.keys())
-    m.FORECASTED_TECH_GROUP_TECHS = Set(m.FORECASTED_TECH_GROUPS, initialize=techs_for_tech_group)
+    m.FORECASTED_TECH_GROUP_TECHS = Set(
+        m.FORECASTED_TECH_GROUPS, initialize=techs_for_tech_group
+    )
     m.FORECASTED_TECHS = Set(initialize=tech_tech_group.keys())
     m.tech_tech_group = Param(m.FORECASTED_TECHS, initialize=tech_tech_group)
 
     # make a list of renewable technologies
     m.RENEWABLE_TECH_GROUPS = Set(
-        initialize=m.FORECASTED_TECH_GROUPS,
-        filter=lambda m, tg: is_renewable(tg)
+        initialize=m.FORECASTED_TECH_GROUPS, filter=lambda m, tg: is_renewable(tg)
     )
 
     def tech_group_target(m, per, tech, targets):
@@ -475,20 +519,28 @@ def define_components(m):
         start = 0 if per == m.PERIODS.first() else m.PERIODS.prev(per)
         end = per
         target = sum(
-            q for (tyear, ttech, q, l) in targets
+            q
+            for (tyear, ttech, q, l) in targets
             if ttech == tech
-                and start < tyear and tyear <= end
-                and tyear + tech_life[ttech] > end
+            and start < tyear
+            and tyear <= end
+            and tyear + tech_life[ttech] > end
         )
         return target
 
     def rule(m, per, tech):
         return tech_group_target(m, per, tech, tech_group_power_targets)
-    m.tech_group_power_target = Param(m.PERIODS, m.FORECASTED_TECH_GROUPS, initialize=rule)
+
+    m.tech_group_power_target = Param(
+        m.PERIODS, m.FORECASTED_TECH_GROUPS, initialize=rule
+    )
 
     def rule(m, per, tech):
         return tech_group_target(m, per, tech, tech_group_energy_targets)
-    m.tech_group_energy_target = Param(m.PERIODS, m.FORECASTED_TECH_GROUPS, initialize=rule)
+
+    m.tech_group_energy_target = Param(
+        m.PERIODS, m.FORECASTED_TECH_GROUPS, initialize=rule
+    )
 
     def MakeTechGroupDicts_rule(m):
         # get unit sizes of all technologies
@@ -499,7 +551,9 @@ def define_components(m):
                 tech_group = m.tech_tech_group[tech]
                 if tech_group in unit_sizes:
                     if unit_sizes[tech_group] != unit_size:
-                        raise ValueError("Generation technology {} uses different unit sizes for different projects.")
+                        raise ValueError(
+                            "Generation technology {} uses different unit sizes for different projects."
+                        )
                 else:
                     unit_sizes[tech_group] = unit_size
         # get predetermined capacity for all technologies
@@ -519,6 +573,7 @@ def define_components(m):
             ):
                 tech_group = m.tech_tech_group[tech]
                 m.tech_group_predetermined_energy_cap_dict[tech_group, per] += cap
+
     m.MakeTechGroupDicts = BuildAction(rule=MakeTechGroupDicts_rule)
 
     # Find last date for which a definite target was specified for each tech group.
@@ -534,15 +589,20 @@ def define_components(m):
 
     # Save targets and group definitions for future reference
     import json
+
     os.makedirs(m.options.outputs_dir, exist_ok=True)  # avoid errors with new dir
-    with open(os.path.join(m.options.outputs_dir, 'heco_outlook.json'), 'w') as f:
-        json.dump({
-            'tech_group_power_targets': tech_group_power_targets,
-            'tech_group_energy_targets': tech_group_energy_targets,
-            'techs_for_tech_group': techs_for_tech_group,
-            'tech_tech_group': tech_tech_group,
-            'last_definite_target': last_definite_target,
-        }, f, indent=4)
+    with open(os.path.join(m.options.outputs_dir, "heco_outlook.json"), "w") as f:
+        json.dump(
+            {
+                "tech_group_power_targets": tech_group_power_targets,
+                "tech_group_energy_targets": tech_group_energy_targets,
+                "techs_for_tech_group": techs_for_tech_group,
+                "tech_tech_group": tech_tech_group,
+                "last_definite_target": last_definite_target,
+            },
+            f,
+            indent=4,
+        )
 
     # def build_tech_group_in_period(m, tech_group, period):
     #     """
@@ -597,8 +657,8 @@ def define_components(m):
             build_var[g, per]
             for g in m.GENERATION_PROJECTS
             if m.gen_tech[g] in m.FORECASTED_TECHS
-                and m.tech_tech_group[m.gen_tech[g]] == tech_group
-                and (g, per) in build_var
+            and m.tech_tech_group[m.gen_tech[g]] == tech_group
+            and (g, per) in build_var
         )
 
         if build is 0:
@@ -607,46 +667,59 @@ def define_components(m):
                 return Constraint.Skip
             else:
                 raise ValueError(
-                    "Target was set for {} in {}, but no matching projects are available."
-                    .format(tech_group, per)
+                    "Target was set for {} in {}, but no matching projects are available.".format(
+                        tech_group, per
+                    )
                 )
 
-        if psip and (m.options.psip_relax_after is None or per <= m.options.psip_relax_after):
+        if psip and (
+            m.options.psip_relax_after is None or per <= m.options.psip_relax_after
+        ):
             # PSIP in effect: exactly match the target (possibly zero)
-            return (build == target)
+            return build == target
         elif per <= last_definite_target.get(tech_group, 0):
             # PSIP not in effect, but a definite target is
-            return (build == target)
-        elif m.options.psip_minimal_renewables and tech_group in m.RENEWABLE_TECH_GROUPS:
+            return build == target
+        elif (
+            m.options.psip_minimal_renewables and tech_group in m.RENEWABLE_TECH_GROUPS
+        ):
             # Only build the specified amount of renewables, no more.
             # This is used to apply the definite targets, but otherwise minimize renewable development.
-            return (build == target)
+            return build == target
         else:
             # treat the target as a lower bound
-            return (build >= target)
+            return build >= target
 
     def rule(m, per, tech_group):
         # get target, including any capacity specified in the predetermined builds,
         # so the target will be additional to those
-        target = m.tech_group_power_target[per, tech_group] + m.tech_group_predetermined_power_cap_dict[tech_group, per]
+        target = (
+            m.tech_group_power_target[per, tech_group]
+            + m.tech_group_predetermined_power_cap_dict[tech_group, per]
+        )
         return tech_group_target_rule(m, per, tech_group, m.BuildGen, target)
+
     m.Enforce_Tech_Group_Power_Target = Constraint(
         m.PERIODS, m.FORECASTED_TECH_GROUPS, rule=rule
     )
+
     def rule(m, per, tech_group):
         # get target, including any capacity specified in the predetermined builds,
         # so the target will be additional to those
-        target = m.tech_group_energy_target[per, tech_group] + m.tech_group_predetermined_energy_cap_dict[tech_group, per]
+        target = (
+            m.tech_group_energy_target[per, tech_group]
+            + m.tech_group_predetermined_energy_cap_dict[tech_group, per]
+        )
         return tech_group_target_rule(m, per, tech_group, m.BuildStorageEnergy, target)
+
     m.Enforce_Tech_Group_Energy_Target = Constraint(
         m.PERIODS, m.FORECASTED_TECH_GROUPS, rule=rule
     )
 
     if psip:
+
         def rule(m):
-            buildable_techs = set(
-                m.gen_tech[g] for (g, y) in m.NEW_GEN_BLD_YRS
-            )
+            buildable_techs = set(m.gen_tech[g] for (g, y) in m.NEW_GEN_BLD_YRS)
             if buildable_techs - set(m.FORECASTED_TECHS):
                 # TODO: automatically add zero-targets
                 m.logger.error(
@@ -657,19 +730,29 @@ def define_components(m):
                 return False
             else:
                 return True
+
         m.Check_For_Buildable_Techs_Under_PSIP = BuildCheck(rule=rule)
 
         # don't allow construction of other technologies (e.g., pumped hydro, fuel cells)
         advanced_tech_vars = [
-            "BuildPumpedHydroMW", "BuildAnyPumpedHydro",
-            "BuildElectrolyzerMW", "BuildLiquifierKgPerHour", "BuildLiquidHydrogenTankKg",
+            "BuildPumpedHydroMW",
+            "BuildAnyPumpedHydro",
+            "BuildElectrolyzerMW",
+            "BuildLiquifierKgPerHour",
+            "BuildLiquidHydrogenTankKg",
             "BuildFuelCellMW",
         ]
+
         def no_advanced_tech_rule_factory(v):
             return lambda m, *k: (getattr(m, v)[k] == 0)
+
         for v in advanced_tech_vars:
             try:
                 var = getattr(m, v)
-                setattr(m, "PSIP_No_"+v, Constraint(var._index, rule=no_advanced_tech_rule_factory(v)))
+                setattr(
+                    m,
+                    "PSIP_No_" + v,
+                    Constraint(var._index, rule=no_advanced_tech_rule_factory(v)),
+                )
             except AttributeError:
-                pass    # model doesn't have this var
+                pass  # model doesn't have this var

--- a/switch_model/hawaii/hi_spinning_reserves.py
+++ b/switch_model/hawaii/hi_spinning_reserves.py
@@ -8,15 +8,15 @@ import os
 from pyomo.environ import *
 
 dependencies = (
-    'switch_model.timescales',
-    'switch_model.balancing.load_zones',
-    'switch_model.balancing.operating_reserves.areas',
-    'switch_model.financials',
-    'switch_model.energy_sources.properties',
-    'switch_model.generators.core.build',
-    'switch_model.generators.core.dispatch',
-    'switch_model.generators.core.commit.operate',
-    'switch_model.balancing.operating_reserves.spinning_reserve',
+    "switch_model.timescales",
+    "switch_model.balancing.load_zones",
+    "switch_model.balancing.operating_reserves.areas",
+    "switch_model.financials",
+    "switch_model.energy_sources.properties",
+    "switch_model.generators.core.build",
+    "switch_model.generators.core.dispatch",
+    "switch_model.generators.core.commit.operate",
+    "switch_model.balancing.operating_reserves.spinning_reserve",
 )
 
 
@@ -31,21 +31,27 @@ def define_components(m):
     # TODO: supply these parameters in input files
 
     # regulating reserves required, as fraction of potential output (up to limit)
-    m.var_gen_power_reserve = Param(['Central_PV', 'CentralTrackingPV', 'DistPV', 'OnshoreWind', 'OffshoreWind'], initialize={
-        'Central_PV': 1.0,
-        'CentralTrackingPV': 1.0,
-        'DistPV': 1.0, # 0.81270193,
-        'OnshoreWind': 1.0,
-        'OffshoreWind': 1.0, # assumed equal to OnshoreWind
-    })
+    m.var_gen_power_reserve = Param(
+        ["Central_PV", "CentralTrackingPV", "DistPV", "OnshoreWind", "OffshoreWind"],
+        initialize={
+            "Central_PV": 1.0,
+            "CentralTrackingPV": 1.0,
+            "DistPV": 1.0,  # 0.81270193,
+            "OnshoreWind": 1.0,
+            "OffshoreWind": 1.0,  # assumed equal to OnshoreWind
+        },
+    )
     # maximum regulating reserves required, as fraction of installed capacity
-    m.var_gen_cap_reserve_limit = Param(['Central_PV', 'CentralTrackingPV', 'DistPV', 'OnshoreWind', 'OffshoreWind'], initialize={
-        'Central_PV': 0.21288916,
-        'CentralTrackingPV': 0.21288916,
-        'DistPV': 0.21288916, # 0.14153171,
-        'OnshoreWind': 0.21624407,
-        'OffshoreWind': 0.21624407, # assumed equal to OnshoreWind
-    })
+    m.var_gen_cap_reserve_limit = Param(
+        ["Central_PV", "CentralTrackingPV", "DistPV", "OnshoreWind", "OffshoreWind"],
+        initialize={
+            "Central_PV": 0.21288916,
+            "CentralTrackingPV": 0.21288916,
+            "DistPV": 0.21288916,  # 0.14153171,
+            "OnshoreWind": 0.21624407,
+            "OffshoreWind": 0.21624407,  # assumed equal to OnshoreWind
+        },
+    )
     # more conservative values (found by giving 10x weight to times when we provide less reserves than GE):
     # [1., 1., 1., 0.25760558, 0.18027923, 0.49123101]
 
@@ -54,23 +60,32 @@ def define_components(m):
         rule=lambda m, b, t: sum(
             m.ProjCapacityTP[g, t]
             * min(
-                m.var_gen_power_reserve[m.proj_gen_tech[g]] * m.proj_max_capacity_factor[g, t],
-                m.var_gen_cap_reserve_limit[m.proj_gen_tech[g]]
+                m.var_gen_power_reserve[m.proj_gen_tech[g]]
+                * m.proj_max_capacity_factor[g, t],
+                m.var_gen_cap_reserve_limit[m.proj_gen_tech[g]],
             )
             for g in m.VARIABLE_PROJECTS
-            if (g, t) in m.VAR_DISPATCH_POINTS and b == m.zone_balancing_area[m.proj_load_zone[g]]),
-        doc="The spinning reserves for backing up variable generation with Hawaii rules."
+            if (g, t) in m.VAR_DISPATCH_POINTS
+            and b == m.zone_balancing_area[m.proj_load_zone[g]]
+        ),
+        doc="The spinning reserves for backing up variable generation with Hawaii rules.",
     )
-    m.Spinning_Reserve_Up_Requirements.append('HawaiiVarGenUpSpinningReserveRequirement')
+    m.Spinning_Reserve_Up_Requirements.append(
+        "HawaiiVarGenUpSpinningReserveRequirement"
+    )
 
     def HawaiiLoadDownSpinningReserveRequirement_rule(m, b, t):
         try:
             load = m.WithdrawFromCentralGrid
         except AttributeError:
             load = m.lz_demand_mw
-        return 0.10 * sum(load[z, t] for z in m.LOAD_ZONES if b == m.zone_balancing_area[z])
+        return 0.10 * sum(
+            load[z, t] for z in m.LOAD_ZONES if b == m.zone_balancing_area[z]
+        )
+
     m.HawaiiLoadDownSpinningReserveRequirement = Expression(
-        m.BALANCING_AREA_TIMEPOINTS,
-        rule=HawaiiLoadDownSpinningReserveRequirement_rule
+        m.BALANCING_AREA_TIMEPOINTS, rule=HawaiiLoadDownSpinningReserveRequirement_rule
     )
-    m.Spinning_Reserve_Down_Requirements.append('HawaiiLoadDownSpinningReserveRequirement')
+    m.Spinning_Reserve_Down_Requirements.append(
+        "HawaiiLoadDownSpinningReserveRequirement"
+    )

--- a/switch_model/hawaii/hydrogen.py
+++ b/switch_model/hawaii/hydrogen.py
@@ -3,34 +3,56 @@ import os
 from pyomo.environ import *
 from switch_model.financials import capital_recovery_factor as crf
 
+
 def define_arguments(argparser):
-    argparser.add_argument('--hydrogen-reserve-types', nargs='+', default=['spinning'],
-        help=
-            "Type(s) of reserves to provide from hydrogen infrastructure (e.g., 'contingency regulation'). "
-            "Specify 'none' to disable."
+    argparser.add_argument(
+        "--hydrogen-reserve-types",
+        nargs="+",
+        default=["spinning"],
+        help="Type(s) of reserves to provide from hydrogen infrastructure (e.g., 'contingency regulation'). "
+        "Specify 'none' to disable.",
     )
-    argparser.add_argument('--no-hydrogen', action='store_true', default=False,
-        help="Don't allow construction of any hydrogen infrastructure."
+    argparser.add_argument(
+        "--no-hydrogen",
+        action="store_true",
+        default=False,
+        help="Don't allow construction of any hydrogen infrastructure.",
     )
+
 
 def define_components(m):
     if not m.options.no_hydrogen:
         define_hydrogen_components(m)
+
 
 def define_hydrogen_components(m):
 
     # electrolyzer details
     m.hydrogen_electrolyzer_capital_cost_per_mw = Param()
     m.hydrogen_electrolyzer_fixed_cost_per_mw_year = Param(default=0.0)
-    m.hydrogen_electrolyzer_variable_cost_per_kg = Param(default=0.0)  # assumed to include any refurbishment needed
-    m.hydrogen_electrolyzer_kg_per_mwh = Param() # assumed to deliver H2 at enough pressure for liquifier and daily buffering
+    m.hydrogen_electrolyzer_variable_cost_per_kg = Param(
+        default=0.0
+    )  # assumed to include any refurbishment needed
+    m.hydrogen_electrolyzer_kg_per_mwh = (
+        Param()
+    )  # assumed to deliver H2 at enough pressure for liquifier and daily buffering
     m.hydrogen_electrolyzer_life_years = Param()
     m.BuildElectrolyzerMW = Var(m.LOAD_ZONES, m.PERIODS, within=NonNegativeReals)
-    m.ElectrolyzerCapacityMW = Expression(m.LOAD_ZONES, m.PERIODS, rule=lambda m, z, p:
-        sum(m.BuildElectrolyzerMW[z, p_] for p_ in m.CURRENT_AND_PRIOR_PERIODS_FOR_PERIOD[p]))
+    m.ElectrolyzerCapacityMW = Expression(
+        m.LOAD_ZONES,
+        m.PERIODS,
+        rule=lambda m, z, p: sum(
+            m.BuildElectrolyzerMW[z, p_]
+            for p_ in m.CURRENT_AND_PRIOR_PERIODS_FOR_PERIOD[p]
+        ),
+    )
     m.RunElectrolyzerMW = Var(m.LOAD_ZONES, m.TIMEPOINTS, within=NonNegativeReals)
-    m.ProduceHydrogenKgPerHour = Expression(m.LOAD_ZONES, m.TIMEPOINTS, rule=lambda m, z, t:
-        m.RunElectrolyzerMW[z, t] * m.hydrogen_electrolyzer_kg_per_mwh)
+    m.ProduceHydrogenKgPerHour = Expression(
+        m.LOAD_ZONES,
+        m.TIMEPOINTS,
+        rule=lambda m, z, t: m.RunElectrolyzerMW[z, t]
+        * m.hydrogen_electrolyzer_kg_per_mwh,
+    )
 
     # note: we assume there is a gaseous hydrogen storage tank that is big enough to buffer
     # daily production, storage and withdrawals of hydrogen, but we don't include a cost
@@ -43,92 +65,144 @@ def define_hydrogen_components(m):
     m.hydrogen_liquifier_variable_cost_per_kg = Param(default=0.0)
     m.hydrogen_liquifier_mwh_per_kg = Param()
     m.hydrogen_liquifier_life_years = Param()
-    m.BuildLiquifierKgPerHour = Var(m.LOAD_ZONES, m.PERIODS, within=NonNegativeReals)  # capacity to build, measured in kg/hour of throughput
-    m.LiquifierCapacityKgPerHour = Expression(m.LOAD_ZONES, m.PERIODS, rule=lambda m, z, p:
-        sum(m.BuildLiquifierKgPerHour[z, p_] for p_ in m.CURRENT_AND_PRIOR_PERIODS_FOR_PERIOD[p]))
-    m.LiquifyHydrogenKgPerHour = Var(m.LOAD_ZONES, m.TIMEPOINTS, within=NonNegativeReals)
-    m.LiquifyHydrogenMW = Expression(m.LOAD_ZONES, m.TIMEPOINTS, rule=lambda m, z, t:
-        m.LiquifyHydrogenKgPerHour[z, t] * m.hydrogen_liquifier_mwh_per_kg
+    m.BuildLiquifierKgPerHour = Var(
+        m.LOAD_ZONES, m.PERIODS, within=NonNegativeReals
+    )  # capacity to build, measured in kg/hour of throughput
+    m.LiquifierCapacityKgPerHour = Expression(
+        m.LOAD_ZONES,
+        m.PERIODS,
+        rule=lambda m, z, p: sum(
+            m.BuildLiquifierKgPerHour[z, p_]
+            for p_ in m.CURRENT_AND_PRIOR_PERIODS_FOR_PERIOD[p]
+        ),
+    )
+    m.LiquifyHydrogenKgPerHour = Var(
+        m.LOAD_ZONES, m.TIMEPOINTS, within=NonNegativeReals
+    )
+    m.LiquifyHydrogenMW = Expression(
+        m.LOAD_ZONES,
+        m.TIMEPOINTS,
+        rule=lambda m, z, t: m.LiquifyHydrogenKgPerHour[z, t]
+        * m.hydrogen_liquifier_mwh_per_kg,
     )
 
     # storage tank details
     m.liquid_hydrogen_tank_capital_cost_per_kg = Param()
     m.liquid_hydrogen_tank_minimum_size_kg = Param(default=0.0)
     m.liquid_hydrogen_tank_life_years = Param()
-    m.BuildLiquidHydrogenTankKg = Var(m.LOAD_ZONES, m.PERIODS, within=NonNegativeReals) # in kg
-    m.LiquidHydrogenTankCapacityKg = Expression(m.LOAD_ZONES, m.PERIODS, rule=lambda m, z, p:
-        sum(m.BuildLiquidHydrogenTankKg[z, p_] for p_ in m.CURRENT_AND_PRIOR_PERIODS_FOR_PERIOD[p]))
-    m.StoreLiquidHydrogenKg = Expression(m.LOAD_ZONES, m.TIMESERIES, rule=lambda m, z, ts:
-        m.ts_duration_of_tp[ts] * sum(m.LiquifyHydrogenKgPerHour[z, tp] for tp in m.TPS_IN_TS[ts])
+    m.BuildLiquidHydrogenTankKg = Var(
+        m.LOAD_ZONES, m.PERIODS, within=NonNegativeReals
+    )  # in kg
+    m.LiquidHydrogenTankCapacityKg = Expression(
+        m.LOAD_ZONES,
+        m.PERIODS,
+        rule=lambda m, z, p: sum(
+            m.BuildLiquidHydrogenTankKg[z, p_]
+            for p_ in m.CURRENT_AND_PRIOR_PERIODS_FOR_PERIOD[p]
+        ),
     )
-    m.WithdrawLiquidHydrogenKg = Var(m.LOAD_ZONES, m.TIMESERIES, within=NonNegativeReals)
+    m.StoreLiquidHydrogenKg = Expression(
+        m.LOAD_ZONES,
+        m.TIMESERIES,
+        rule=lambda m, z, ts: m.ts_duration_of_tp[ts]
+        * sum(m.LiquifyHydrogenKgPerHour[z, tp] for tp in m.TPS_IN_TS[ts]),
+    )
+    m.WithdrawLiquidHydrogenKg = Var(
+        m.LOAD_ZONES, m.TIMESERIES, within=NonNegativeReals
+    )
     # note: we assume the system will be large enough to neglect boil-off
 
     # fuel cell details
     m.hydrogen_fuel_cell_capital_cost_per_mw = Param()
     m.hydrogen_fuel_cell_fixed_cost_per_mw_year = Param(default=0.0)
-    m.hydrogen_fuel_cell_variable_cost_per_mwh = Param(default=0.0) # assumed to include any refurbishment needed
+    m.hydrogen_fuel_cell_variable_cost_per_mwh = Param(
+        default=0.0
+    )  # assumed to include any refurbishment needed
     m.hydrogen_fuel_cell_mwh_per_kg = Param()
     m.hydrogen_fuel_cell_life_years = Param()
     m.BuildFuelCellMW = Var(m.LOAD_ZONES, m.PERIODS, within=NonNegativeReals)
-    m.FuelCellCapacityMW = Expression(m.LOAD_ZONES, m.PERIODS, rule=lambda m, z, p:
-        sum(m.BuildFuelCellMW[z, p_] for p_ in m.CURRENT_AND_PRIOR_PERIODS_FOR_PERIOD[p]))
+    m.FuelCellCapacityMW = Expression(
+        m.LOAD_ZONES,
+        m.PERIODS,
+        rule=lambda m, z, p: sum(
+            m.BuildFuelCellMW[z, p_] for p_ in m.CURRENT_AND_PRIOR_PERIODS_FOR_PERIOD[p]
+        ),
+    )
     m.DispatchFuelCellMW = Var(m.LOAD_ZONES, m.TIMEPOINTS, within=NonNegativeReals)
-    m.ConsumeHydrogenKgPerHour = Expression(m.LOAD_ZONES, m.TIMEPOINTS, rule=lambda m, z, t:
-        m.DispatchFuelCellMW[z, t] / m.hydrogen_fuel_cell_mwh_per_kg
+    m.ConsumeHydrogenKgPerHour = Expression(
+        m.LOAD_ZONES,
+        m.TIMEPOINTS,
+        rule=lambda m, z, t: m.DispatchFuelCellMW[z, t]
+        / m.hydrogen_fuel_cell_mwh_per_kg,
     )
 
     # hydrogen mass balances
     # note: this allows for buffering of same-day production and consumption
     # of hydrogen without ever liquifying it
-    m.Hydrogen_Conservation_of_Mass_Daily = Constraint(m.LOAD_ZONES, m.TIMESERIES, rule=lambda m, z, ts:
-        m.StoreLiquidHydrogenKg[z, ts] - m.WithdrawLiquidHydrogenKg[z, ts]
-        ==
-        m.ts_duration_of_tp[ts] * sum(
+    m.Hydrogen_Conservation_of_Mass_Daily = Constraint(
+        m.LOAD_ZONES,
+        m.TIMESERIES,
+        rule=lambda m, z, ts: m.StoreLiquidHydrogenKg[z, ts]
+        - m.WithdrawLiquidHydrogenKg[z, ts]
+        == m.ts_duration_of_tp[ts]
+        * sum(
             m.ProduceHydrogenKgPerHour[z, tp] - m.ConsumeHydrogenKgPerHour[z, tp]
             for tp in m.TPS_IN_TS[ts]
-        )
+        ),
     )
-    m.Hydrogen_Conservation_of_Mass_Annual = Constraint(m.LOAD_ZONES, m.PERIODS, rule=lambda m, z, p:
-        sum(
+    m.Hydrogen_Conservation_of_Mass_Annual = Constraint(
+        m.LOAD_ZONES,
+        m.PERIODS,
+        rule=lambda m, z, p: sum(
             (m.StoreLiquidHydrogenKg[z, ts] - m.WithdrawLiquidHydrogenKg[z, ts])
-                * m.ts_scale_to_year[ts]
+            * m.ts_scale_to_year[ts]
             for ts in m.TS_IN_PERIOD[p]
-        ) == 0
+        )
+        == 0,
     )
 
     # limits on equipment
-    m.Max_Run_Electrolyzer = Constraint(m.LOAD_ZONES, m.TIMEPOINTS, rule=lambda m, z, t:
-        m.RunElectrolyzerMW[z, t] <= m.ElectrolyzerCapacityMW[z, m.tp_period[t]])
-    m.Max_Run_Fuel_Cell = Constraint(m.LOAD_ZONES, m.TIMEPOINTS, rule=lambda m, z, t:
-        m.DispatchFuelCellMW[z, t] <= m.FuelCellCapacityMW[z, m.tp_period[t]])
-    m.Max_Run_Liquifier = Constraint(m.LOAD_ZONES, m.TIMEPOINTS, rule=lambda m, z, t:
-        m.LiquifyHydrogenKgPerHour[z, t] <= m.LiquifierCapacityKgPerHour[z, m.tp_period[t]])
+    m.Max_Run_Electrolyzer = Constraint(
+        m.LOAD_ZONES,
+        m.TIMEPOINTS,
+        rule=lambda m, z, t: m.RunElectrolyzerMW[z, t]
+        <= m.ElectrolyzerCapacityMW[z, m.tp_period[t]],
+    )
+    m.Max_Run_Fuel_Cell = Constraint(
+        m.LOAD_ZONES,
+        m.TIMEPOINTS,
+        rule=lambda m, z, t: m.DispatchFuelCellMW[z, t]
+        <= m.FuelCellCapacityMW[z, m.tp_period[t]],
+    )
+    m.Max_Run_Liquifier = Constraint(
+        m.LOAD_ZONES,
+        m.TIMEPOINTS,
+        rule=lambda m, z, t: m.LiquifyHydrogenKgPerHour[z, t]
+        <= m.LiquifierCapacityKgPerHour[z, m.tp_period[t]],
+    )
 
     # Enforce minimum size for hydrogen tank if specified. We only define these
     # variables and constraints if needed, to avoid warnings about variables
     # with no values assigned.
     def action(m):
         if m.liquid_hydrogen_tank_minimum_size_kg != 0.0:
-            m.BuildAnyLiquidHydrogenTank = Var(
-                m.LOAD_ZONES, m.PERIODS, within=Binary
-            )
+            m.BuildAnyLiquidHydrogenTank = Var(m.LOAD_ZONES, m.PERIODS, within=Binary)
             m.Set_BuildAnyLiquidHydrogenTank_Flag = Constraint(
-                m.LOAD_ZONES, m.PERIODS,
-                rule=lambda m, z, p:
-                    m.BuildLiquidHydrogenTankKg[z, p]
-                    <=
-                    1000 * m.BuildAnyLiquidHydrogenTank[z, p]
-                    * m.liquid_hydrogen_tank_minimum_size_kg
+                m.LOAD_ZONES,
+                m.PERIODS,
+                rule=lambda m, z, p: m.BuildLiquidHydrogenTankKg[z, p]
+                <= 1000
+                * m.BuildAnyLiquidHydrogenTank[z, p]
+                * m.liquid_hydrogen_tank_minimum_size_kg,
             )
             m.Build_Minimum_Liquid_Hydrogen_Tank = Constraint(
-                m.LOAD_ZONES, m.PERIODS,
-                rule=lambda m, z, p:
-                    m.BuildLiquidHydrogenTankKg[z, p]
-                    >=
-                    m.BuildAnyLiquidHydrogenTank[z, p]
-                    * m.liquid_hydrogen_tank_minimum_size_kg
+                m.LOAD_ZONES,
+                m.PERIODS,
+                rule=lambda m, z, p: m.BuildLiquidHydrogenTankKg[z, p]
+                >= m.BuildAnyLiquidHydrogenTank[z, p]
+                * m.liquid_hydrogen_tank_minimum_size_kg,
             )
+
     m.Apply_liquid_hydrogen_tank_minimum_size = BuildAction(rule=action)
 
     # maximum amount that hydrogen fuel cells can contribute to system reserves
@@ -136,92 +210,125 @@ def define_hydrogen_components(m):
     # as much electrolyzer capacity and a tank that can provide the reserves for 12 hours
     # (this is pretty arbitrary, but avoids just installing a fuel cell as a "free" source of reserves)
     m.HydrogenFuelCellMaxReservePower = Var(m.LOAD_ZONES, m.TIMEPOINTS)
-    m.Hydrogen_FC_Reserve_Capacity_Limit = Constraint(m.LOAD_ZONES, m.TIMEPOINTS, rule=lambda m, z, t:
-        m.HydrogenFuelCellMaxReservePower[z, t]
-        <=
-        m.FuelCellCapacityMW[z, m.tp_period[t]]
+    m.Hydrogen_FC_Reserve_Capacity_Limit = Constraint(
+        m.LOAD_ZONES,
+        m.TIMEPOINTS,
+        rule=lambda m, z, t: m.HydrogenFuelCellMaxReservePower[z, t]
+        <= m.FuelCellCapacityMW[z, m.tp_period[t]],
     )
-    m.Hydrogen_FC_Reserve_Storage_Limit = Constraint(m.LOAD_ZONES, m.TIMEPOINTS, rule=lambda m, z, t:
-        m.HydrogenFuelCellMaxReservePower[z, t]
-        <=
-        m.LiquidHydrogenTankCapacityKg[z, m.tp_period[t]] * m.hydrogen_fuel_cell_mwh_per_kg / 12.0
+    m.Hydrogen_FC_Reserve_Storage_Limit = Constraint(
+        m.LOAD_ZONES,
+        m.TIMEPOINTS,
+        rule=lambda m, z, t: m.HydrogenFuelCellMaxReservePower[z, t]
+        <= m.LiquidHydrogenTankCapacityKg[z, m.tp_period[t]]
+        * m.hydrogen_fuel_cell_mwh_per_kg
+        / 12.0,
     )
-    m.Hydrogen_FC_Reserve_Electrolyzer_Limit = Constraint(m.LOAD_ZONES, m.TIMEPOINTS, rule=lambda m, z, t:
-        m.HydrogenFuelCellMaxReservePower[z, t]
-        <=
-        2.0 * m.ElectrolyzerCapacityMW[z, m.tp_period[t]]
+    m.Hydrogen_FC_Reserve_Electrolyzer_Limit = Constraint(
+        m.LOAD_ZONES,
+        m.TIMEPOINTS,
+        rule=lambda m, z, t: m.HydrogenFuelCellMaxReservePower[z, t]
+        <= 2.0 * m.ElectrolyzerCapacityMW[z, m.tp_period[t]],
     )
 
     # how much extra power could hydrogen equipment produce or absorb on short notice (for reserves)
-    m.HydrogenSlackUp = Expression(m.LOAD_ZONES, m.TIMEPOINTS, rule=lambda m, z, t:
-        m.RunElectrolyzerMW[z, t]
+    m.HydrogenSlackUp = Expression(
+        m.LOAD_ZONES,
+        m.TIMEPOINTS,
+        rule=lambda m, z, t: m.RunElectrolyzerMW[z, t]
         + m.LiquifyHydrogenMW[z, t]
         + m.HydrogenFuelCellMaxReservePower[z, t]
-        - m.DispatchFuelCellMW[z, t]
+        - m.DispatchFuelCellMW[z, t],
     )
-    m.HydrogenSlackDown = Expression(m.LOAD_ZONES, m.TIMEPOINTS, rule=lambda m, z, t:
-        m.ElectrolyzerCapacityMW[z, m.tp_period[t]] - m.RunElectrolyzerMW[z, t]
+    m.HydrogenSlackDown = Expression(
+        m.LOAD_ZONES,
+        m.TIMEPOINTS,
+        rule=lambda m, z, t: m.ElectrolyzerCapacityMW[z, m.tp_period[t]]
+        - m.RunElectrolyzerMW[z, t]
         # ignore liquifier potential since it's small and this is a low-value reserve product
-        + m.DispatchFuelCellMW[z, t]
+        + m.DispatchFuelCellMW[z, t],
     )
 
     # there must be enough storage to hold _all_ the production each period (net of same-day consumption)
     # note: this assumes we cycle the system only once per year (store all energy, then release all energy)
     # alternatives: allow monthly or seasonal cycling, or directly model the whole year with inter-day linkages
-    m.Max_Store_Liquid_Hydrogen = Constraint(m.LOAD_ZONES, m.PERIODS, rule=lambda m, z, p:
-        sum(m.StoreLiquidHydrogenKg[z, ts] * m.ts_scale_to_year[ts] for ts in m.TS_IN_PERIOD[p])
-        <= m.LiquidHydrogenTankCapacityKg[z, p]
+    m.Max_Store_Liquid_Hydrogen = Constraint(
+        m.LOAD_ZONES,
+        m.PERIODS,
+        rule=lambda m, z, p: sum(
+            m.StoreLiquidHydrogenKg[z, ts] * m.ts_scale_to_year[ts]
+            for ts in m.TS_IN_PERIOD[p]
+        )
+        <= m.LiquidHydrogenTankCapacityKg[z, p],
     )
 
     # add electricity consumption and production to the zonal energy balance
-    m.Zone_Power_Withdrawals.append('RunElectrolyzerMW')
-    m.Zone_Power_Withdrawals.append('LiquifyHydrogenMW')
-    m.Zone_Power_Injections.append('DispatchFuelCellMW')
+    m.Zone_Power_Withdrawals.append("RunElectrolyzerMW")
+    m.Zone_Power_Withdrawals.append("LiquifyHydrogenMW")
+    m.Zone_Power_Injections.append("DispatchFuelCellMW")
 
     # add costs to the model
-    m.HydrogenVariableCost = Expression(m.TIMEPOINTS, rule=lambda m, t:
-        sum(
-            m.ProduceHydrogenKgPerHour[z, t] * m.hydrogen_electrolyzer_variable_cost_per_kg
-            + m.LiquifyHydrogenKgPerHour[z, t] * m.hydrogen_liquifier_variable_cost_per_kg
+    m.HydrogenVariableCost = Expression(
+        m.TIMEPOINTS,
+        rule=lambda m, t: sum(
+            m.ProduceHydrogenKgPerHour[z, t]
+            * m.hydrogen_electrolyzer_variable_cost_per_kg
+            + m.LiquifyHydrogenKgPerHour[z, t]
+            * m.hydrogen_liquifier_variable_cost_per_kg
             + m.DispatchFuelCellMW[z, t] * m.hydrogen_fuel_cell_variable_cost_per_mwh
             for z in m.LOAD_ZONES
-        )
+        ),
     )
-    m.HydrogenFixedCostAnnual = Expression(m.PERIODS, rule=lambda m, p:
-        sum(
-            m.ElectrolyzerCapacityMW[z, p] * (
-                m.hydrogen_electrolyzer_capital_cost_per_mw * crf(m.interest_rate, m.hydrogen_electrolyzer_life_years)
-                + m.hydrogen_electrolyzer_fixed_cost_per_mw_year)
-            + m.LiquifierCapacityKgPerHour[z, p] * (
-                m.hydrogen_liquifier_capital_cost_per_kg_per_hour * crf(m.interest_rate, m.hydrogen_liquifier_life_years)
-                + m.hydrogen_liquifier_fixed_cost_per_kg_hour_year)
-            + m.LiquidHydrogenTankCapacityKg[z, p] * (
-                m.liquid_hydrogen_tank_capital_cost_per_kg * crf(m.interest_rate, m.liquid_hydrogen_tank_life_years))
-            + m.FuelCellCapacityMW[z, p] * (
-                m.hydrogen_fuel_cell_capital_cost_per_mw * crf(m.interest_rate, m.hydrogen_fuel_cell_life_years)
-                + m.hydrogen_fuel_cell_fixed_cost_per_mw_year)
+    m.HydrogenFixedCostAnnual = Expression(
+        m.PERIODS,
+        rule=lambda m, p: sum(
+            m.ElectrolyzerCapacityMW[z, p]
+            * (
+                m.hydrogen_electrolyzer_capital_cost_per_mw
+                * crf(m.interest_rate, m.hydrogen_electrolyzer_life_years)
+                + m.hydrogen_electrolyzer_fixed_cost_per_mw_year
+            )
+            + m.LiquifierCapacityKgPerHour[z, p]
+            * (
+                m.hydrogen_liquifier_capital_cost_per_kg_per_hour
+                * crf(m.interest_rate, m.hydrogen_liquifier_life_years)
+                + m.hydrogen_liquifier_fixed_cost_per_kg_hour_year
+            )
+            + m.LiquidHydrogenTankCapacityKg[z, p]
+            * (
+                m.liquid_hydrogen_tank_capital_cost_per_kg
+                * crf(m.interest_rate, m.liquid_hydrogen_tank_life_years)
+            )
+            + m.FuelCellCapacityMW[z, p]
+            * (
+                m.hydrogen_fuel_cell_capital_cost_per_mw
+                * crf(m.interest_rate, m.hydrogen_fuel_cell_life_years)
+                + m.hydrogen_fuel_cell_fixed_cost_per_mw_year
+            )
             for z in m.LOAD_ZONES
-        )
+        ),
     )
-    m.Cost_Components_Per_TP.append('HydrogenVariableCost')
-    m.Cost_Components_Per_Period.append('HydrogenFixedCostAnnual')
+    m.Cost_Components_Per_TP.append("HydrogenVariableCost")
+    m.Cost_Components_Per_Period.append("HydrogenFixedCostAnnual")
 
     # Register with spinning reserves if it is available
-    if [rt.lower() for rt in m.options.hydrogen_reserve_types] != ['none']:
+    if [rt.lower() for rt in m.options.hydrogen_reserve_types] != ["none"]:
         # Register with spinning reserves
-        if hasattr(m, 'Spinning_Reserve_Up_Provisions'):
+        if hasattr(m, "Spinning_Reserve_Up_Provisions"):
             # calculate available slack from hydrogen equipment
             m.HydrogenSlackUpForArea = Expression(
                 m.BALANCING_AREA_TIMEPOINTS,
-                rule=lambda m, b, t:
-                    sum(m.HydrogenSlackUp[z, t] for z in m.ZONES_IN_BALANCING_AREA[b])
+                rule=lambda m, b, t: sum(
+                    m.HydrogenSlackUp[z, t] for z in m.ZONES_IN_BALANCING_AREA[b]
+                ),
             )
             m.HydrogenSlackDownForArea = Expression(
                 m.BALANCING_AREA_TIMEPOINTS,
-                rule=lambda m, b, t:
-                    sum(m.HydrogenSlackDown[z, t] for z in m.ZONES_IN_BALANCING_AREA[b])
+                rule=lambda m, b, t: sum(
+                    m.HydrogenSlackDown[z, t] for z in m.ZONES_IN_BALANCING_AREA[b]
+                ),
             )
-            if hasattr(m, 'GEN_SPINNING_RESERVE_TYPES'):
+            if hasattr(m, "GEN_SPINNING_RESERVE_TYPES"):
                 # using advanced formulation, index by reserve type, balancing area, timepoint
                 # define variables for each type of reserves to be provided
                 # choose how to allocate the slack between the different reserve products
@@ -229,40 +336,42 @@ def define_hydrogen_components(m):
                     initialize=m.options.hydrogen_reserve_types
                 )
                 m.HydrogenSpinningReserveUp = Var(
-                    m.HYDROGEN_SPINNING_RESERVE_TYPES, m.BALANCING_AREA_TIMEPOINTS,
-                    within=NonNegativeReals
+                    m.HYDROGEN_SPINNING_RESERVE_TYPES,
+                    m.BALANCING_AREA_TIMEPOINTS,
+                    within=NonNegativeReals,
                 )
                 m.HydrogenSpinningReserveDown = Var(
-                    m.HYDROGEN_SPINNING_RESERVE_TYPES, m.BALANCING_AREA_TIMEPOINTS,
-                    within=NonNegativeReals
+                    m.HYDROGEN_SPINNING_RESERVE_TYPES,
+                    m.BALANCING_AREA_TIMEPOINTS,
+                    within=NonNegativeReals,
                 )
                 # constrain reserve provision within available slack
                 m.Limit_HydrogenSpinningReserveUp = Constraint(
                     m.BALANCING_AREA_TIMEPOINTS,
-                    rule=lambda m, ba, tp:
-                        sum(
-                            m.HydrogenSpinningReserveUp[rt, ba, tp]
-                            for rt in m.HYDROGEN_SPINNING_RESERVE_TYPES
-                        ) <= m.HydrogenSlackUpForArea[ba, tp]
+                    rule=lambda m, ba, tp: sum(
+                        m.HydrogenSpinningReserveUp[rt, ba, tp]
+                        for rt in m.HYDROGEN_SPINNING_RESERVE_TYPES
+                    )
+                    <= m.HydrogenSlackUpForArea[ba, tp],
                 )
                 m.Limit_HydrogenSpinningReserveDown = Constraint(
                     m.BALANCING_AREA_TIMEPOINTS,
-                    rule=lambda m, ba, tp:
-                        sum(
-                            m.HydrogenSpinningReserveDown[rt, ba, tp]
-                            for rt in m.HYDROGEN_SPINNING_RESERVE_TYPES
-                        ) <= m.HydrogenSlackDownForArea[ba, tp]
+                    rule=lambda m, ba, tp: sum(
+                        m.HydrogenSpinningReserveDown[rt, ba, tp]
+                        for rt in m.HYDROGEN_SPINNING_RESERVE_TYPES
+                    )
+                    <= m.HydrogenSlackDownForArea[ba, tp],
                 )
-                m.Spinning_Reserve_Up_Provisions.append('HydrogenSpinningReserveUp')
-                m.Spinning_Reserve_Down_Provisions.append('HydrogenSpinningReserveDown')
+                m.Spinning_Reserve_Up_Provisions.append("HydrogenSpinningReserveUp")
+                m.Spinning_Reserve_Down_Provisions.append("HydrogenSpinningReserveDown")
             else:
                 # using older formulation, only one type of spinning reserves, indexed by balancing area, timepoint
-                if m.options.hydrogen_reserve_types != ['spinning']:
+                if m.options.hydrogen_reserve_types != ["spinning"]:
                     raise ValueError(
                         'Unable to use reserve types other than "spinning" with simple spinning reserves module.'
                     )
-                m.Spinning_Reserve_Up_Provisions.append('HydrogenSlackUpForArea')
-                m.Spinning_Reserve_Down_Provisions.append('HydrogenSlackDownForArea')
+                m.Spinning_Reserve_Up_Provisions.append("HydrogenSlackUpForArea")
+                m.Spinning_Reserve_Down_Provisions.append("HydrogenSlackDownForArea")
 
 
 def load_inputs(m, switch_data, inputs_dir):
@@ -272,7 +381,7 @@ def load_inputs(m, switch_data, inputs_dir):
     """
     if not m.options.no_hydrogen:
         switch_data.load_aug(
-            filename=os.path.join(inputs_dir, 'hydrogen.csv'),
+            filename=os.path.join(inputs_dir, "hydrogen.csv"),
             optional=False,
             param=(
                 m.hydrogen_electrolyzer_capital_cost_per_mw,
@@ -293,5 +402,5 @@ def load_inputs(m, switch_data, inputs_dir):
                 m.liquid_hydrogen_tank_capital_cost_per_kg,
                 m.liquid_hydrogen_tank_life_years,
                 m.liquid_hydrogen_tank_minimum_size_kg,
-            )
+            ),
         )

--- a/switch_model/hawaii/lake_wilson.py
+++ b/switch_model/hawaii/lake_wilson.py
@@ -5,23 +5,31 @@ for net inflow.
 from __future__ import division
 from pyomo.environ import *
 
+
 def define_components(m):
     def rule(m):
-        g = 'Oahu_Lake_Wilson'
+        g = "Oahu_Lake_Wilson"
         inflow = 10.0
         if g in m.GENERATION_PROJECTS:
             for t in m.TPS_FOR_GEN[g]:
                 # assign new energy balance with extra inflow, and allow spilling
                 m.Track_State_Of_Charge[g, t] = (
                     m.StateOfCharge[g, t]
-                    <=
-                    m.StateOfCharge[g, m.tp_previous[t]]
-                    + (m.ChargeStorage[g, t] * m.gen_storage_efficiency[g]
-                    - m.DispatchGen[g, t]) * m.tp_duration_hrs[t]
+                    <= m.StateOfCharge[g, m.tp_previous[t]]
+                    + (
+                        m.ChargeStorage[g, t] * m.gen_storage_efficiency[g]
+                        - m.DispatchGen[g, t]
+                    )
+                    * m.tp_duration_hrs[t]
                     # allow inflow only if capacity is built
-                    + inflow * m.tp_duration_hrs * m.GenCapacityInTP[g] / m.gen_unit_size[g]
+                    + inflow
+                    * m.tp_duration_hrs
+                    * m.GenCapacityInTP[g]
+                    / m.gen_unit_size[g]
                 )
+
     m.Add_Lake_Wilson_Inflow = BuildAction(rule=rule)
+
 
 # TODO: don't allow zero crossing when calculating reserves available
 # see http://www.ucdenver.edu/faculty-staff/dmays/3414/Documents/Antal-MS-2014.pdf

--- a/switch_model/hawaii/lng_conversion.py
+++ b/switch_model/hawaii/lng_conversion.py
@@ -11,9 +11,15 @@ from __future__ import print_function
 from pyomo.environ import *
 from switch_model.financials import capital_recovery_factor
 
+
 def define_arguments(argparser):
-    argparser.add_argument('--force-lng-tier', nargs='*', default=None,
-        help="LNG tier to use: tier [start [stop]] or 'none' to use no LNG. Optimal choices will be made if nothing specified.")
+    argparser.add_argument(
+        "--force-lng-tier",
+        nargs="*",
+        default=None,
+        help="LNG tier to use: tier [start [stop]] or 'none' to use no LNG. Optimal choices will be made if nothing specified.",
+    )
+
 
 def define_components(m):
 
@@ -26,7 +32,7 @@ def define_components(m):
 
     m.LNG_RFM_SUPPLY_TIERS = Set(
         initialize=m.RFM_SUPPLY_TIERS,
-        filter=lambda m, rfm, per, tier: m.rfm_fuel[rfm].upper() == 'LNG'
+        filter=lambda m, rfm, per, tier: m.rfm_fuel[rfm].upper() == "LNG",
     )
     m.LNG_REGIONAL_FUEL_MARKETS = Set(
         initialize=lambda m: {rfm for rfm, per, tier in m.LNG_RFM_SUPPLY_TIERS}
@@ -38,12 +44,14 @@ def define_components(m):
     # force LNG to be deactivated when RPS is 100%;
     # this forces recovery of all costs before the 100% RPS takes effect
     # (otherwise the model sometimes tries to postpone recovery beyond the end of the study)
-    if hasattr(m, 'RPS_Enforce'):
-        m.No_LNG_In_100_RPS = Constraint(m.LNG_RFM_SUPPLY_TIERS,
-            rule=lambda m, rfm, per, tier:
-                (m.RFMSupplyTierActivate[rfm, per, tier] == 0)
-                    if m.rps_target_for_period[per] >= 1.0
-                        else Constraint.Skip
+    if hasattr(m, "RPS_Enforce"):
+        m.No_LNG_In_100_RPS = Constraint(
+            m.LNG_RFM_SUPPLY_TIERS,
+            rule=lambda m, rfm, per, tier: (
+                m.RFMSupplyTierActivate[rfm, per, tier] == 0
+            )
+            if m.rps_target_for_period[per] >= 1.0
+            else Constraint.Skip,
         )
 
     # user can study different LNG durations by specifying a tier to activate and
@@ -78,13 +86,23 @@ def define_components(m):
             # user specified a tier to activate and possibly a date range
             # force that active and deactivate all others.
             force_tier = m.options.force_lng_tier[0]
-            force_tier_start = float(m.options.force_lng_tier[1]) if len(m.options.force_lng_tier) > 1 else m.PERIODS.first()
-            force_tier_end = float(m.options.force_lng_tier[2]) if len(m.options.force_lng_tier) > 2 else m.PERIODS.last()
-            if force_tier.lower() == 'none':
+            force_tier_start = (
+                float(m.options.force_lng_tier[1])
+                if len(m.options.force_lng_tier) > 1
+                else m.PERIODS.first()
+            )
+            force_tier_end = (
+                float(m.options.force_lng_tier[2])
+                if len(m.options.force_lng_tier) > 2
+                else m.PERIODS.last()
+            )
+            if force_tier.lower() == "none":
                 action = 0
             elif force_tier not in m.LNG_TIERS:
                 raise ValueError(
-                    "--force-lng-tier argument '{}' does not match any LNG market tier.".format(force_tier)
+                    "--force-lng-tier argument '{}' does not match any LNG market tier.".format(
+                        force_tier
+                    )
                 )
             elif tier == force_tier and force_tier_start <= per <= force_tier_end:
                 # force tier on
@@ -98,16 +116,25 @@ def define_components(m):
             result = action
         else:
             if m.options.verbose:
-                print("{} activation of tier {}.".format('Forcing' if action else 'Blocking', (rfm, per, tier)))
-            result = (m.RFMSupplyTierActivate[rfm, per, tier] == action)
+                print(
+                    "{} activation of tier {}.".format(
+                        "Forcing" if action else "Blocking", (rfm, per, tier)
+                    )
+                )
+            result = m.RFMSupplyTierActivate[rfm, per, tier] == action
         return result
+
     m.Force_LNG_Tier = Constraint(m.LNG_RFM_SUPPLY_TIERS, rule=Force_LNG_Tier_rule)
 
-
     # list of all projects and timepoints when LNG could potentially be used
-    m.LNG_GEN_TIMEPOINTS = Set(dimen=2, initialize = lambda m:
-        ((p, t) for p in m.GENS_BY_FUEL['LNG'] for t in m.TIMEPOINTS
-            if (p, t) in m.GEN_TPS)
+    m.LNG_GEN_TIMEPOINTS = Set(
+        dimen=2,
+        initialize=lambda m: (
+            (p, t)
+            for p in m.GENS_BY_FUEL["LNG"]
+            for t in m.TIMEPOINTS
+            if (p, t) in m.GEN_TPS
+        ),
     )
 
     # HECO PSIP 2016-04 has only Kahe 5, Kahe 6, Kalaeloa and CC_383 burning LNG,
@@ -120,16 +147,22 @@ def define_components(m):
     # are included in the LNG supply tiers, so we don't need to worry about that.
     m.LNG_CONVERTED_PLANTS = Set(
         initialize=[
-            'Oahu_Kahe_K5', 'Oahu_Kahe_K6',
-            'Oahu_Kalaeloa_CC1_CC2', # used in some older models
-            'Oahu_Kalaeloa_CC1', 'Oahu_Kalaeloa_CC2', 'Oahu_Kalaeloa_CC3',
-            'Oahu_CC_383', 'Oahu_CC_152', 'Oahu_CT_100'
+            "Oahu_Kahe_K5",
+            "Oahu_Kahe_K6",
+            "Oahu_Kalaeloa_CC1_CC2",  # used in some older models
+            "Oahu_Kalaeloa_CC1",
+            "Oahu_Kalaeloa_CC2",
+            "Oahu_Kalaeloa_CC3",
+            "Oahu_CC_383",
+            "Oahu_CC_152",
+            "Oahu_CT_100",
         ]
     )
-    m.LNG_In_Converted_Plants_Only = Constraint(m.LNG_GEN_TIMEPOINTS,
-        rule=lambda m, g, tp:
-            Constraint.Skip if g in m.LNG_CONVERTED_PLANTS
-            else (m.GenFuelUseRate[g, tp, 'LNG'] == 0)
+    m.LNG_In_Converted_Plants_Only = Constraint(
+        m.LNG_GEN_TIMEPOINTS,
+        rule=lambda m, g, tp: Constraint.Skip
+        if g in m.LNG_CONVERTED_PLANTS
+        else (m.GenFuelUseRate[g, tp, "LNG"] == 0),
     )
 
     # CODE BELOW IS DISABLED because we have abandoned the 'container' tier which cost

--- a/switch_model/hawaii/no_central_pv.py
+++ b/switch_model/hawaii/no_central_pv.py
@@ -1,17 +1,18 @@
 from pyomo.environ import *
 
+
 def define_components(m):
     """
     prevent construction of any new central PV projects
     """
 
     # TODO: put these in a data file and share them between rps.py and no_renewables.py
-    renewable_energy_technologies = ['CentralPV', 'CentralTrackingPV']
+    renewable_energy_technologies = ["CentralPV", "CentralTrackingPV"]
 
     def No_CentralPV_rule(m, g, bld_yr):
         if m.gen_tech[g] in renewable_energy_technologies:
             return m.BuildGen[g, bld_yr] == 0
         else:
             return Constraint.Skip
-    m.No_CentralPV = Constraint(m.NEW_GEN_BLD_YRS, rule=No_CentralPV_rule)
 
+    m.No_CentralPV = Constraint(m.NEW_GEN_BLD_YRS, rule=No_CentralPV_rule)

--- a/switch_model/hawaii/no_onshore_wind.py
+++ b/switch_model/hawaii/no_onshore_wind.py
@@ -1,13 +1,15 @@
 from pyomo.environ import *
 
+
 def define_components(m):
     """
     prevent construction of new onshore wind projects
     """
+
     def No_Onshore_Wind_rule(m, g, bld_yr):
-        if m.gen_tech[g] == 'OnshoreWind':
+        if m.gen_tech[g] == "OnshoreWind":
             return m.BuildGen[g, bld_yr] == 0
         else:
             return Constraint.Skip
-    m.No_Onshore_Wind = Constraint(m.NEW_GEN_BLD_YRS, rule=No_Onshore_Wind_rule)
 
+    m.No_Onshore_Wind = Constraint(m.NEW_GEN_BLD_YRS, rule=No_Onshore_Wind_rule)

--- a/switch_model/hawaii/no_renewables.py
+++ b/switch_model/hawaii/no_renewables.py
@@ -5,20 +5,18 @@ import switch_model.utilities as utilities
 
 
 def define_components(m):
-    """
-
-    """
+    """"""
     ###################
     # prevent construction of any new renewable projects (useful for "business as usual" baseline)
     ##################
 
     # TODO: put these in a data file and share them between rps.py and no_renewables.py
-    renewable_energy_sources = ['WND', 'SUN', 'Biocrude', 'Biodiesel', 'MLG']
+    renewable_energy_sources = ["WND", "SUN", "Biocrude", "Biodiesel", "MLG"]
 
     def No_Renewables_rule(m, g, bld_yr):
         if m.g_energy_source[m.gen_tech[g]] in renewable_energy_sources:
             return m.BuildGen[g, bld_yr] == 0
         else:
             return Constraint.Skip
-    m.No_Renewables = Constraint(m.NEW_GEN_BLD_YRS, rule=No_Renewables_rule)
 
+    m.No_Renewables = Constraint(m.NEW_GEN_BLD_YRS, rule=No_Renewables_rule)

--- a/switch_model/hawaii/no_wind.py
+++ b/switch_model/hawaii/no_wind.py
@@ -10,12 +10,12 @@ def define_components(m):
     """
 
     # TODO: put these in a data file and share them between rps.py and no_renewables.py
-    renewable_energy_sources = ['WND']
+    renewable_energy_sources = ["WND"]
 
     def No_Wind_rule(m, g, bld_yr):
         if m.g_energy_source[m.gen_tech[g]] in renewable_energy_sources:
             return m.BuildGen[g, bld_yr] == 0
         else:
             return Constraint.Skip
-    m.No_Wind = Constraint(m.NEW_GEN_BLD_YRS, rule=No_Wind_rule)
 
+    m.No_Wind = Constraint(m.NEW_GEN_BLD_YRS, rule=No_Wind_rule)

--- a/switch_model/hawaii/oahu_plants.py
+++ b/switch_model/hawaii/oahu_plants.py
@@ -3,16 +3,23 @@
 import os
 from pyomo.environ import *
 
+
 def define_arguments(argparser):
-    argparser.add_argument("--run-kalaeloa-even-with-high-rps", action='store_true', default=False,
+    argparser.add_argument(
+        "--run-kalaeloa-even-with-high-rps",
+        action="store_true",
+        default=False,
         help="Enforce the 75 MW minimum-output rule for Kalaeloa in all years (otherwise relaxed "
-             "if RPS or EV share >= 75%%). Mimics behavior from switch 2.0.0b2.")
+        "if RPS or EV share >= 75%%). Mimics behavior from switch 2.0.0b2.",
+    )
+
 
 def define_components(m):
     refineries_closed(m)
     kalaeloa(m)
     schofield(m)
     cogen(m)
+
 
 def refineries_closed(m):
     """
@@ -29,22 +36,20 @@ def refineries_closed(m):
     We shut these down if fossil fuel is used for less than 25% of total power
     or vehicles. (Maybe 50% would be better?)
     """
+
     def filter(m, tp):
         ev_share = (
-            m.ev_share['Oahu', m.tp_period[tp]]
-            if hasattr(m, 'ev_share')
-            else 0.0
+            m.ev_share["Oahu", m.tp_period[tp]] if hasattr(m, "ev_share") else 0.0
         )
         rps_level = (
             m.rps_target_for_period[m.tp_period[tp]]
-            if hasattr(m, 'rps_target_for_period')
+            if hasattr(m, "rps_target_for_period")
             else 0.0
         )
-        return (ev_share >= 0.75 or rps_level >= 0.75)
-    m.REFINERIES_CLOSED_TPS = Set(
-        initialize=m.TIMEPOINTS,
-        filter=filter
-    )
+        return ev_share >= 0.75 or rps_level >= 0.75
+
+    m.REFINERIES_CLOSED_TPS = Set(initialize=m.TIMEPOINTS, filter=filter)
+
 
 def kalaeloa(m):
     """Special dispatch/commitment rules for Kalaeloa plant."""
@@ -56,25 +61,30 @@ def kalaeloa(m):
     # run both 1 & 2 at 90 MW, and run 3 at 28 MW
 
     m.KALAELOA_MAIN_UNITS = Set(
-        initialize=["Oahu_Kalaeloa_CC1", "Oahu_Kalaeloa_CC2", "Kalaeloa_CC1", "Kalaeloa_CC2"],
-        filter=lambda m, g: g in m.GENERATION_PROJECTS
+        initialize=[
+            "Oahu_Kalaeloa_CC1",
+            "Oahu_Kalaeloa_CC2",
+            "Kalaeloa_CC1",
+            "Kalaeloa_CC2",
+        ],
+        filter=lambda m, g: g in m.GENERATION_PROJECTS,
     )
     m.KALAELOA_DUCT_BURNERS = Set(
         initialize=["Oahu_Kalaeloa_CC3", "Kalaeloa_CC3"],
-        filter=lambda m, g: g in m.GENERATION_PROJECTS
+        filter=lambda m, g: g in m.GENERATION_PROJECTS,
     )
 
     m.KALAELOA_MAIN_UNIT_DISPATCH_POINTS = Set(
         dimen=2,
         initialize=lambda m: (
             (g, tp) for g in m.KALAELOA_MAIN_UNITS for tp in m.TPS_FOR_GEN[g]
-        )
+        ),
     )
     m.KALAELOA_DUCT_BURNER_DISPATCH_POINTS = Set(
         dimen=2,
         initialize=lambda m: (
             (g, tp) for g in m.KALAELOA_DUCT_BURNERS for tp in m.TPS_FOR_GEN[g]
-        )
+        ),
     )
     m.KALAELOA_ACTIVE_TIMEPOINTS = Set(
         initialize=lambda m: set(tp for g, tp in m.KALAELOA_MAIN_UNIT_DISPATCH_POINTS)
@@ -84,22 +94,19 @@ def kalaeloa(m):
     # (if linearized, this is the fraction of capacity that is dispatched)
     m.RunKalaeloaUnitFull = Var(m.KALAELOA_MAIN_UNIT_DISPATCH_POINTS, within=Binary)
 
-    m.Run_Kalaeloa_Unit_Full_Enforce = Constraint( # big-m constraint
+    m.Run_Kalaeloa_Unit_Full_Enforce = Constraint(  # big-m constraint
         m.KALAELOA_MAIN_UNIT_DISPATCH_POINTS,
-        rule=lambda m, g, tp:
-            m.DispatchGen[g, tp]
-            + (1 - m.RunKalaeloaUnitFull[g, tp]) * m.gen_capacity_limit_mw[g]
-            >=
-            m.GenCapacityInTP[g, tp] * m.gen_availability[g]
+        rule=lambda m, g, tp: m.DispatchGen[g, tp]
+        + (1 - m.RunKalaeloaUnitFull[g, tp]) * m.gen_capacity_limit_mw[g]
+        >= m.GenCapacityInTP[g, tp] * m.gen_availability[g],
     )
 
     # only run duct burner if all main units are full-on
     m.Run_Kalaeloa_Duct_Burner_Only_When_Full = Constraint(
-        m.KALAELOA_DUCT_BURNER_DISPATCH_POINTS, m.KALAELOA_MAIN_UNITS,
-        rule=lambda m, g_duct, tp, g_main:
-            m.DispatchGen[g_duct, tp]
-            <=
-            m.RunKalaeloaUnitFull[g_main, tp] * m.gen_capacity_limit_mw[g_duct]
+        m.KALAELOA_DUCT_BURNER_DISPATCH_POINTS,
+        m.KALAELOA_MAIN_UNITS,
+        rule=lambda m, g_duct, tp, g_main: m.DispatchGen[g_duct, tp]
+        <= m.RunKalaeloaUnitFull[g_main, tp] * m.gen_capacity_limit_mw[g_duct],
     )
 
     # force at least one Kalaeloa unit to run at full power at all times
@@ -117,13 +124,16 @@ def kalaeloa(m):
         # We assume that Kalaeloa's must-run rule applies only until the
         # refineries close, as specified in the m.oahu_refineries_closed parameter
         if both_units_out or (
-             tp in m.REFINERIES_CLOSED_TPS
-             and not m.options.run_kalaeloa_even_with_high_rps
+            tp in m.REFINERIES_CLOSED_TPS
+            and not m.options.run_kalaeloa_even_with_high_rps
         ):
             return Constraint.Skip
         else:
-            return (sum(m.DispatchGen[g, tp] for g in m.KALAELOA_MAIN_UNITS) >= 75.0)
-    m.Kalaeloa_Must_Run = Constraint(m.KALAELOA_ACTIVE_TIMEPOINTS, rule=Kalaeloa_Must_Run_rule)
+            return sum(m.DispatchGen[g, tp] for g in m.KALAELOA_MAIN_UNITS) >= 75.0
+
+    m.Kalaeloa_Must_Run = Constraint(
+        m.KALAELOA_ACTIVE_TIMEPOINTS, rule=Kalaeloa_Must_Run_rule
+    )
 
 
 def schofield(m):
@@ -136,14 +146,13 @@ def schofield(m):
     """
 
     m.SCHOFIELD_GENS = Set(
-        initialize=m.GENERATION_PROJECTS,
-        filter=lambda m, g: 'schofield' in g.lower()
+        initialize=m.GENERATION_PROJECTS, filter=lambda m, g: "schofield" in g.lower()
     )
-    m.One_Schofield = BuildCheck(rule=lambda m: len(m.SCHOFIELD_GENS)==1)
+    m.One_Schofield = BuildCheck(rule=lambda m: len(m.SCHOFIELD_GENS) == 1)
 
-    if not hasattr(m, 'f_rps_eligible'):
+    if not hasattr(m, "f_rps_eligible"):
         raise RuntimeError(
-            'The {} module requires the hawaii.rps module.'.format(__name__)
+            "The {} module requires the hawaii.rps module.".format(__name__)
         )
 
     def rule(m, g, t):
@@ -151,11 +160,13 @@ def schofield(m):
             return Constraint.Skip  # beyond retirement date
         all_fuel = sum(m.GenFuelUseRate[g, t, f] for f in m.FUELS_FOR_GEN[g])
         renewable_fuel = sum(
-            m.GenFuelUseRate[g, t, f]
-            for f in m.FUELS_FOR_GEN[g] if m.f_rps_eligible[f]
+            m.GenFuelUseRate[g, t, f] for f in m.FUELS_FOR_GEN[g] if m.f_rps_eligible[f]
         )
         return renewable_fuel >= 0.5 * all_fuel
-    m.Schofield_50_Percent_Renewable = Constraint(m.SCHOFIELD_GENS, m.TIMEPOINTS, rule=rule)
+
+    m.Schofield_50_Percent_Renewable = Constraint(
+        m.SCHOFIELD_GENS, m.TIMEPOINTS, rule=rule
+    )
 
 
 def cogen(m):
@@ -165,25 +176,26 @@ def cogen(m):
     """
     m.REFINERY_GENS = Set(
         initialize=m.GENERATION_PROJECTS,
-        filter=lambda m, g: any(rg in g for rg in ['Hawaii_Cogen', 'Tesoro_Hawaii'])
+        filter=lambda m, g: any(rg in g for rg in ["Hawaii_Cogen", "Tesoro_Hawaii"]),
     )
-    m.Two_Refinery_Gens = BuildCheck(rule=lambda m: len(m.REFINERY_GENS)==2)
+    m.Two_Refinery_Gens = BuildCheck(rule=lambda m: len(m.REFINERY_GENS) == 2)
 
     # relax commitment requirement when refineries are closed
     def rule(m, g, tp):
         if (g, tp) in m.Enforce_Commit_Lower_Limit:
             print("relaxing commitment for {}, {}".format(g, tp))
             m.Enforce_Commit_Lower_Limit[g, tp].deactivate()
+
     m.Relax_Refinery_Cogen_Baseload_Constraint = BuildAction(
-        m.REFINERY_GENS, m.REFINERIES_CLOSED_TPS,
-        rule=rule
+        m.REFINERY_GENS, m.REFINERIES_CLOSED_TPS, rule=rule
     )
     # force 0 production when refineries are closed
     def rule(m, g, t):
         if (g, t) not in m.GEN_TPS:
             return Constraint.Skip  # beyond retirement date
         else:
-            return (m.DispatchGen[g, tp] == 0)
+            return m.DispatchGen[g, tp] == 0
+
     m.Shutdown_Refinery_Cogens = Constraint(
         m.REFINERY_GENS, m.REFINERIES_CLOSED_TPS, rule=rule
     )
@@ -202,4 +214,7 @@ def cogen(m):
             return Constraint.Skip  # beyond retirement date or wrong fuel
         else:
             return m.GenFuelUseRate[g, t, f] == 0.0
-    m.Cogen_No_Biofuel = Constraint(m.REFINERY_GENS, m.TIMEPOINTS, m.REFINERY_BIOFUELS, rule=rule)
+
+    m.Cogen_No_Biofuel = Constraint(
+        m.REFINERY_GENS, m.TIMEPOINTS, m.REFINERY_BIOFUELS, rule=rule
+    )

--- a/switch_model/hawaii/psip_2016_04.py
+++ b/switch_model/hawaii/psip_2016_04.py
@@ -3,15 +3,33 @@ from __future__ import print_function
 import os
 from pyomo.environ import *
 
+
 def define_arguments(argparser):
-    argparser.add_argument('--psip-force', action='store_true', default=True,
-        help="Force following of PSIP plans (retiring AES and building certain technologies).")
-    argparser.add_argument('--psip-relax', dest='psip_force', action='store_false',
-        help="Relax PSIP plans, to find a more optimal strategy.")
-    argparser.add_argument('--psip-minimal-renewables', action='store_true', default=False,
-        help="Use only the amount of renewables shown in PSIP plans, and no more (should be combined with --psip-relax).")
-    argparser.add_argument('--force-build', nargs=3, default=None,
-        help="Force construction of at least a certain quantity of a particular technology during certain years. Space-separated list of year, technology and quantity.")
+    argparser.add_argument(
+        "--psip-force",
+        action="store_true",
+        default=True,
+        help="Force following of PSIP plans (retiring AES and building certain technologies).",
+    )
+    argparser.add_argument(
+        "--psip-relax",
+        dest="psip_force",
+        action="store_false",
+        help="Relax PSIP plans, to find a more optimal strategy.",
+    )
+    argparser.add_argument(
+        "--psip-minimal-renewables",
+        action="store_true",
+        default=False,
+        help="Use only the amount of renewables shown in PSIP plans, and no more (should be combined with --psip-relax).",
+    )
+    argparser.add_argument(
+        "--force-build",
+        nargs=3,
+        default=None,
+        help="Force construction of at least a certain quantity of a particular technology during certain years. Space-separated list of year, technology and quantity.",
+    )
+
 
 def define_components(m):
     ###################
@@ -21,7 +39,7 @@ def define_components(m):
     # decide whether to enforce the PSIP preferred plan
     # if an environment variable is set, that takes precedence
     # (e.g., on a cluster to override options.txt)
-    psip_env_var = os.environ.get('USE_PSIP_PLAN')
+    psip_env_var = os.environ.get("USE_PSIP_PLAN")
     if psip_env_var is None:
         # no environment variable; use the --psip-relax flag
         psip = m.options.psip_force
@@ -30,7 +48,11 @@ def define_components(m):
     elif psip_env_var.lower() in ["0", "false", "n", "no", "off"]:
         psip = False
     else:
-        raise ValueError('Unrecognized value for environment variable USE_PSIP_PLAN={} (should be 0 or 1)'.format(psip_env_var))
+        raise ValueError(
+            "Unrecognized value for environment variable USE_PSIP_PLAN={} (should be 0 or 1)".format(
+                psip_env_var
+            )
+        )
 
     if psip:
         print("Using PSIP construction plan.")
@@ -51,63 +73,71 @@ def define_components(m):
     # are underway and military projects are being built for their own
     # reasons)
     technology_targets_definite = [
-        (2016, 'CentralTrackingPV', 27.6),  # Waianae Solar by Eurus Energy America
-        (2018, 'IC_Schofield', 54.0),
-        (2018, 'IC_Barge', 100.0),         # JBPHH plant
-        (2021, 'IC_MCBH', 27.0),
+        (2016, "CentralTrackingPV", 27.6),  # Waianae Solar by Eurus Energy America
+        (2018, "IC_Schofield", 54.0),
+        (2018, "IC_Barge", 100.0),  # JBPHH plant
+        (2021, "IC_MCBH", 27.0),
         # Distributed PV from Figure J-19
-        (2016, 'DistPV',  443.993468266547 - 210), # net of 210 MW of pre-existing DistPV
-        (2017, 'DistPV',  92.751756737742),
-        (2018, 'DistPV',  27.278236032368),
-        (2019, 'DistPV',  26.188129564885),
+        (
+            2016,
+            "DistPV",
+            443.993468266547 - 210,
+        ),  # net of 210 MW of pre-existing DistPV
+        (2017, "DistPV", 92.751756737742),
+        (2018, "DistPV", 27.278236032368),
+        (2019, "DistPV", 26.188129564885),
     ]
     # technologies proposed in PSIP but which may not be built if a
     # better plan is found
     technology_targets_psip = [
-        (2018, 'OnshoreWind', 24),      # NPM wind
-        (2018, 'CentralTrackingPV', 109.6),  # replacement for canceled SunEdison projects
-        (2018, 'OnshoreWind', 10),      # CBRE wind
-        (2018, 'CentralTrackingPV', 15),  # CBRE PV
-        (2020, 'OnshoreWind', 30),
-        (2020, 'CentralTrackingPV', 60),
-        (2021, 'CC_383', 383.0),
-        (2030, 'CentralTrackingPV', 100),
-        (2030, 'OffshoreWind', 200),
-        (2040, 'CentralTrackingPV', 200),
-        (2040, 'OffshoreWind', 200),
-        (2045, 'CentralTrackingPV', 300),
-        (2045, 'OffshoreWind', 400),
-        (2020, 'DistPV',  21.8245069017911),
-        (2021, 'DistPV',  15.27427771741),
-        (2022, 'DistPV',  12.0039583149589),
-        (2023, 'DistPV',  10.910655054315),
-        (2024, 'DistPV',  10.913851847475),
-        (2025, 'DistPV',  10.910655054316),
-        (2026, 'DistPV',  9.82054858683205),
-        (2027, 'DistPV',  10.910655054316),
-        (2028, 'DistPV',  10.910655054315),
-        (2029, 'DistPV',  14.1873680430859),
-        (2030, 'DistPV',  9.82054858683205),
-        (2031, 'DistPV',  10.913851847475),
-        (2032, 'DistPV',  9.82054858683193),
-        (2033, 'DistPV',  14.1841712499261),
-        (2034, 'DistPV',  7.64033565186492),
-        (2035, 'DistPV',  13.094064782442),
-        (2036, 'DistPV',  9.82054858683205),
-        (2037, 'DistPV',  10.9202454337949),
-        (2038, 'DistPV',  9.66989970917803),
-        (2039, 'DistPV',  12.1514103994531),
-        (2040, 'DistPV',  12.2397218104919),
-        (2041, 'DistPV',  11.7673956211361),
-        (2042, 'DistPV',  10.9106550543149),
-        (2043, 'DistPV',  9.82054858683205),
-        (2044, 'DistPV',  15.27747451057),
-        (2045, 'DistPV',  10.291675978754),
+        (2018, "OnshoreWind", 24),  # NPM wind
+        (
+            2018,
+            "CentralTrackingPV",
+            109.6,
+        ),  # replacement for canceled SunEdison projects
+        (2018, "OnshoreWind", 10),  # CBRE wind
+        (2018, "CentralTrackingPV", 15),  # CBRE PV
+        (2020, "OnshoreWind", 30),
+        (2020, "CentralTrackingPV", 60),
+        (2021, "CC_383", 383.0),
+        (2030, "CentralTrackingPV", 100),
+        (2030, "OffshoreWind", 200),
+        (2040, "CentralTrackingPV", 200),
+        (2040, "OffshoreWind", 200),
+        (2045, "CentralTrackingPV", 300),
+        (2045, "OffshoreWind", 400),
+        (2020, "DistPV", 21.8245069017911),
+        (2021, "DistPV", 15.27427771741),
+        (2022, "DistPV", 12.0039583149589),
+        (2023, "DistPV", 10.910655054315),
+        (2024, "DistPV", 10.913851847475),
+        (2025, "DistPV", 10.910655054316),
+        (2026, "DistPV", 9.82054858683205),
+        (2027, "DistPV", 10.910655054316),
+        (2028, "DistPV", 10.910655054315),
+        (2029, "DistPV", 14.1873680430859),
+        (2030, "DistPV", 9.82054858683205),
+        (2031, "DistPV", 10.913851847475),
+        (2032, "DistPV", 9.82054858683193),
+        (2033, "DistPV", 14.1841712499261),
+        (2034, "DistPV", 7.64033565186492),
+        (2035, "DistPV", 13.094064782442),
+        (2036, "DistPV", 9.82054858683205),
+        (2037, "DistPV", 10.9202454337949),
+        (2038, "DistPV", 9.66989970917803),
+        (2039, "DistPV", 12.1514103994531),
+        (2040, "DistPV", 12.2397218104919),
+        (2041, "DistPV", 11.7673956211361),
+        (2042, "DistPV", 10.9106550543149),
+        (2043, "DistPV", 9.82054858683205),
+        (2044, "DistPV", 15.27747451057),
+        (2045, "DistPV", 10.291675978754),
     ]
 
     if m.options.force_build is not None:
         b = list(m.options.force_build)
-        b[0] = int(b[0])    # year
+        b[0] = int(b[0])  # year
         b[2] = float(b[2])  # quantity
         b = tuple(b)
         print("Forcing build: {}".format(b))
@@ -123,11 +153,15 @@ def define_components(m):
         start = 2000 if per == m.PERIODS.first() else per
         end = per + m.period_length_years[per]
         target = sum(
-            mw for (tyear, ttech, mw) in technology_targets
-                if ttech == tech and start <= tyear and tyear < end
+            mw
+            for (tyear, ttech, mw) in technology_targets
+            if ttech == tech and start <= tyear and tyear < end
         )
         return target
-    m.technology_target = Param(m.PERIODS, m.GENERATION_TECHNOLOGIES, initialize=technology_target_init)
+
+    m.technology_target = Param(
+        m.PERIODS, m.GENERATION_TECHNOLOGIES, initialize=technology_target_init
+    )
 
     # with PSIP: BuildGen is zero except for technology_targets
     #     (sum during each period or before first period)
@@ -142,7 +176,9 @@ def define_components(m):
                 # needed to exactly meet the target.
                 # This is needed because some of the targets are based on
                 # nominal unit sizes rather than actual max output.
-                return (target / m.gen_unit_size[g]) / round(target / m.gen_unit_size[g])
+                return (target / m.gen_unit_size[g]) / round(
+                    target / m.gen_unit_size[g]
+                )
             else:
                 return 1.0
 
@@ -164,52 +200,67 @@ def define_components(m):
                 )
                 return Constraint.Infeasible
         elif psip:
-            return (build == target)
-        elif m.options.psip_minimal_renewables and any(txt in tech for txt in ["PV", "Wind", "Solar"]):
+            return build == target
+        elif m.options.psip_minimal_renewables and any(
+            txt in tech for txt in ["PV", "Wind", "Solar"]
+        ):
             # only build the specified amount of renewables, no more
-            return (build == target)
+            return build == target
         else:
             # treat the target as a lower bound
-            return (build >= target)
+            return build >= target
+
     m.Enforce_Technology_Target = Constraint(
         m.PERIODS, m.GENERATION_TECHNOLOGIES, rule=Enforce_Technology_Target_rule
     )
 
-    aes_g = 'Oahu_AES'
+    aes_g = "Oahu_AES"
     aes_size = 180
     aes_bld_year = 1992
-    m.AES_OPERABLE_PERIODS = Set(initialize = lambda m:
-        m.PERIODS_FOR_GEN_BLD_YR[aes_g, aes_bld_year]
+    m.AES_OPERABLE_PERIODS = Set(
+        initialize=lambda m: m.PERIODS_FOR_GEN_BLD_YR[aes_g, aes_bld_year]
     )
     m.OperateAES = Var(m.AES_OPERABLE_PERIODS, within=Binary)
-    m.Enforce_AES_Deactivate = Constraint(m.TIMEPOINTS, rule=lambda m, tp:
-        Constraint.Skip if (aes_g, tp) not in m.GEN_TPS
-        else (m.DispatchGen[aes_g, tp] <= m.OperateAES[m.tp_period[tp]] * aes_size)
+    m.Enforce_AES_Deactivate = Constraint(
+        m.TIMEPOINTS,
+        rule=lambda m, tp: Constraint.Skip
+        if (aes_g, tp) not in m.GEN_TPS
+        else (m.DispatchGen[aes_g, tp] <= m.OperateAES[m.tp_period[tp]] * aes_size),
     )
-    m.AESDeactivateFixedCost = Expression(m.PERIODS, rule=lambda m, per:
-        0.0 if per not in m.AES_OPERABLE_PERIODS
-        else - m.OperateAES[per] * aes_size * m.gen_fixed_om[aes_g, aes_bld_year]
+    m.AESDeactivateFixedCost = Expression(
+        m.PERIODS,
+        rule=lambda m, per: 0.0
+        if per not in m.AES_OPERABLE_PERIODS
+        else -m.OperateAES[per] * aes_size * m.gen_fixed_om[aes_g, aes_bld_year],
     )
-    m.Cost_Components_Per_Period.append('AESDeactivateFixedCost')
+    m.Cost_Components_Per_Period.append("AESDeactivateFixedCost")
 
     if psip:
         # keep AES active until 2022 or just before; deactivate after that
-        m.PSIP_Retire_AES = Constraint(m.AES_OPERABLE_PERIODS, rule=lambda m, per:
-            (m.OperateAES[per] == 1) if per + m.period_length_years[per] <= 2022
-            else (m.OperateAES[per] == 0)
+        m.PSIP_Retire_AES = Constraint(
+            m.AES_OPERABLE_PERIODS,
+            rule=lambda m, per: (m.OperateAES[per] == 1)
+            if per + m.period_length_years[per] <= 2022
+            else (m.OperateAES[per] == 0),
         )
 
         # before 2040: no biodiesel, and only 100-300 GWh of non-LNG fossil fuels
         # period including 2040-2045: <= 300 GWh of oil; unlimited biodiesel or LNG
 
         # no biodiesel before 2040 (then phased in fast enough to meet the RPS)
-        m.EARLY_BIODIESEL_MARKETS = Set(dimen=2, initialize=lambda m: [
-            (rfm, per)
-                for per in m.PERIODS if per + m.period_length_years[per] <= 2040
-                    for rfm in m.REGIONAL_FUEL_MARKETS if m.rfm_fuel == 'Biodiesel'
-        ])
-        m.NoEarlyBiodiesel = Constraint(m.EARLY_BIODIESEL_MARKETS, rule=lambda m, rfm, per:
-            m.FuelConsumptionInMarket[rfm, per] == 0
+        m.EARLY_BIODIESEL_MARKETS = Set(
+            dimen=2,
+            initialize=lambda m: [
+                (rfm, per)
+                for per in m.PERIODS
+                if per + m.period_length_years[per] <= 2040
+                for rfm in m.REGIONAL_FUEL_MARKETS
+                if m.rfm_fuel == "Biodiesel"
+            ],
+        )
+        m.NoEarlyBiodiesel = Constraint(
+            m.EARLY_BIODIESEL_MARKETS,
+            rule=lambda m, rfm, per: m.FuelConsumptionInMarket[rfm, per] == 0,
         )
 
         # # 100-300 GWh of non-LNG fuels in 2021-2040 (based on 2016-04 PSIP fig. 5-5)
@@ -268,18 +319,27 @@ def define_components(m):
         # don't allow construction of any advanced technologies (e.g., batteries, pumped hydro, fuel cells)
         advanced_tech_vars = [
             "BuildBattery",
-            "BuildPumpedHydroMW", "BuildAnyPumpedHydro",
-            "BuildElectrolyzerMW", "BuildLiquifierKgPerHour", "BuildLiquidHydrogenTankKg",
+            "BuildPumpedHydroMW",
+            "BuildAnyPumpedHydro",
+            "BuildElectrolyzerMW",
+            "BuildLiquifierKgPerHour",
+            "BuildLiquidHydrogenTankKg",
             "BuildFuelCellMW",
         ]
+
         def no_advanced_tech_rule_factory(v):
             return lambda m, *k: (getattr(m, v)[k] == 0)
+
         for v in advanced_tech_vars:
             try:
                 var = getattr(m, v)
-                setattr(m, "PSIP_No_"+v, Constraint(var._index, rule=no_advanced_tech_rule_factory(v)))
+                setattr(
+                    m,
+                    "PSIP_No_" + v,
+                    Constraint(var._index, rule=no_advanced_tech_rule_factory(v)),
+                )
             except AttributeError:
-                pass    # model doesn't have this var
+                pass  # model doesn't have this var
 
         # # don't allow any changes to the fuel market, including bulk LNG
         # # not used now; use "--force-lng-tier container" instead

--- a/switch_model/hawaii/pumped_hydro.py
+++ b/switch_model/hawaii/pumped_hydro.py
@@ -3,11 +3,21 @@ import os
 from pyomo.environ import *
 from switch_model.financials import capital_recovery_factor as crf
 
+
 def define_arguments(argparser):
-    argparser.add_argument("--ph-mw", type=float, default=None,
-        help="Force construction of a certain total capacity of pumped storage hydro during one or more periods chosen by Switch")
-    argparser.add_argument("--ph-year", type=int, default=None,
-        help="Force all pumped storage hydro to be constructed during one particular year (must be in the list of periods)")
+    argparser.add_argument(
+        "--ph-mw",
+        type=float,
+        default=None,
+        help="Force construction of a certain total capacity of pumped storage hydro during one or more periods chosen by Switch",
+    )
+    argparser.add_argument(
+        "--ph-year",
+        type=int,
+        default=None,
+        help="Force all pumped storage hydro to be constructed during one particular year (must be in the list of periods)",
+    )
+
 
 def define_components(m):
 
@@ -22,9 +32,10 @@ def define_components(m):
     m.ph_fixed_om_percent = Param(m.PH_GENS, within=NonNegativeReals)
 
     # total annual cost
-    m.ph_fixed_cost_per_mw_per_year = Param(m.PH_GENS, initialize=lambda m, p:
-        m.ph_capital_cost_per_mw[p] *
-            (crf(m.interest_rate, m.ph_project_life[p]) + m.ph_fixed_om_percent[p])
+    m.ph_fixed_cost_per_mw_per_year = Param(
+        m.PH_GENS,
+        initialize=lambda m, p: m.ph_capital_cost_per_mw[p]
+        * (crf(m.interest_rate, m.ph_project_life[p]) + m.ph_fixed_om_percent[p]),
     )
 
     # round-trip efficiency of the pumped hydro facility
@@ -39,8 +50,13 @@ def define_components(m):
 
     # How much pumped hydro to build
     m.BuildPumpedHydroMW = Var(m.PH_GENS, m.PERIODS, within=NonNegativeReals)
-    m.Pumped_Hydro_Proj_Capacity_MW = Expression(m.PH_GENS, m.PERIODS, rule=lambda m, g, pe:
-        sum(m.BuildPumpedHydroMW[g, pp] for pp in m.CURRENT_AND_PRIOR_PERIODS_FOR_PERIOD[pe])
+    m.Pumped_Hydro_Proj_Capacity_MW = Expression(
+        m.PH_GENS,
+        m.PERIODS,
+        rule=lambda m, g, pe: sum(
+            m.BuildPumpedHydroMW[g, pp]
+            for pp in m.CURRENT_AND_PRIOR_PERIODS_FOR_PERIOD[pe]
+        ),
     )
 
     # flag indicating whether any capacity is added to each project each year
@@ -53,91 +69,144 @@ def define_components(m):
     # constraints on construction of pumped hydro
 
     # don't build more than the max allowed capacity
-    m.Pumped_Hydro_Max_Build = Constraint(m.PH_GENS, m.PERIODS, rule=lambda m, g, pe:
-        m.Pumped_Hydro_Proj_Capacity_MW[g, pe] <= m.ph_max_capacity_mw[g]
+    m.Pumped_Hydro_Max_Build = Constraint(
+        m.PH_GENS,
+        m.PERIODS,
+        rule=lambda m, g, pe: m.Pumped_Hydro_Proj_Capacity_MW[g, pe]
+        <= m.ph_max_capacity_mw[g],
     )
 
     # force the build flag on for the year(s) when pumped hydro is built
-    m.Pumped_Hydro_Set_Build_Flag = Constraint(m.PH_GENS, m.PERIODS, rule=lambda m, g, pe:
-        m.BuildPumpedHydroMW[g, pe] <= m.BuildAnyPumpedHydro[g, pe] * m.ph_max_capacity_mw[g]
+    m.Pumped_Hydro_Set_Build_Flag = Constraint(
+        m.PH_GENS,
+        m.PERIODS,
+        rule=lambda m, g, pe: m.BuildPumpedHydroMW[g, pe]
+        <= m.BuildAnyPumpedHydro[g, pe] * m.ph_max_capacity_mw[g],
     )
     # only build in one year (can be deactivated to allow incremental construction)
-    m.Pumped_Hydro_Build_Once = Constraint(m.PH_GENS, rule=lambda m, g:
-        sum(m.BuildAnyPumpedHydro[g, pe] for pe in m.PERIODS) <= 1)
+    m.Pumped_Hydro_Build_Once = Constraint(
+        m.PH_GENS,
+        rule=lambda m, g: sum(m.BuildAnyPumpedHydro[g, pe] for pe in m.PERIODS) <= 1,
+    )
     # only build full project size (deactivated by default, to allow smaller projects)
-    m.Pumped_Hydro_Build_All_Or_None = Constraint(m.PH_GENS, m.PERIODS, rule=lambda m, g, pe:
-        m.BuildPumpedHydroMW[g, pe] == m.BuildAnyPumpedHydro[g, pe] * m.ph_max_capacity_mw[g]
+    m.Pumped_Hydro_Build_All_Or_None = Constraint(
+        m.PH_GENS,
+        m.PERIODS,
+        rule=lambda m, g, pe: m.BuildPumpedHydroMW[g, pe]
+        == m.BuildAnyPumpedHydro[g, pe] * m.ph_max_capacity_mw[g],
     )
     # m.Deactivate_Pumped_Hydro_Build_All_Or_None = BuildAction(rule=lambda m:
     #     m.Pumped_Hydro_Build_All_Or_None.deactivate()
     # )
 
     # limits on pumping and generation
-    m.Pumped_Hydro_Max_Generate_Rate = Constraint(m.PH_GENS, m.TIMEPOINTS, rule=lambda m, g, t:
-        m.PumpedHydroProjGenerateMW[g, t]
-        <=
-        m.Pumped_Hydro_Proj_Capacity_MW[g, m.tp_period[t]]
+    m.Pumped_Hydro_Max_Generate_Rate = Constraint(
+        m.PH_GENS,
+        m.TIMEPOINTS,
+        rule=lambda m, g, t: m.PumpedHydroProjGenerateMW[g, t]
+        <= m.Pumped_Hydro_Proj_Capacity_MW[g, m.tp_period[t]],
     )
-    m.Pumped_Hydro_Max_Store_Rate = Constraint(m.PH_GENS, m.TIMEPOINTS, rule=lambda m, g, t:
-        m.PumpedHydroProjStoreMW[g, t]
-        <=
-        m.Pumped_Hydro_Proj_Capacity_MW[g, m.tp_period[t]]
+    m.Pumped_Hydro_Max_Store_Rate = Constraint(
+        m.PH_GENS,
+        m.TIMEPOINTS,
+        rule=lambda m, g, t: m.PumpedHydroProjStoreMW[g, t]
+        <= m.Pumped_Hydro_Proj_Capacity_MW[g, m.tp_period[t]],
     )
 
     # return reservoir to at least the starting level every day, net of any inflow
     # it can also go higher than starting level, which indicates spilling surplus water
-    m.Pumped_Hydro_Daily_Balance = Constraint(m.PH_GENS, m.TIMESERIES, rule=lambda m, g, ts:
-        sum(
+    m.Pumped_Hydro_Daily_Balance = Constraint(
+        m.PH_GENS,
+        m.TIMESERIES,
+        rule=lambda m, g, ts: sum(
             m.PumpedHydroProjStoreMW[g, tp] * m.ph_efficiency[g]
             + m.ph_inflow_mw[g]
             - m.PumpedHydroProjGenerateMW[g, tp]
             for tp in m.TPS_IN_TS[ts]
-         ) >= 0
+        )
+        >= 0,
     )
 
-    m.GeneratePumpedHydro = Expression(m.LOAD_ZONES, m.TIMEPOINTS, rule=lambda m, z, t:
-        sum(m.PumpedHydroProjGenerateMW[g, t] for g in m.PH_GENS if m.ph_load_zone[g]==z)
+    m.GeneratePumpedHydro = Expression(
+        m.LOAD_ZONES,
+        m.TIMEPOINTS,
+        rule=lambda m, z, t: sum(
+            m.PumpedHydroProjGenerateMW[g, t]
+            for g in m.PH_GENS
+            if m.ph_load_zone[g] == z
+        ),
     )
-    m.StorePumpedHydro = Expression(m.LOAD_ZONES, m.TIMEPOINTS, rule=lambda m, z, t:
-        sum(m.PumpedHydroProjStoreMW[g, t] for g in m.PH_GENS if m.ph_load_zone[g]==z)
+    m.StorePumpedHydro = Expression(
+        m.LOAD_ZONES,
+        m.TIMEPOINTS,
+        rule=lambda m, z, t: sum(
+            m.PumpedHydroProjStoreMW[g, t] for g in m.PH_GENS if m.ph_load_zone[g] == z
+        ),
     )
 
     # calculate costs
-    m.Pumped_Hydro_Fixed_Cost_Annual = Expression(m.PERIODS, rule=lambda m, pe:
-        sum(m.ph_fixed_cost_per_mw_per_year[g] * m.Pumped_Hydro_Proj_Capacity_MW[g, pe] for g in m.PH_GENS)
+    m.Pumped_Hydro_Fixed_Cost_Annual = Expression(
+        m.PERIODS,
+        rule=lambda m, pe: sum(
+            m.ph_fixed_cost_per_mw_per_year[g] * m.Pumped_Hydro_Proj_Capacity_MW[g, pe]
+            for g in m.PH_GENS
+        ),
     )
-    m.Cost_Components_Per_Period.append('Pumped_Hydro_Fixed_Cost_Annual')
+    m.Cost_Components_Per_Period.append("Pumped_Hydro_Fixed_Cost_Annual")
 
     # add pumped hydro to zonal energy balance
-    m.Zone_Power_Injections.append('GeneratePumpedHydro')
-    m.Zone_Power_Withdrawals.append('StorePumpedHydro')
+    m.Zone_Power_Injections.append("GeneratePumpedHydro")
+    m.Zone_Power_Withdrawals.append("StorePumpedHydro")
 
     # total pumped hydro capacity in each zone each period (for reporting)
-    m.Pumped_Hydro_Capacity_MW = Expression(m.LOAD_ZONES, m.PERIODS, rule=lambda m, z, pe:
-        sum(m.Pumped_Hydro_Proj_Capacity_MW[g, pe] for g in m.PH_GENS if m.ph_load_zone[g]==z)
+    m.Pumped_Hydro_Capacity_MW = Expression(
+        m.LOAD_ZONES,
+        m.PERIODS,
+        rule=lambda m, z, pe: sum(
+            m.Pumped_Hydro_Proj_Capacity_MW[g, pe]
+            for g in m.PH_GENS
+            if m.ph_load_zone[g] == z
+        ),
     )
 
     # force construction of a fixed amount of pumped hydro
     if m.options.ph_mw is not None:
-        print("Forcing construction of {m} MW of pumped hydro.".format(m=m.options.ph_mw))
-        m.Build_Pumped_Hydro_MW = Constraint(m.LOAD_ZONES, rule=lambda m, z:
-            m.Pumped_Hydro_Capacity_MW[z, m.PERIODS.last()] == m.options.ph_mw
+        print(
+            "Forcing construction of {m} MW of pumped hydro.".format(m=m.options.ph_mw)
+        )
+        m.Build_Pumped_Hydro_MW = Constraint(
+            m.LOAD_ZONES,
+            rule=lambda m, z: m.Pumped_Hydro_Capacity_MW[z, m.PERIODS.last()]
+            == m.options.ph_mw,
         )
     # force construction of pumped hydro only in a certain period
     if m.options.ph_year is not None:
-        print("Allowing construction of pumped hydro only in {p}.".format(p=m.options.ph_year))
+        print(
+            "Allowing construction of pumped hydro only in {p}.".format(
+                p=m.options.ph_year
+            )
+        )
         m.Build_Pumped_Hydro_Year = Constraint(
-            m.PH_GENS, m.PERIODS,
-            rule=lambda m, g, pe:
-                m.BuildPumpedHydroMW[g, pe] == 0.0 if pe != m.options.ph_year else Constraint.Skip
+            m.PH_GENS,
+            m.PERIODS,
+            rule=lambda m, g, pe: m.BuildPumpedHydroMW[g, pe] == 0.0
+            if pe != m.options.ph_year
+            else Constraint.Skip,
         )
 
 
 def load_inputs(m, switch_data, inputs_dir):
     switch_data.load_aug(
         optional=True,
-        filename=os.path.join(inputs_dir, 'pumped_hydro.csv'),
+        filename=os.path.join(inputs_dir, "pumped_hydro.csv"),
         index=m.PH_GENS,
         param=(
-            m.ph_load_zone, m.ph_capital_cost_per_mw, m.ph_project_life, m.ph_fixed_om_percent,
-            m.ph_efficiency, m.ph_inflow_mw, m.ph_max_capacity_mw))
+            m.ph_load_zone,
+            m.ph_capital_cost_per_mw,
+            m.ph_project_life,
+            m.ph_fixed_om_percent,
+            m.ph_efficiency,
+            m.ph_inflow_mw,
+            m.ph_max_capacity_mw,
+        ),
+    )

--- a/switch_model/hawaii/register_hi_storage_reserves.py
+++ b/switch_model/hawaii/register_hi_storage_reserves.py
@@ -11,91 +11,111 @@ from pyomo.environ import *
 # But eventually those modules should use the standard storage module and
 # extend that as needed.
 
+
 def define_arguments(argparser):
-    argparser.add_argument('--hawaii-storage-reserve-types', nargs='+', default=['spinning'],
-        help=
-            "Type(s) of reserves to provide from " # hydrogen and/or
-            "pumped-hydro storage "
-            "(e.g., 'contingency regulation'). "
-            "Default is generic 'spinning'. Specify 'none' to disable."
+    argparser.add_argument(
+        "--hawaii-storage-reserve-types",
+        nargs="+",
+        default=["spinning"],
+        help="Type(s) of reserves to provide from "  # hydrogen and/or
+        "pumped-hydro storage "
+        "(e.g., 'contingency regulation'). "
+        "Default is generic 'spinning'. Specify 'none' to disable.",
     )
+
 
 def define_components(m):
 
-    if [rt.lower() for rt in m.options.hawaii_storage_reserve_types] != ['none']:
-        if hasattr(m, 'PumpedHydroProjGenerateMW'):
+    if [rt.lower() for rt in m.options.hawaii_storage_reserve_types] != ["none"]:
+        if hasattr(m, "PumpedHydroProjGenerateMW"):
             m.PumpedStorageCharging = Var(m.PH_GENS, m.TIMEPOINTS, within=Binary)
-            m.Set_PumpedStorageCharging_Flag = Constraint(m.PH_GENS, m.TIMEPOINTS, rule=lambda m, phg, tp:
-                m.PumpedHydroProjGenerateMW[phg, tp]
-                <=
-                m.ph_max_capacity_mw[phg] * (1 - m.PumpedStorageCharging[phg, tp])
+            m.Set_PumpedStorageCharging_Flag = Constraint(
+                m.PH_GENS,
+                m.TIMEPOINTS,
+                rule=lambda m, phg, tp: m.PumpedHydroProjGenerateMW[phg, tp]
+                <= m.ph_max_capacity_mw[phg] * (1 - m.PumpedStorageCharging[phg, tp]),
             )
             # choose how much pumped storage reserves to provide each hour, without reversing direction
-            m.PumpedStorageSpinningUpReserves = Var(m.PH_GENS, m.TIMEPOINTS, within=NonNegativeReals)
+            m.PumpedStorageSpinningUpReserves = Var(
+                m.PH_GENS, m.TIMEPOINTS, within=NonNegativeReals
+            )
             m.Limit_PumpedStorageSpinningUpReserves_When_Charging = Constraint(
-                m.PH_GENS, m.TIMEPOINTS,
-                rule=lambda m, phg, tp:
-                    m.PumpedStorageSpinningUpReserves[phg, tp]
-                    <=
-                    m.PumpedHydroProjStoreMW[phg, tp]
-                    + m.ph_max_capacity_mw[phg] * (1 - m.PumpedStorageCharging[phg, tp]) # relax when discharging
+                m.PH_GENS,
+                m.TIMEPOINTS,
+                rule=lambda m, phg, tp: m.PumpedStorageSpinningUpReserves[phg, tp]
+                <= m.PumpedHydroProjStoreMW[phg, tp]
+                + m.ph_max_capacity_mw[phg]
+                * (1 - m.PumpedStorageCharging[phg, tp]),  # relax when discharging
             )
             m.Limit_PumpedStorageSpinningUpReserves_When_Discharging = Constraint(
-                m.PH_GENS, m.TIMEPOINTS,
-                rule=lambda m, phg, tp:
-                    m.PumpedStorageSpinningUpReserves[phg, tp]
-                    <=
-                    m.Pumped_Hydro_Proj_Capacity_MW[phg, m.tp_period[tp]] - m.PumpedHydroProjGenerateMW[phg, tp]
-                    + m.ph_max_capacity_mw[phg] * m.PumpedStorageCharging[phg, tp] # relax when charging
+                m.PH_GENS,
+                m.TIMEPOINTS,
+                rule=lambda m, phg, tp: m.PumpedStorageSpinningUpReserves[phg, tp]
+                <= m.Pumped_Hydro_Proj_Capacity_MW[phg, m.tp_period[tp]]
+                - m.PumpedHydroProjGenerateMW[phg, tp]
+                + m.ph_max_capacity_mw[phg]
+                * m.PumpedStorageCharging[phg, tp],  # relax when charging
             )
-            m.PumpedStorageSpinningDownReserves = Var(m.PH_GENS, m.TIMEPOINTS, within=NonNegativeReals, bounds=(0,0))
+            m.PumpedStorageSpinningDownReserves = Var(
+                m.PH_GENS, m.TIMEPOINTS, within=NonNegativeReals, bounds=(0, 0)
+            )
             m.Limit_PumpedStorageSpinningDownReserves_When_Charging = Constraint(
-                m.PH_GENS, m.TIMEPOINTS,
-                rule=lambda m, phg, tp:
-                    m.PumpedStorageSpinningDownReserves[phg, tp]
-                    <=
-                    m.Pumped_Hydro_Proj_Capacity_MW[phg, m.tp_period[tp]] - m.PumpedHydroProjStoreMW[phg, tp]
-                    + m.ph_max_capacity_mw[phg] * (1 - m.PumpedStorageCharging[phg, tp]) # relax when discharging
+                m.PH_GENS,
+                m.TIMEPOINTS,
+                rule=lambda m, phg, tp: m.PumpedStorageSpinningDownReserves[phg, tp]
+                <= m.Pumped_Hydro_Proj_Capacity_MW[phg, m.tp_period[tp]]
+                - m.PumpedHydroProjStoreMW[phg, tp]
+                + m.ph_max_capacity_mw[phg]
+                * (1 - m.PumpedStorageCharging[phg, tp]),  # relax when discharging
             )
             m.Limit_PumpedStorageSpinningDownReserves_When_Discharging = Constraint(
-                m.PH_GENS, m.TIMEPOINTS,
-                rule=lambda m, phg, tp:
-                    m.PumpedStorageSpinningDownReserves[phg, tp]
-                    <=
-                    m.PumpedHydroProjGenerateMW[phg, tp]
-                    + m.ph_max_capacity_mw[phg] * m.PumpedStorageCharging[phg, tp] # relax when charging
+                m.PH_GENS,
+                m.TIMEPOINTS,
+                rule=lambda m, phg, tp: m.PumpedStorageSpinningDownReserves[phg, tp]
+                <= m.PumpedHydroProjGenerateMW[phg, tp]
+                + m.ph_max_capacity_mw[phg]
+                * m.PumpedStorageCharging[phg, tp],  # relax when charging
             )
 
         # Register with spinning reserves
-        if hasattr(m, 'Spinning_Reserve_Up_Provisions'): # using spinning_reserves_advanced
+        if hasattr(
+            m, "Spinning_Reserve_Up_Provisions"
+        ):  # using spinning_reserves_advanced
             # calculate available slack from hawaii storage
             def up_expr(m, a, tp):
                 avail = 0.0
                 # now handled in hydrogen module:
                 # if hasattr(m, 'HydrogenSlackUp'):
                 #     avail += sum(m.HydrogenSlackUp[z, tp] for z in m.ZONES_IN_BALANCING_AREA[a])
-                if hasattr(m, 'PumpedStorageSpinningUpReserves'):
+                if hasattr(m, "PumpedStorageSpinningUpReserves"):
                     avail += sum(
                         m.PumpedStorageSpinningUpReserves[phg, tp]
                         for phg in m.PH_GENS
                         if m.ph_load_zone[phg] in m.ZONES_IN_BALANCING_AREA[a]
                     )
                 return avail
-            m.HawaiiStorageSlackUp = Expression(m.BALANCING_AREA_TIMEPOINTS, rule=up_expr)
+
+            m.HawaiiStorageSlackUp = Expression(
+                m.BALANCING_AREA_TIMEPOINTS, rule=up_expr
+            )
+
             def down_expr(m, a, tp):
                 avail = 0.0
                 # if hasattr(m, 'HydrogenSlackDown'):
                 #     avail += sum(m.HydrogenSlackDown[z, tp] for z in m.ZONES_IN_BALANCING_AREA[a])
-                if hasattr(m, 'PumpedStorageSpinningDownReserves'):
+                if hasattr(m, "PumpedStorageSpinningDownReserves"):
                     avail += sum(
                         m.PumpedStorageSpinningDownReserves[phg, tp]
                         for phg in m.PH_GENS
                         if m.ph_load_zone[phg] in m.ZONES_IN_BALANCING_AREA[a]
                     )
                 return avail
-            m.HawaiiStorageSlackDown = Expression(m.BALANCING_AREA_TIMEPOINTS, rule=down_expr)
 
-            if hasattr(m, 'GEN_SPINNING_RESERVE_TYPES'):
+            m.HawaiiStorageSlackDown = Expression(
+                m.BALANCING_AREA_TIMEPOINTS, rule=down_expr
+            )
+
+            if hasattr(m, "GEN_SPINNING_RESERVE_TYPES"):
                 # using advanced formulation, index by reserve type, balancing area, timepoint
                 # define variables for each type of reserves to be provided
                 # choose how to allocate the slack between the different reserve products
@@ -103,37 +123,43 @@ def define_components(m):
                     initialize=m.options.hawaii_storage_reserve_types
                 )
                 m.HawaiiStorageSpinningReserveUp = Var(
-                    m.HI_STORAGE_SPINNING_RESERVE_TYPES, m.BALANCING_AREA_TIMEPOINTS,
-                    within=NonNegativeReals
+                    m.HI_STORAGE_SPINNING_RESERVE_TYPES,
+                    m.BALANCING_AREA_TIMEPOINTS,
+                    within=NonNegativeReals,
                 )
                 m.HawaiiStorageSpinningReserveDown = Var(
-                    m.HI_STORAGE_SPINNING_RESERVE_TYPES, m.BALANCING_AREA_TIMEPOINTS,
-                    within=NonNegativeReals
+                    m.HI_STORAGE_SPINNING_RESERVE_TYPES,
+                    m.BALANCING_AREA_TIMEPOINTS,
+                    within=NonNegativeReals,
                 )
                 # constrain reserve provision within available slack
                 m.Limit_HawaiiStorageSpinningReserveUp = Constraint(
                     m.BALANCING_AREA_TIMEPOINTS,
-                    rule=lambda m, ba, tp:
-                        sum(
-                            m.HawaiiStorageSpinningReserveUp[rt, ba, tp]
-                            for rt in m.HI_STORAGE_SPINNING_RESERVE_TYPES
-                        ) <= m.HawaiiStorageSlackUp[ba, tp]
+                    rule=lambda m, ba, tp: sum(
+                        m.HawaiiStorageSpinningReserveUp[rt, ba, tp]
+                        for rt in m.HI_STORAGE_SPINNING_RESERVE_TYPES
+                    )
+                    <= m.HawaiiStorageSlackUp[ba, tp],
                 )
                 m.Limit_HawaiiStorageSpinningReserveDown = Constraint(
                     m.BALANCING_AREA_TIMEPOINTS,
-                    rule=lambda m, ba, tp:
-                        sum(
-                            m.HawaiiStorageSpinningReserveDown[rt, ba, tp]
-                            for rt in m.HI_STORAGE_SPINNING_RESERVE_TYPES
-                        ) <= m.HawaiiStorageSlackDown[ba, tp]
+                    rule=lambda m, ba, tp: sum(
+                        m.HawaiiStorageSpinningReserveDown[rt, ba, tp]
+                        for rt in m.HI_STORAGE_SPINNING_RESERVE_TYPES
+                    )
+                    <= m.HawaiiStorageSlackDown[ba, tp],
                 )
-                m.Spinning_Reserve_Up_Provisions.append('HawaiiStorageSpinningReserveUp')
-                m.Spinning_Reserve_Down_Provisions.append('HawaiiStorageSpinningReserveDown')
+                m.Spinning_Reserve_Up_Provisions.append(
+                    "HawaiiStorageSpinningReserveUp"
+                )
+                m.Spinning_Reserve_Down_Provisions.append(
+                    "HawaiiStorageSpinningReserveDown"
+                )
             else:
                 # using older formulation, only one type of spinning reserves, indexed by balancing area, timepoint
-                if m.options.hawaii_storage_reserve_types != ['spinning']:
+                if m.options.hawaii_storage_reserve_types != ["spinning"]:
                     raise ValueError(
                         'Unable to use reserve types other than "spinning" with simple spinning reserves module.'
                     )
-                m.Spinning_Reserve_Up_Provisions.append('HawaiiStorageSlackUp')
-                m.Spinning_Reserve_Down_Provisions.append('HawaiiStorageSlackDown')
+                m.Spinning_Reserve_Up_Provisions.append("HawaiiStorageSlackUp")
+                m.Spinning_Reserve_Down_Provisions.append("HawaiiStorageSlackDown")

--- a/switch_model/hawaii/reserves.py
+++ b/switch_model/hawaii/reserves.py
@@ -8,17 +8,33 @@ from pyomo.environ import *
 
 # TODO: use standard reserves module for this
 
+
 def define_arguments(argparser):
-    argparser.add_argument('--reserves-from-storage', action='store_true', default=True,
-        help="Allow storage (batteries and hydrogen) to provide up- and down-reserves.")
-    argparser.add_argument('--no-reserves-from-storage', dest='reserves_from_storage',
-        action='store_false',
-        help="Don't allow storage (batteries and hydrogen) to provide up- and down-reserves.")
-    argparser.add_argument('--reserves-from-demand-response', action='store_true', default=True,
-        help="Allow demand response to provide up- and down-reserves.")
-    argparser.add_argument('--no-reserves-from-demand-response', dest='reserves_from_demand_response',
-        action='store_false',
-        help="Don't allow demand response to provide up- and down-reserves.")
+    argparser.add_argument(
+        "--reserves-from-storage",
+        action="store_true",
+        default=True,
+        help="Allow storage (batteries and hydrogen) to provide up- and down-reserves.",
+    )
+    argparser.add_argument(
+        "--no-reserves-from-storage",
+        dest="reserves_from_storage",
+        action="store_false",
+        help="Don't allow storage (batteries and hydrogen) to provide up- and down-reserves.",
+    )
+    argparser.add_argument(
+        "--reserves-from-demand-response",
+        action="store_true",
+        default=True,
+        help="Allow demand response to provide up- and down-reserves.",
+    )
+    argparser.add_argument(
+        "--no-reserves-from-demand-response",
+        dest="reserves_from_demand_response",
+        action="store_false",
+        help="Don't allow demand response to provide up- and down-reserves.",
+    )
+
 
 def define_components(m):
     """
@@ -33,19 +49,15 @@ def define_components(m):
     # TODO: add batteries, hydrogen and pumped storage to this
     m.FIRM_GENS = Set(
         initialize=m.GENERATION_PROJECTS,
-        #filter=lambda m, p: m.gen_energy_source[p] not in ['Wind', 'Solar']
+        # filter=lambda m, p: m.gen_energy_source[p] not in ['Wind', 'Solar']
     )
-    m.FIRM_GEN_TPS = Set(
-        initialize=m.GEN_TPS,
-        filter=lambda m, p, tp: p in m.FIRM_GENS
-    )
+    m.FIRM_GEN_TPS = Set(initialize=m.GEN_TPS, filter=lambda m, p, tp: p in m.FIRM_GENS)
     m.CONTINGENCY_GENS = Set(
         initialize=m.GENERATION_PROJECTS,
-        filter=lambda m, p: p in m.DISCRETELY_SIZED_GENS
+        filter=lambda m, p: p in m.DISCRETELY_SIZED_GENS,
     )
     m.CONTINGENCY_GEN_TPS = Set(
-        initialize=m.GEN_TPS,
-        filter=lambda m, p, tp: p in m.CONTINGENCY_GENS
+        initialize=m.GEN_TPS, filter=lambda m, p, tp: p in m.CONTINGENCY_GENS
     )
 
     # Calculate spinning reserve requirements.
@@ -57,31 +69,42 @@ def define_components(m):
     # TODO: supply these parameters in input files
 
     # regulating reserves required, as fraction of potential output (up to limit)
-    m.regulating_reserve_fraction = Param(['CentralTrackingPV', 'DistPV', 'OnshoreWind', 'OffshoreWind'], initialize={
-        'CentralTrackingPV': 1.0,
-        'DistPV': 1.0, # 0.81270193,
-        'OnshoreWind': 1.0,
-        'OffshoreWind': 1.0, # assumed equal to OnshoreWind
-    })
+    m.regulating_reserve_fraction = Param(
+        ["CentralTrackingPV", "DistPV", "OnshoreWind", "OffshoreWind"],
+        initialize={
+            "CentralTrackingPV": 1.0,
+            "DistPV": 1.0,  # 0.81270193,
+            "OnshoreWind": 1.0,
+            "OffshoreWind": 1.0,  # assumed equal to OnshoreWind
+        },
+    )
     # maximum regulating reserves required, as fraction of installed capacity
-    m.regulating_reserve_limit = Param(['CentralTrackingPV', 'DistPV', 'OnshoreWind', 'OffshoreWind'], initialize={
-        'CentralTrackingPV': 0.21288916,
-        'DistPV': 0.21288916, # 0.14153171,
-        'OnshoreWind': 0.21624407,
-        'OffshoreWind': 0.21624407, # assumed equal to OnshoreWind
-    })
+    m.regulating_reserve_limit = Param(
+        ["CentralTrackingPV", "DistPV", "OnshoreWind", "OffshoreWind"],
+        initialize={
+            "CentralTrackingPV": 0.21288916,
+            "DistPV": 0.21288916,  # 0.14153171,
+            "OnshoreWind": 0.21624407,
+            "OffshoreWind": 0.21624407,  # assumed equal to OnshoreWind
+        },
+    )
     # more conservative values (found by giving 10x weight to times when we provide less reserves than GE):
     # [1., 1., 1., 0.25760558, 0.18027923, 0.49123101]
 
-    m.RegulatingReserveRequirementMW = Expression(m.TIMEPOINTS, rule=lambda m, tp: sum(
-        m.GenCapacity[g, m.tp_period[tp]]
-        * min(
-            m.regulating_reserve_fraction[m.gen_tech[g]] * m.gen_max_capacity_factor[g, tp],
-            m.regulating_reserve_limit[m.gen_tech[g]]
-        )
+    m.RegulatingReserveRequirementMW = Expression(
+        m.TIMEPOINTS,
+        rule=lambda m, tp: sum(
+            m.GenCapacity[g, m.tp_period[tp]]
+            * min(
+                m.regulating_reserve_fraction[m.gen_tech[g]]
+                * m.gen_max_capacity_factor[g, tp],
+                m.regulating_reserve_limit[m.gen_tech[g]],
+            )
             for g in m.GENERATION_PROJECTS
-                if m.gen_tech[g] in m.regulating_reserve_fraction and (g, tp) in m.GEN_TPS
-    ))
+            if m.gen_tech[g] in m.regulating_reserve_fraction and (g, tp) in m.GEN_TPS
+        ),
+    )
+
 
 def define_dynamic_components(m):
     # these are defined late, so they can check whether various components have been defined by other modules
@@ -98,14 +121,15 @@ def define_dynamic_components(m):
     m.CommitGenFlag = Var(m.CONTINGENCY_GEN_TPS, within=Binary)
     m.Set_CommitGenFlag = Constraint(
         m.CONTINGENCY_GEN_TPS,
-        rule = lambda m, g, tp:
-            m.CommitGen[g, tp] <= m.CommitGenFlag[g, tp] * m.gen_capacity_limit_mw[g]
+        rule=lambda m, g, tp: m.CommitGen[g, tp]
+        <= m.CommitGenFlag[g, tp] * m.gen_capacity_limit_mw[g],
     )
     m.ContingencyReserveUpRequirement_Calculate = Constraint(
         m.CONTINGENCY_GEN_TPS,
         rule=lambda m, g, tp:
-            # m.ContingencyReserveUpRequirement[tp] >= m.CommitGen[g, tp]
-            m.ContingencyReserveUpRequirement[tp] >= m.CommitGenFlag[g, tp] * m.gen_unit_size[g]
+        # m.ContingencyReserveUpRequirement[tp] >= m.CommitGen[g, tp]
+        m.ContingencyReserveUpRequirement[tp]
+        >= m.CommitGenFlag[g, tp] * m.gen_unit_size[g],
     )
 
     m.ContingencyReserveDownRequirement = Var(m.TIMEPOINTS, within=NonNegativeReals)
@@ -119,23 +143,26 @@ def define_dynamic_components(m):
     # So we just assume we could lose 10% of all loads of any type, at any time.)
     m.ContingencyReserveDownRequirement_Calculate = Constraint(
         m.TIMEPOINTS,
-        rule=lambda m, tp:
-            m.ContingencyReserveDownRequirement[tp] >=
-            0.1 * sum(getattr(m, x)[z, tp] for x in m.Zone_Power_Withdrawals for z in m.LOAD_ZONES)
+        rule=lambda m, tp: m.ContingencyReserveDownRequirement[tp]
+        >= 0.1
+        * sum(
+            getattr(m, x)[z, tp] for x in m.Zone_Power_Withdrawals for z in m.LOAD_ZONES
+        ),
     )
 
     # Calculate total spinning reserve requirements
-    m.SpinningReserveUpRequirement = Expression(m.TIMEPOINTS, rule=lambda m, tp:
-        m.RegulatingReserveRequirementMW[tp] + m.ContingencyReserveUpRequirement[tp]
+    m.SpinningReserveUpRequirement = Expression(
+        m.TIMEPOINTS,
+        rule=lambda m, tp: m.RegulatingReserveRequirementMW[tp]
+        + m.ContingencyReserveUpRequirement[tp],
     )
-    m.SpinningReserveDownRequirement = Expression(m.TIMEPOINTS, rule=lambda m, tp:
-        m.ContingencyReserveDownRequirement[tp]
+    m.SpinningReserveDownRequirement = Expression(
+        m.TIMEPOINTS, rule=lambda m, tp: m.ContingencyReserveDownRequirement[tp]
     )
-
 
     # Available reserves
     def expr(m, tp):
-        STORAGE_GENS = getattr(m, 'STORAGE_GENS', [])
+        STORAGE_GENS = getattr(m, "STORAGE_GENS", [])
         # all regular generators; omit storage because they'll be added separately if needed
         avail = sum(
             m.DispatchSlackUp[g, tp]
@@ -144,9 +171,9 @@ def define_dynamic_components(m):
         )
         if m.options.reserves_from_storage:
             # hawaii battery and hydrogen modules
-            if hasattr(m, 'BatterySlackUp'):
+            if hasattr(m, "BatterySlackUp"):
                 avail += sum(m.BatterySlackUp[z, tp] for z in m.LOAD_ZONES)
-            if hasattr(m, 'HydrogenSlackUp'):
+            if hasattr(m, "HydrogenSlackUp"):
                 avail += sum(m.HydrogenSlackUp[z, tp] for z in m.LOAD_ZONES)
             # standard storage module (can stop charging and raise output to max)
             avail += sum(
@@ -155,21 +182,29 @@ def define_dynamic_components(m):
                 if (g, tp) in m.GEN_TPS
             )
         if m.options.reserves_from_demand_response:
-            if hasattr(m, 'DemandUpReserves'):
+            if hasattr(m, "DemandUpReserves"):
                 avail += sum(m.DemandUpReserves[z, tp] for z in m.LOAD_ZONES)
-            if hasattr(m, 'ShiftDemand'):
-                avail += sum(m.ShiftDemand[z, tp] -  m.ShiftDemand[z, tp].lb for z in m.LOAD_ZONES)
-            if hasattr(m, 'ChargeEVs') and hasattr(m.options, 'ev_timing') and m.options.ev_timing=='optimal':
+            if hasattr(m, "ShiftDemand"):
+                avail += sum(
+                    m.ShiftDemand[z, tp] - m.ShiftDemand[z, tp].lb for z in m.LOAD_ZONES
+                )
+            if (
+                hasattr(m, "ChargeEVs")
+                and hasattr(m.options, "ev_timing")
+                and m.options.ev_timing == "optimal"
+            ):
                 avail += sum(m.ChargeEVs[z, tp] for z in m.LOAD_ZONES)
-        if hasattr(m, 'UnservedUpReserves'):
+        if hasattr(m, "UnservedUpReserves"):
             avail += m.UnservedUpReserves[tp]
         # if tp == 2045012604:
         #     print "inspect avail to see up reserve calculation"
         #     import pdb; pdb.set_trace()
         return avail
+
     m.SpinningReservesUpAvailable = Expression(m.TIMEPOINTS, rule=expr)
+
     def expr(m, tp):
-        STORAGE_GENS = getattr(m, 'STORAGE_GENS', [])
+        STORAGE_GENS = getattr(m, "STORAGE_GENS", [])
         # all regular generators; omit storage because they'll be added separately if needed
         avail = sum(
             m.DispatchSlackDown[g, tp]
@@ -177,9 +212,9 @@ def define_dynamic_components(m):
             if (g, tp) in m.GEN_TPS and g not in STORAGE_GENS
         )
         if m.options.reserves_from_storage:
-            if hasattr(m, 'BatterySlackDown'):
+            if hasattr(m, "BatterySlackDown"):
                 avail += sum(m.BatterySlackDown[z, tp] for z in m.LOAD_ZONES)
-            if hasattr(m, 'HydrogenSlackDown'):
+            if hasattr(m, "HydrogenSlackDown"):
                 avail += sum(m.HydrogenSlackDown[z, tp] for z in m.LOAD_ZONES)
             # standard storage module (can stop producing power and raise charging to max)
             avail += sum(
@@ -191,31 +226,37 @@ def define_dynamic_components(m):
             )
 
         if m.options.reserves_from_demand_response:
-            if hasattr(m, 'DemandDownReserves'):
+            if hasattr(m, "DemandDownReserves"):
                 avail += sum(m.DemandDownReserves[z, tp] for z in m.LOAD_ZONES)
-            if hasattr(m, 'ShiftDemand'):
+            if hasattr(m, "ShiftDemand"):
                 # avail += sum(m.ShiftDemand[z, tp].ub - m.ShiftDemand[z, tp] for z in m.LOAD_ZONES)
                 avail += sum(
-                    24/3 * m.demand_response_max_share * m.zone_demand_mw[z, tp]
+                    24 / 3 * m.demand_response_max_share * m.zone_demand_mw[z, tp]
                     - m.ShiftDemand[z, tp]
                     for z in m.LOAD_ZONES
                 )
             # note: we currently ignore down-reserves (option of increasing consumption)
             # from EVs since it's not clear how high they could go; we could revisit this if
             # down-reserves have a positive price at equilibrium (probabably won't)
-        if hasattr(m, 'UnservedDownReserves'):
+        if hasattr(m, "UnservedDownReserves"):
             avail += m.UnservedDownReserves[tp]
         return avail
+
     m.SpinningReservesDownAvailable = Expression(m.TIMEPOINTS, rule=expr)
 
     # Meet the reserve requirements (we use zero on RHS to enforce the right sign for the duals)
-    m.Satisfy_Spinning_Reserve_Up_Requirement = Constraint(m.TIMEPOINTS, rule=lambda m, tp:
-        m.SpinningReservesUpAvailable[tp] - m.SpinningReserveUpRequirement[tp] >= 0
+    m.Satisfy_Spinning_Reserve_Up_Requirement = Constraint(
+        m.TIMEPOINTS,
+        rule=lambda m, tp: m.SpinningReservesUpAvailable[tp]
+        - m.SpinningReserveUpRequirement[tp]
+        >= 0,
     )
-    m.Satisfy_Spinning_Reserve_Down_Requirement = Constraint(m.TIMEPOINTS, rule=lambda m, tp:
-        m.SpinningReservesDownAvailable[tp] - m.SpinningReserveDownRequirement[tp] >= 0
+    m.Satisfy_Spinning_Reserve_Down_Requirement = Constraint(
+        m.TIMEPOINTS,
+        rule=lambda m, tp: m.SpinningReservesDownAvailable[tp]
+        - m.SpinningReserveDownRequirement[tp]
+        >= 0,
     )
-
 
     # NOTE: the shutdown constraints below are not used, because they conflict with
     # the baseload status set in build_scenario_data.py. You should set the plant type
@@ -253,9 +294,8 @@ def define_dynamic_components(m):
     #     print list(m.CYCLING_PLANTS_TIMEPOINTS)
     # m.ShowCyclingPlants = BuildAction(rule=show_it)
 
+
 # def load_inputs(m, switch_data, inputs_dir):
 #     switch_data.load_aug(
 #         filename=os.path.join(inputs_dir, 'reserve_requirements.csv'),
 #         param=(m.RegulatingReserveRequirementMW))
-
-

--- a/switch_model/hawaii/rps.py
+++ b/switch_model/hawaii/rps.py
@@ -7,47 +7,91 @@ from pprint import pprint
 import switch_model.utilities as utilities
 from .util import get
 
+
 def define_arguments(argparser):
-    argparser.add_argument('--biofuel-limit', type=float, default=1.0,
-        help="Maximum fraction of power that can be obtained from biofuel in any period (default=1.0)")
-    argparser.add_argument('--biofuel-switch-threshold', type=float, default=1.0,
-        help="RPS level at which all thermal plants switch to biofuels (0.0-1.0, default=1.0); use with --rps-allocation fuel_switch_at_high_rps")
-    argparser.add_argument('--rps-activate', default='activate',
-        dest='rps_level', action='store_const', const='activate',
-        help="Activate RPS (on by default).")
-    argparser.add_argument('--rps-deactivate',
-        dest='rps_level', action='store_const', const='deactivate',
-        help="Deactivate RPS.")
-    argparser.add_argument('--rps-exact',
-        dest='rps_level', action='store_const', const='exact',
-        help="Require exact satisfaction of RPS target (no excess or shortfall).")
-    argparser.add_argument('--rps-no-new-renewables',
-        dest='rps_level', action='store_const', const='no_new_renewables',
-        help="Deactivate RPS and don't allow any new renewables except to replace existing capacity.")
-    argparser.add_argument('--rps-no-new-wind', action='store_true', default=False,
-        help="Don't allow any new wind capacity except to replace existing capacity.")
-    argparser.add_argument('--rps-no-wind', action='store_true', default=False,
-        help="Don't allow any new wind capacity or replacement of existing capacity.")
-    argparser.add_argument('--rps-prefer-dist-pv', action='store_true', default=False,
-        help="Don't allow any new large solar capacity unless 90%% of distributed PV ('*DistPV') capacity has been developed.")
     argparser.add_argument(
-        '--rps-allocation', default=None,
+        "--biofuel-limit",
+        type=float,
+        default=1.0,
+        help="Maximum fraction of power that can be obtained from biofuel in any period (default=1.0)",
+    )
+    argparser.add_argument(
+        "--biofuel-switch-threshold",
+        type=float,
+        default=1.0,
+        help="RPS level at which all thermal plants switch to biofuels (0.0-1.0, default=1.0); use with --rps-allocation fuel_switch_at_high_rps",
+    )
+    argparser.add_argument(
+        "--rps-activate",
+        default="activate",
+        dest="rps_level",
+        action="store_const",
+        const="activate",
+        help="Activate RPS (on by default).",
+    )
+    argparser.add_argument(
+        "--rps-deactivate",
+        dest="rps_level",
+        action="store_const",
+        const="deactivate",
+        help="Deactivate RPS.",
+    )
+    argparser.add_argument(
+        "--rps-exact",
+        dest="rps_level",
+        action="store_const",
+        const="exact",
+        help="Require exact satisfaction of RPS target (no excess or shortfall).",
+    )
+    argparser.add_argument(
+        "--rps-no-new-renewables",
+        dest="rps_level",
+        action="store_const",
+        const="no_new_renewables",
+        help="Deactivate RPS and don't allow any new renewables except to replace existing capacity.",
+    )
+    argparser.add_argument(
+        "--rps-no-new-wind",
+        action="store_true",
+        default=False,
+        help="Don't allow any new wind capacity except to replace existing capacity.",
+    )
+    argparser.add_argument(
+        "--rps-no-wind",
+        action="store_true",
+        default=False,
+        help="Don't allow any new wind capacity or replacement of existing capacity.",
+    )
+    argparser.add_argument(
+        "--rps-prefer-dist-pv",
+        action="store_true",
+        default=False,
+        help="Don't allow any new large solar capacity unless 90%% of distributed PV ('*DistPV') capacity has been developed.",
+    )
+    argparser.add_argument(
+        "--rps-allocation",
+        default=None,
         choices=[
-            'quadratic',
-            'fuel_switch_by_period', 'fuel_switch_by_timeseries',
-            'full_load_heat_rate',
-            'split_commit',
-            'relaxed_split_commit',
-            'fuel_switch_at_high_rps',
+            "quadratic",
+            "fuel_switch_by_period",
+            "fuel_switch_by_timeseries",
+            "full_load_heat_rate",
+            "split_commit",
+            "relaxed_split_commit",
+            "fuel_switch_at_high_rps",
         ],
         help="Method to use to allocate power output among fuels. Default is fuel_switch_by_period for models "
-            + "with unit commitment, full_load_heat_rate for models without."
+        + "with unit commitment, full_load_heat_rate for models without.",
     )
-    argparser.add_argument('--rps-targets', nargs='*', default=None,
+    argparser.add_argument(
+        "--rps-targets",
+        nargs="*",
+        default=None,
         help="Targets to use for RPS, specified as --rps-targets year1 level1 year2 level2 ..., "
         "where years are transition years and levels are fractions between 0 and 1. "
-        "If not specified, values from rps_targets.csv will be used."
+        "If not specified, values from rps_targets.csv will be used.",
     )
+
 
 # TODO: make this work with progressive hedging as follows:
 # add a variable indexed over all weather scenarios and all cost scenarios,
@@ -62,18 +106,19 @@ def define_arguments(argparser):
 # Could do the same with hydrogen storage: require average hydrogen stored across all scenarios
 # to be less than the size of the storage built.
 
-def define_components(m):
-    """
 
-    """
+def define_components(m):
+    """"""
     ###################
     # RPS calculation
     ##################
 
     m.f_rps_eligible = Param(m.FUELS, within=Binary, default=False)
 
-    m.RPS_ENERGY_SOURCES = Set(initialize=lambda m:
-        [s for s in m.NON_FUEL_ENERGY_SOURCES if s.lower() != 'battery']
+    m.RPS_ENERGY_SOURCES = Set(
+        initialize=lambda m: [
+            s for s in m.NON_FUEL_ENERGY_SOURCES if s.lower() != "battery"
+        ]
         + [f for f in m.FUELS if m.f_rps_eligible[f]]
     )
 
@@ -82,8 +127,11 @@ def define_components(m):
 
     def rps_target_for_period_rule(m, p):
         """find the last target that is in effect before the _end_ of the period"""
-        latest_target = max(y for y in m.RPS_YEARS if y < m.period_start[p] + m.period_length_years[p])
+        latest_target = max(
+            y for y in m.RPS_YEARS if y < m.period_start[p] + m.period_length_years[p]
+        )
         return m.rps_target[latest_target]
+
     m.rps_target_for_period = Param(m.PERIODS, initialize=rps_target_for_period_rule)
 
     # maximum share of (bio)fuels in rps
@@ -98,7 +146,7 @@ def define_components(m):
         rule=lambda m, g: (
             m.GenCapacity[g, m.PERIODS.first()]
             - get(m.BuildGen, (g, m.PERIODS.first()), 0)
-        )
+        ),
     )
 
     # Define DispatchGenRenewableMW, which shows the amount of power produced
@@ -106,12 +154,13 @@ def define_components(m):
     define_DispatchGenRenewableMW(m)
 
     # calculate amount of power produced from renewable fuels during each period
-    m.RPSFuelPower = Expression(m.PERIODS, rule=lambda m, per:
-        sum(
+    m.RPSFuelPower = Expression(
+        m.PERIODS,
+        rule=lambda m, per: sum(
             m.DispatchGenRenewableMW[g, tp] * m.tp_weight[tp]
             for g in m.FUEL_BASED_GENS
             for tp in m.TPS_FOR_GEN_IN_PERIOD[g, per]
-        )
+        ),
     )
 
     # Note: this rule ignores pumped hydro and batteries, so it could be gamed by producing extra
@@ -121,92 +170,111 @@ def define_components(m):
     # sum(getattr(m, component)[z, t] for z in m.LOAD_ZONES) for component in m.Zone_Power_Injections)
 
     # power production that can be counted toward the RPS each period
-    m.RPSEligiblePower = Expression(m.PERIODS, rule=lambda m, per:
-        m.RPSFuelPower[per]
-        +
-        sum(
+    m.RPSEligiblePower = Expression(
+        m.PERIODS,
+        rule=lambda m, per: m.RPSFuelPower[per]
+        + sum(
             m.DispatchGen[g, tp] * m.tp_weight[tp]
-            for f in m.NON_FUEL_ENERGY_SOURCES if f in m.RPS_ENERGY_SOURCES
+            for f in m.NON_FUEL_ENERGY_SOURCES
+            if f in m.RPS_ENERGY_SOURCES
             for g in m.GENS_BY_NON_FUEL_ENERGY_SOURCE[f]
             for tp in m.TPS_FOR_GEN_IN_PERIOD[g, per]
-        )
+        ),
     )
 
     # total power production each period (against which RPS is measured)
     # note: we exclude production from storage
-    m.RPSTotalPower = Expression(m.PERIODS, rule=lambda m, per:
-        sum(
+    m.RPSTotalPower = Expression(
+        m.PERIODS,
+        rule=lambda m, per: sum(
             m.DispatchGen[g, tp] * m.tp_weight[tp]
-            for g in m.GENERATION_PROJECTS if g not in getattr(m, 'STORAGE_GENS', [])
+            for g in m.GENERATION_PROJECTS
+            if g not in getattr(m, "STORAGE_GENS", [])
             for tp in m.TPS_FOR_GEN_IN_PERIOD[g, per]
-        )
+        ),
     )
 
     # note: we completely skip creating the constraint if the RPS is not activated.
     # this makes it easy for other modules to check whether there's an RPS in effect
     # (if we deactivated the RPS after it is constructed, then other modules would
     # have to postpone checking until then)
-    if m.options.rps_level in {'activate', 'exact'}:
-        if m.options.rps_level == 'exact':
-            rule = lambda m, p: m.RPSEligiblePower[p] == m.rps_target_for_period[p] * m.RPSTotalPower[p]
+    if m.options.rps_level in {"activate", "exact"}:
+        if m.options.rps_level == "exact":
+            rule = (
+                lambda m, p: m.RPSEligiblePower[p]
+                == m.rps_target_for_period[p] * m.RPSTotalPower[p]
+            )
         else:
-            rule = lambda m, p: m.RPSEligiblePower[p] >= m.rps_target_for_period[p] * m.RPSTotalPower[p]
+            rule = (
+                lambda m, p: m.RPSEligiblePower[p]
+                >= m.rps_target_for_period[p] * m.RPSTotalPower[p]
+            )
         m.RPS_Enforce = Constraint(m.PERIODS, rule=rule)
-    elif m.options.rps_level == 'no_new_renewables':
+    elif m.options.rps_level == "no_new_renewables":
         # prevent construction of any new exclusively-renewable projects, but allow
         # replacement of existing ones
         # (doesn't ban use of biofuels in existing or multi-fuel projects, but that could
         # be done with --biofuel-limit 0)
-        m.No_New_Renewables = Constraint(m.NEW_GEN_BLD_YRS, rule=lambda m, g, bld_yr:
-            (m.GenCapacity[g, bld_yr] <= m.gen_pre_existing_capacity[g])
+        m.No_New_Renewables = Constraint(
+            m.NEW_GEN_BLD_YRS,
+            rule=lambda m, g, bld_yr: (
+                m.GenCapacity[g, bld_yr] <= m.gen_pre_existing_capacity[g]
+            )
             if m.gen_energy_source[g] in m.RPS_ENERGY_SOURCES
-            else Constraint.Skip
+            else Constraint.Skip,
         )
 
-    wind_energy_sources = {'WND'}
+    wind_energy_sources = {"WND"}
     if m.options.rps_no_new_wind:
         # limit wind to existing capacity
-        m.No_New_Wind = Constraint(m.NEW_GEN_BLD_YRS, rule=lambda m, g, bld_yr:
-            (m.GenCapacity[g, bld_yr] <= m.gen_pre_existing_capacity[g])
+        m.No_New_Wind = Constraint(
+            m.NEW_GEN_BLD_YRS,
+            rule=lambda m, g, bld_yr: (
+                m.GenCapacity[g, bld_yr] <= m.gen_pre_existing_capacity[g]
+            )
             if m.gen_energy_source[g] in wind_energy_sources
-            else Constraint.Skip
+            else Constraint.Skip,
         )
     if m.options.rps_no_wind:
         # don't build any new capacity or replace existing
-        m.No_Wind = Constraint(m.NEW_GEN_BLD_YRS, rule=lambda m, g, bld_yr:
-            (m.BuildGen[g, bld_yr] == 0.0)
+        m.No_Wind = Constraint(
+            m.NEW_GEN_BLD_YRS,
+            rule=lambda m, g, bld_yr: (m.BuildGen[g, bld_yr] == 0.0)
             if m.gen_energy_source[g] in wind_energy_sources
-            else Constraint.Skip
+            else Constraint.Skip,
         )
 
     if m.options.rps_prefer_dist_pv:
-        m.DIST_PV_GENS = Set(initialize=lambda m: [
-            g for g in m.GENS_BY_NON_FUEL_ENERGY_SOURCE['SUN']
-            if 'DistPV' in m.gen_tech[g]
-        ])
-        m.LARGE_PV_GENS = Set(initialize=lambda m: [
-            g for g in m.GENS_BY_NON_FUEL_ENERGY_SOURCE['SUN']
-            if g not in m.DIST_PV_GENS
-        ])
+        m.DIST_PV_GENS = Set(
+            initialize=lambda m: [
+                g
+                for g in m.GENS_BY_NON_FUEL_ENERGY_SOURCE["SUN"]
+                if "DistPV" in m.gen_tech[g]
+            ]
+        )
+        m.LARGE_PV_GENS = Set(
+            initialize=lambda m: [
+                g
+                for g in m.GENS_BY_NON_FUEL_ENERGY_SOURCE["SUN"]
+                if g not in m.DIST_PV_GENS
+            ]
+        )
         # LargePVAllowed must be 1 to allow large PV to be built
-        m.LargePVAllowed = Var(m.PERIODS, within=Binary) #
+        m.LargePVAllowed = Var(m.PERIODS, within=Binary)  #
         # LargePVAllowed can only be 1 if 90% of the available rooftop PV has been built
         m.Set_LargePVAllowed = Constraint(
             m.PERIODS,
-            rule=lambda m, p:
-                sum(m.GenCapacity[g, p] for g in m.DIST_PV_GENS)
-                >=
-                m.LargePVAllowed[p]
-                * 0.9
-                * sum(m.gen_capacity_limit_mw[g] for g in m.DIST_PV_GENS)
+            rule=lambda m, p: sum(m.GenCapacity[g, p] for g in m.DIST_PV_GENS)
+            >= m.LargePVAllowed[p]
+            * 0.9
+            * sum(m.gen_capacity_limit_mw[g] for g in m.DIST_PV_GENS),
         )
         m.Apply_LargePVAllowed = Constraint(
-            m.LARGE_PV_GENS, m.PERIODS,
-            rule=lambda m, g, p:
-                m.GenCapacity[g, p]
-                <=
-                m.LargePVAllowed[p] * m.gen_capacity_limit_mw[g]
-                + m.gen_pre_existing_capacity[g]
+            m.LARGE_PV_GENS,
+            m.PERIODS,
+            rule=lambda m, g, p: m.GenCapacity[g, p]
+            <= m.LargePVAllowed[p] * m.gen_capacity_limit_mw[g]
+            + m.gen_pre_existing_capacity[g],
         )
 
     # Don't allow (bio)fuels to provide more than a certain percentage of the system's energy
@@ -229,9 +297,12 @@ def define_components(m):
     # transmission losses, the cycling costs for batteries are too high and pumped storage is only
     # adopted on a small scale.
 
-    m.RPS_Fuel_Cap = Constraint(m.PERIODS, rule = lambda m, per:
-        m.RPSFuelPower[per] <= m.rps_fuel_limit * m.RPSTotalPower[per]
+    m.RPS_Fuel_Cap = Constraint(
+        m.PERIODS,
+        rule=lambda m, per: m.RPSFuelPower[per]
+        <= m.rps_fuel_limit * m.RPSTotalPower[per],
     )
+
 
 def define_DispatchGenRenewableMW(m):
     # Define DispatchGenRenewableMW, which shows the amount of power produced
@@ -240,30 +311,35 @@ def define_DispatchGenRenewableMW(m):
     # This can get complex when a project uses multiple fuels and incremental
     # heat rate curves.
     if m.options.rps_allocation is None:
-        if hasattr(m, 'FUEL_USE_SEGMENTS_FOR_GEN'):
+        if hasattr(m, "FUEL_USE_SEGMENTS_FOR_GEN"):
             # using heat rate curves and possibly startup fuel;
             # have to do more advanced allocation of power to fuels
-            m.options.rps_allocation = 'fuel_switch_by_period'
+            m.options.rps_allocation = "fuel_switch_by_period"
         else:
             # only using full load heat rate; use simpler allocation strategy
-            m.options.rps_allocation = 'full_load_heat_rate'
+            m.options.rps_allocation = "full_load_heat_rate"
         if m.options.verbose:
-            print("Using {} method to allocate DispatchGenRenewableMW".format(m.options.rps_allocation))
+            print(
+                "Using {} method to allocate DispatchGenRenewableMW".format(
+                    m.options.rps_allocation
+                )
+            )
 
-    if m.options.rps_allocation == 'full_load_heat_rate':
+    if m.options.rps_allocation == "full_load_heat_rate":
         simple_DispatchGenRenewableMW(m)
-    elif m.options.rps_allocation == 'quadratic':
+    elif m.options.rps_allocation == "quadratic":
         quadratic_DispatchGenRenewableMW(m)
-    elif m.options.rps_allocation == 'fuel_switch_by_period':
+    elif m.options.rps_allocation == "fuel_switch_by_period":
         binary_by_period_DispatchGenRenewableMW(m)
-    elif m.options.rps_allocation == 'fuel_switch_by_timeseries':
+    elif m.options.rps_allocation == "fuel_switch_by_timeseries":
         binary_by_timeseries_DispatchGenRenewableMW(m)
-    elif m.options.rps_allocation == 'split_commit':
+    elif m.options.rps_allocation == "split_commit":
         split_commit_DispatchGenRenewableMW(m)
-    elif m.options.rps_allocation == 'relaxed_split_commit':
+    elif m.options.rps_allocation == "relaxed_split_commit":
         relaxed_split_commit_DispatchGenRenewableMW(m)
-    elif m.options.rps_allocation == 'fuel_switch_at_high_rps':
+    elif m.options.rps_allocation == "fuel_switch_at_high_rps":
         fuel_switch_at_high_rps_DispatchGenRenewableMW(m)
+
 
 def simple_DispatchGenRenewableMW(m):
     # Allocate the power produced during each timepoint among the fuels.
@@ -272,13 +348,10 @@ def simple_DispatchGenRenewableMW(m):
     # multiple fuels in the same project at the same time.
     m.DispatchGenRenewableMW = Expression(
         m.FUEL_BASED_GEN_TPS,
-        rule=lambda m, g, t:
-            sum(
-                m.GenFuelUseRate[g, t, f]
-                    for f in m.FUELS_FOR_GEN[g]
-                        if m.f_rps_eligible[f]
-            )
-            / m.gen_full_load_heat_rate[g]
+        rule=lambda m, g, t: sum(
+            m.GenFuelUseRate[g, t, f] for f in m.FUELS_FOR_GEN[g] if m.f_rps_eligible[f]
+        )
+        / m.gen_full_load_heat_rate[g],
     )
 
 
@@ -301,77 +374,78 @@ def split_commit_DispatchGenRenewableMW(m):
 
     # count amount of renewable power produced from project
     m.DispatchGenRenewableMW = Var(m.FUEL_BASED_GEN_TPS, within=NonNegativeReals)
-    m.DispatchGenRenewableMW_Cap = Constraint(m.FUEL_BASED_GEN_TPS,
-        rule = lambda m, g, tp:
-            m.DispatchGenRenewableMW[g, tp] <= m.DispatchGen[g, tp]
+    m.DispatchGenRenewableMW_Cap = Constraint(
+        m.FUEL_BASED_GEN_TPS,
+        rule=lambda m, g, tp: m.DispatchGenRenewableMW[g, tp] <= m.DispatchGen[g, tp],
     )
     # a portion of every startup and shutdown must be designated as renewable
     m.CommitGenRenewable = Var(m.FUEL_BASED_GEN_TPS, within=NonNegativeReals)
-    m.CommitGenRenewable_Cap = Constraint(m.FUEL_BASED_GEN_TPS,
-        rule = lambda m, g, tp:
-            m.CommitGenRenewable[g, tp] <= m.CommitGen[g, tp]
+    m.CommitGenRenewable_Cap = Constraint(
+        m.FUEL_BASED_GEN_TPS,
+        rule=lambda m, g, tp: m.CommitGenRenewable[g, tp] <= m.CommitGen[g, tp],
     )
     m.StartupGenCapacityRenewable = Var(m.FUEL_BASED_GEN_TPS, within=NonNegativeReals)
-    m.StartupGenCapacityRenewable_Cap = Constraint(m.FUEL_BASED_GEN_TPS,
-        rule = lambda m, g, tp:
-            m.StartupGenCapacityRenewable[g, tp] <= m.StartupGenCapacity[g, tp]
+    m.StartupGenCapacityRenewable_Cap = Constraint(
+        m.FUEL_BASED_GEN_TPS,
+        rule=lambda m, g, tp: m.StartupGenCapacityRenewable[g, tp]
+        <= m.StartupGenCapacity[g, tp],
     )
     m.ShutdownGenCapacityRenewable = Var(m.FUEL_BASED_GEN_TPS, within=NonNegativeReals)
-    m.ShutdownGenCapacityRenewable_Cap = Constraint(m.FUEL_BASED_GEN_TPS,
-        rule = lambda m, g, tp:
-            m.ShutdownGenCapacityRenewable[g, tp] <= m.ShutdownGenCapacity[g, tp]
+    m.ShutdownGenCapacityRenewable_Cap = Constraint(
+        m.FUEL_BASED_GEN_TPS,
+        rule=lambda m, g, tp: m.ShutdownGenCapacityRenewable[g, tp]
+        <= m.ShutdownGenCapacity[g, tp],
     )
     # chain commitments, startup and shutdown for renewables
     m.Commit_StartupGenCapacity_ShutdownGenCapacity_Consistency_Renewable = Constraint(
         m.FUEL_BASED_GEN_TPS,
-        rule=lambda m, g, tp:
-            m.CommitGenRenewable[g, m.tp_previous[tp]]
-            + m.StartupGenCapacityRenewable[g, tp]
-            - m.ShutdownGenCapacityRenewable[g, tp]
-            == m.CommitGenRenewable[g, tp]
+        rule=lambda m, g, tp: m.CommitGenRenewable[g, m.tp_previous[tp]]
+        + m.StartupGenCapacityRenewable[g, tp]
+        - m.ShutdownGenCapacityRenewable[g, tp]
+        == m.CommitGenRenewable[g, tp],
     )
     # must use committed capacity for renewable production
     m.Enforce_Dispatch_Upper_Limit_Renewable = Constraint(
         m.FUEL_BASED_GEN_TPS,
-        rule=lambda m, g, tp:
-            m.DispatchGenRenewableMW[g, tp] <= m.CommitGenRenewable[g, tp]
+        rule=lambda m, g, tp: m.DispatchGenRenewableMW[g, tp]
+        <= m.CommitGenRenewable[g, tp],
     )
     # can't dispatch non-renewable capacity below its lower limit
     m.Enforce_Dispatch_Lower_Limit_Non_Renewable = Constraint(
         m.FUEL_BASED_GEN_TPS,
-        rule=lambda m, g, tp:
-            (m.DispatchGen[g, tp] - m.DispatchGenRenewableMW[g, tp])
-            >=
-            (m.CommitGen[g, tp] - m.CommitGenRenewable[g, tp])
-            * m.gen_min_load_fraction_TP[g, tp]
+        rule=lambda m, g, tp: (m.DispatchGen[g, tp] - m.DispatchGenRenewableMW[g, tp])
+        >= (m.CommitGen[g, tp] - m.CommitGenRenewable[g, tp])
+        * m.gen_min_load_fraction_TP[g, tp],
     )
     # use standard heat rate calculations for renewable and non-renewable parts
     m.ProjRenewableFuelUseRate_Calculate = Constraint(
         m.GEN_TPS_FUEL_PIECEWISE_CONS_SET,
-        rule=lambda m, g, tp, intercept, incremental_heat_rate:
-            sum(
-                m.GenFuelUseRate[g, tp, f]
-                    for f in m.FUELS_FOR_GEN[g]
-                        if f in m.RPS_ENERGY_SOURCES
-            )
-            >=
-            m.StartupGenCapacityRenewable[g, tp] * m.gen_startup_fuel[g] / m.tp_duration_hrs[tp]
-            + intercept * m.CommitGenRenewable[g, tp]
-            + incremental_heat_rate * m.DispatchGenRenewableMW[g, tp]
+        rule=lambda m, g, tp, intercept, incremental_heat_rate: sum(
+            m.GenFuelUseRate[g, tp, f]
+            for f in m.FUELS_FOR_GEN[g]
+            if f in m.RPS_ENERGY_SOURCES
+        )
+        >= m.StartupGenCapacityRenewable[g, tp]
+        * m.gen_startup_fuel[g]
+        / m.tp_duration_hrs[tp]
+        + intercept * m.CommitGenRenewable[g, tp]
+        + incremental_heat_rate * m.DispatchGenRenewableMW[g, tp],
     )
     m.ProjNonRenewableFuelUseRate_Calculate = Constraint(
         m.GEN_TPS_FUEL_PIECEWISE_CONS_SET,
-        rule=lambda m, g, tp, intercept, incremental_heat_rate:
-            sum(
-                m.GenFuelUseRate[g, tp, f]
-                    for f in m.FUELS_FOR_GEN[g]
-                        if f not in m.RPS_ENERGY_SOURCES
-            )
-            >=
-            (m.StartupGenCapacity[g, tp] - m.StartupGenCapacityRenewable[g, tp]) * m.gen_startup_fuel[g] / m.tp_duration_hrs[tp]
-            + intercept * (m.CommitGen[g, tp] - m.CommitGenRenewable[g, tp])
-            + incremental_heat_rate * (m.DispatchGen[g, tp] - m.DispatchGenRenewableMW[g, tp])
+        rule=lambda m, g, tp, intercept, incremental_heat_rate: sum(
+            m.GenFuelUseRate[g, tp, f]
+            for f in m.FUELS_FOR_GEN[g]
+            if f not in m.RPS_ENERGY_SOURCES
+        )
+        >= (m.StartupGenCapacity[g, tp] - m.StartupGenCapacityRenewable[g, tp])
+        * m.gen_startup_fuel[g]
+        / m.tp_duration_hrs[tp]
+        + intercept * (m.CommitGen[g, tp] - m.CommitGenRenewable[g, tp])
+        + incremental_heat_rate
+        * (m.DispatchGen[g, tp] - m.DispatchGenRenewableMW[g, tp]),
     )
+
 
 def relaxed_split_commit_DispatchGenRenewableMW(m):
     # This is similar to the split_commit approach, but allows startup fuel
@@ -383,24 +457,23 @@ def relaxed_split_commit_DispatchGenRenewableMW(m):
 
     # count amount of renewable power produced from project
     m.DispatchGenRenewableMW = Var(m.FUEL_BASED_GEN_TPS, within=NonNegativeReals)
-    m.DispatchGenRenewableMW_Cap = Constraint(m.FUEL_BASED_GEN_TPS,
-        rule = lambda m, g, tp:
-            m.DispatchGenRenewableMW[g, tp] <= m.DispatchGen[g, tp]
+    m.DispatchGenRenewableMW_Cap = Constraint(
+        m.FUEL_BASED_GEN_TPS,
+        rule=lambda m, g, tp: m.DispatchGenRenewableMW[g, tp] <= m.DispatchGen[g, tp],
     )
     m.StartupGenCapacityRenewable = Var(m.FUEL_BASED_GEN_TPS, within=NonNegativeReals)
-    m.StartupGenCapacityRenewable_Cap = Constraint(m.FUEL_BASED_GEN_TPS,
-        rule = lambda m, g, tp:
-            m.StartupGenCapacityRenewable[g, tp] <= m.StartupGenCapacity[g, tp]
+    m.StartupGenCapacityRenewable_Cap = Constraint(
+        m.FUEL_BASED_GEN_TPS,
+        rule=lambda m, g, tp: m.StartupGenCapacityRenewable[g, tp]
+        <= m.StartupGenCapacity[g, tp],
     )
 
     # can't dispatch non-renewable capacity below its lower limit
     m.Enforce_Dispatch_Lower_Limit_Non_Renewable = Constraint(
         m.FUEL_BASED_GEN_TPS,
-        rule=lambda m, g, tp:
-            (m.DispatchGen[g, tp] - m.DispatchGenRenewableMW[g, tp])
-            >=
-            (m.CommitGen[g, tp] - m.DispatchGenRenewableMW[g, tp])
-            * m.gen_min_load_fraction_TP[g, tp]
+        rule=lambda m, g, tp: (m.DispatchGen[g, tp] - m.DispatchGenRenewableMW[g, tp])
+        >= (m.CommitGen[g, tp] - m.DispatchGenRenewableMW[g, tp])
+        * m.gen_min_load_fraction_TP[g, tp],
     )
 
     # rule=lambda m, g, t, intercept, incremental_heat_rate: (
@@ -420,81 +493,92 @@ def relaxed_split_commit_DispatchGenRenewableMW(m):
     # for renewables and one slice for non-renewable, equal to the amount of power from each.
     m.ProjRenewableFuelUseRate_Calculate = Constraint(
         m.GEN_TPS_FUEL_PIECEWISE_CONS_SET,
-        rule=lambda m, g, tp, intercept, incremental_heat_rate:
-            sum(
-                m.GenFuelUseRate[g, tp, f]
-                    for f in m.FUELS_FOR_GEN[g]
-                        if f in m.RPS_ENERGY_SOURCES
-            )
-            >=
-            m.StartupGenCapacityRenewable[g, tp] * m.gen_startup_fuel[g] / m.tp_duration_hrs[tp]
-            + intercept * m.DispatchGenRenewableMW[g, tp]
-            + incremental_heat_rate * m.DispatchGenRenewableMW[g, tp]
+        rule=lambda m, g, tp, intercept, incremental_heat_rate: sum(
+            m.GenFuelUseRate[g, tp, f]
+            for f in m.FUELS_FOR_GEN[g]
+            if f in m.RPS_ENERGY_SOURCES
+        )
+        >= m.StartupGenCapacityRenewable[g, tp]
+        * m.gen_startup_fuel[g]
+        / m.tp_duration_hrs[tp]
+        + intercept * m.DispatchGenRenewableMW[g, tp]
+        + incremental_heat_rate * m.DispatchGenRenewableMW[g, tp],
     )
     m.ProjNonRenewableFuelUseRate_Calculate = Constraint(
         m.GEN_TPS_FUEL_PIECEWISE_CONS_SET,
-        rule=lambda m, g, tp, intercept, incremental_heat_rate:
-            sum(
-                m.GenFuelUseRate[g, tp, f]
-                    for f in m.FUELS_FOR_GEN[g]
-                        if f not in m.RPS_ENERGY_SOURCES
-            )
-            >=
-            (m.StartupGenCapacity[g, tp] - m.StartupGenCapacityRenewable[g, tp]) * m.gen_startup_fuel[g] / m.tp_duration_hrs[tp]
-            + intercept * (m.DispatchGen[g, tp] - m.DispatchGenRenewableMW[g, tp])
-            + incremental_heat_rate * (m.DispatchGen[g, tp] - m.DispatchGenRenewableMW[g, tp])
+        rule=lambda m, g, tp, intercept, incremental_heat_rate: sum(
+            m.GenFuelUseRate[g, tp, f]
+            for f in m.FUELS_FOR_GEN[g]
+            if f not in m.RPS_ENERGY_SOURCES
+        )
+        >= (m.StartupGenCapacity[g, tp] - m.StartupGenCapacityRenewable[g, tp])
+        * m.gen_startup_fuel[g]
+        / m.tp_duration_hrs[tp]
+        + intercept * (m.DispatchGen[g, tp] - m.DispatchGenRenewableMW[g, tp])
+        + incremental_heat_rate
+        * (m.DispatchGen[g, tp] - m.DispatchGenRenewableMW[g, tp]),
     )
 
     # don't allow any non-renewable fuel if RPS is 100%
-    if m.options.rps_level == 'activate':
+    if m.options.rps_level == "activate":
         # find all dispatch points for non-renewable fuels during periods with 100% RPS
         m.FULL_RPS_GEN_FOSSIL_FUEL_DISPATCH_POINTS = Set(
             dimen=3,
             initialize=lambda m: [
                 (g, tp, f)
-                for per in m.PERIODS if m.rps_target_for_period[per] == 1.0
-                for g in m.FUEL_BASED_GENS if (g, per) in m.GEN_PERIODS
-                for f in m.FUELS_FOR_GEN[g] if not m.f_rps_eligible[f]
+                for per in m.PERIODS
+                if m.rps_target_for_period[per] == 1.0
+                for g in m.FUEL_BASED_GENS
+                if (g, per) in m.GEN_PERIODS
+                for f in m.FUELS_FOR_GEN[g]
+                if not m.f_rps_eligible[f]
                 for tp in m.TPS_IN_PERIOD[per]
-            ]
+            ],
         )
         m.No_Fossil_Fuel_With_Full_RPS = Constraint(
             m.FULL_RPS_GEN_FOSSIL_FUEL_DISPATCH_POINTS,
-            rule=lambda m, g, tp, f: m.GenFuelUseRate[g, tp, f] == 0.0
+            rule=lambda m, g, tp, f: m.GenFuelUseRate[g, tp, f] == 0.0,
         )
 
 
 def fuel_switch_at_high_rps_DispatchGenRenewableMW(m):
     """ switch all plants to biofuel (and count toward RPS) if and only if rps is above threshold """
 
-    if m.options.rps_level == 'activate':
+    if m.options.rps_level == "activate":
         # find all dispatch points for non-renewable fuels during periods with 100% RPS
         m.HIGH_RPS_GEN_FOSSIL_FUEL_DISPATCH_POINTS = Set(
             dimen=3,
             initialize=lambda m: [
                 (g, tp, f)
-                    for p in m.PERIODS if m.rps_target_for_period[p] >= m.options.biofuel_switch_threshold
-                        for g in m.FUEL_BASED_GENS if (g, p) in m.GEN_PERIODS
-                            for f in m.FUELS_FOR_GEN[g] if not m.f_rps_eligible[f]
-                                for tp in m.TPS_IN_PERIOD[p]
-            ]
+                for p in m.PERIODS
+                if m.rps_target_for_period[p] >= m.options.biofuel_switch_threshold
+                for g in m.FUEL_BASED_GENS
+                if (g, p) in m.GEN_PERIODS
+                for f in m.FUELS_FOR_GEN[g]
+                if not m.f_rps_eligible[f]
+                for tp in m.TPS_IN_PERIOD[p]
+            ],
         )
         m.No_Fossil_Fuel_With_High_RPS = Constraint(
             m.HIGH_RPS_GEN_FOSSIL_FUEL_DISPATCH_POINTS,
-            rule=lambda m, g, tp, f: m.GenFuelUseRate[g, tp, f] == 0.0
+            rule=lambda m, g, tp, f: m.GenFuelUseRate[g, tp, f] == 0.0,
         )
         # count full dispatch toward RPS during non-fossil periods, otherwise give no credit
         def rule(m, g, tp):
-            if m.rps_target_for_period[m.tp_period[tp]] >=  m.options.biofuel_switch_threshold:
+            if (
+                m.rps_target_for_period[m.tp_period[tp]]
+                >= m.options.biofuel_switch_threshold
+            ):
                 return m.DispatchGen[g, tp]
             else:
                 return 0.0
+
         m.DispatchGenRenewableMW = Expression(m.FUEL_BASED_GEN_TPS, rule=rule)
     else:
         m.DispatchGenRenewableMW = Expression(
-            m.FUEL_BASED_GEN_TPS, within=NonNegativeReals,
-            rule=lambda m, g, tp: 0.0
+            m.FUEL_BASED_GEN_TPS, within=NonNegativeReals, rule=lambda m, g, tp: 0.0
         )
+
 
 def binary_by_period_DispatchGenRenewableMW(m):
     # NOTE: this could be extended to handle fuel blends (e.g., 50% biomass/50% coal)
@@ -507,35 +591,39 @@ def binary_by_period_DispatchGenRenewableMW(m):
     # and choosing the amount to produce from each eligibility level (similar to the
     # renewable/non-renewable distinction here, but with a 50% renewable category)
 
-    m.GEN_WITH_FUEL_ACTIVE_PERIODS = Set(dimen=2, initialize=lambda m: {
-        (g, pe)
-            for g in m.FUEL_BASED_GENS for pe in m.PERIODS
-                if (g, m.TPS_IN_PERIOD[pe].first()) in m.FUEL_BASED_GEN_TPS
-    })
+    m.GEN_WITH_FUEL_ACTIVE_PERIODS = Set(
+        dimen=2,
+        initialize=lambda m: {
+            (g, pe)
+            for g in m.FUEL_BASED_GENS
+            for pe in m.PERIODS
+            if (g, m.TPS_IN_PERIOD[pe].first()) in m.FUEL_BASED_GEN_TPS
+        },
+    )
 
     # choose whether to run (only) on renewable fuels during each period
     m.DispatchRenewableFlag = Var(m.GEN_WITH_FUEL_ACTIVE_PERIODS, within=Binary)
 
     # force flag on or off when the RPS is simple (to speed computation)
     def rule(m, g, p):
-        if m.rps_target_for_period[pe]==1.0:
+        if m.rps_target_for_period[pe] == 1.0:
             # 100% RPS; use only renewable fuels
-            return (m.DispatchRenewableFlag[g, pe] == 1)
-        elif m.rps_target_for_period[pe]==0.0 or m.options.rps_level != 'activate':
+            return m.DispatchRenewableFlag[g, pe] == 1
+        elif m.rps_target_for_period[pe] == 0.0 or m.options.rps_level != "activate":
             # no RPS, don't bother counting renewable fuels
-            return (m.DispatchRenewableFlag[g, pe] == 0)
+            return m.DispatchRenewableFlag[g, pe] == 0
         else:
             return Constraint.Skip
+
     m.Force_DispatchRenewableFlag = Constraint(
         m.GEN_WITH_FUEL_ACTIVE_PERIODS,
-        rule=lambda m, g, pe:
-            (m.DispatchRenewableFlag[g, pe] == 0)
-            if (m.rps_target_for_period[pe]==0.0 or m.options.rps_level != 'activate')
-            else (
-                (m.DispatchRenewableFlag[g, pe] == 1)
-                if m.rps_target_for_period[pe]==1.0
-                else Constraint.Skip
-            )
+        rule=lambda m, g, pe: (m.DispatchRenewableFlag[g, pe] == 0)
+        if (m.rps_target_for_period[pe] == 0.0 or m.options.rps_level != "activate")
+        else (
+            (m.DispatchRenewableFlag[g, pe] == 1)
+            if m.rps_target_for_period[pe] == 1.0
+            else Constraint.Skip
+        ),
     )
 
     # count amount of renewable power produced from project
@@ -544,16 +632,13 @@ def binary_by_period_DispatchGenRenewableMW(m):
     # don't overcount renewable power production
     m.Limit_DispatchGenRenewableMW = Constraint(
         m.FUEL_BASED_GEN_TPS,
-            rule=lambda m, g, tp:
-                m.DispatchGenRenewableMW[g, tp] <= m.DispatchGen[g, tp]
+        rule=lambda m, g, tp: m.DispatchGenRenewableMW[g, tp] <= m.DispatchGen[g, tp],
     )
     # force the flag to be set during renewable timepoints
     m.Set_DispatchRenewableFlag = Constraint(
-            m.FUEL_BASED_GEN_TPS,
-            rule=lambda m, g, tp:
-                 m.DispatchGenRenewableMW[g, tp]
-                 <=
-                 m.DispatchRenewableFlag[g, m.tp_period[tp]] * m.gen_capacity_limit_mw[g]
+        m.FUEL_BASED_GEN_TPS,
+        rule=lambda m, g, tp: m.DispatchGenRenewableMW[g, tp]
+        <= m.DispatchRenewableFlag[g, m.tp_period[tp]] * m.gen_capacity_limit_mw[g],
     )
 
     # prevent use of non-renewable fuels during renewable timepoints
@@ -569,19 +654,24 @@ def binary_by_period_DispatchGenRenewableMW(m):
             return (
                 m.GenFuelUseRate[g, tp, f]
                 + m.DispatchRenewableFlag[g, m.tp_period[tp]] * big_fuel
-                <=
-                big_fuel
+                <= big_fuel
             )
+
     m.Enforce_DispatchRenewableFlag = Constraint(
         m.GEN_TP_FUELS, rule=Enforce_DispatchRenewableFlag_rule
     )
 
+
 def binary_by_timeseries_DispatchGenRenewableMW(m):
-    m.GEN_WITH_FUEL_ACTIVE_TIMESERIES = Set(dimen=2, initialize=lambda m: {
-        (g, ts)
-            for g in m.FUEL_BASED_GENS for ts in m.TIMESERIES
-                if (g, m.TPS_IN_TS[ts].first()) in m.FUEL_BASED_GEN_TPS
-    })
+    m.GEN_WITH_FUEL_ACTIVE_TIMESERIES = Set(
+        dimen=2,
+        initialize=lambda m: {
+            (g, ts)
+            for g in m.FUEL_BASED_GENS
+            for ts in m.TIMESERIES
+            if (g, m.TPS_IN_TS[ts].first()) in m.FUEL_BASED_GEN_TPS
+        },
+    )
 
     # choose whether to run (only) on renewable fuels during each period
     m.DispatchRenewableFlag = Var(m.GEN_WITH_FUEL_ACTIVE_TIMESERIES, within=Binary)
@@ -589,12 +679,13 @@ def binary_by_timeseries_DispatchGenRenewableMW(m):
     # force flag on or off depending on RPS status (to speed computation)
     m.Force_DispatchRenewableFlag = Constraint(
         m.GEN_WITH_FUEL_ACTIVE_TIMESERIES,
-        rule=lambda m, g, ts:
-            (m.DispatchRenewableFlag[g, ts] == 0) if m.rps_target_for_period[m.ts_period[ts]]==0.0
-            else (
-                (m.DispatchRenewableFlag[g, ts] == 1) if m.rps_target_for_period[m.ts_period[ts]]==1.0
-                else Constraint.Skip
-            )
+        rule=lambda m, g, ts: (m.DispatchRenewableFlag[g, ts] == 0)
+        if m.rps_target_for_period[m.ts_period[ts]] == 0.0
+        else (
+            (m.DispatchRenewableFlag[g, ts] == 1)
+            if m.rps_target_for_period[m.ts_period[ts]] == 1.0
+            else Constraint.Skip
+        ),
     )
 
     # count amount of renewable power produced from project
@@ -603,35 +694,32 @@ def binary_by_timeseries_DispatchGenRenewableMW(m):
     # don't overcount renewable power production
     m.Limit_DispatchGenRenewableMW = Constraint(
         m.FUEL_BASED_GEN_TPS,
-            rule=lambda m, g, tp:
-                m.DispatchGenRenewableMW[g, tp] <= m.DispatchGen[g, tp]
+        rule=lambda m, g, tp: m.DispatchGenRenewableMW[g, tp] <= m.DispatchGen[g, tp],
     )
     # force the flag to be set during renewable timepoints
     m.Set_DispatchRenewableFlag = Constraint(
-            m.FUEL_BASED_GEN_TPS,
-            rule=lambda m, g, tp:
-                 m.DispatchGenRenewableMW[g, tp]
-                 <=
-                 m.DispatchRenewableFlag[g, m.tp_ts[tp]] * m.gen_capacity_limit_mw[g]
+        m.FUEL_BASED_GEN_TPS,
+        rule=lambda m, g, tp: m.DispatchGenRenewableMW[g, tp]
+        <= m.DispatchRenewableFlag[g, m.tp_ts[tp]] * m.gen_capacity_limit_mw[g],
     )
 
     # prevent use of non-renewable fuels during renewable timepoints
     m.Enforce_DispatchRenewableFlag = Constraint(
         m.GEN_TP_FUELS,
-        rule=lambda m, g, tp, f:
-            Constraint.Skip if m.f_rps_eligible[f]
-            else (
-                # original code, rewritten to get numerical parts on rhs
-                # m.GenFuelUseRate[g, tp, f]
-                # <=
-                # (1-m.DispatchRenewableFlag[g, m.tp_ts[tp]]) * m.gen_capacity_limit_mw[g] * m.gen_full_load_heat_rate[g]
-                m.GenFuelUseRate[g, tp, f]
-                + m.DispatchRenewableFlag[g, m.tp_ts[tp]] * m.gen_capacity_limit_mw[g] * m.gen_full_load_heat_rate[g]
-                <=
-                m.gen_capacity_limit_mw[g] * m.gen_full_load_heat_rate[g]
-            )
+        rule=lambda m, g, tp, f: Constraint.Skip
+        if m.f_rps_eligible[f]
+        else (
+            # original code, rewritten to get numerical parts on rhs
+            # m.GenFuelUseRate[g, tp, f]
+            # <=
+            # (1-m.DispatchRenewableFlag[g, m.tp_ts[tp]]) * m.gen_capacity_limit_mw[g] * m.gen_full_load_heat_rate[g]
+            m.GenFuelUseRate[g, tp, f]
+            + m.DispatchRenewableFlag[g, m.tp_ts[tp]]
+            * m.gen_capacity_limit_mw[g]
+            * m.gen_full_load_heat_rate[g]
+            <= m.gen_capacity_limit_mw[g] * m.gen_full_load_heat_rate[g]
+        ),
     )
-
 
 
 def advanced2_DispatchGenRenewableMW(m):
@@ -644,27 +732,26 @@ def advanced2_DispatchGenRenewableMW(m):
     # don't overcount renewable power production
     m.Limit_DispatchGenRenewableMW = Constraint(
         m.FUEL_BASED_GEN_TPS,
-            rule=lambda m, g, tp: m.DispatchGenRenewableMW[g, tp] <= m.DispatchGen[g, tp]
+        rule=lambda m, g, tp: m.DispatchGenRenewableMW[g, tp] <= m.DispatchGen[g, tp],
     )
     # force the flag to be set during renewable timepoints
     m.Set_DispatchRenewableFlag = Constraint(
-            m.FUEL_BASED_GEN_TPS,
-            rule=lambda m, g, tp:
-                 m.DispatchGenRenewableMW[g, tp]
-                 <=
-                 m.DispatchRenewableFlag[g, tp] * m.gen_capacity_limit_mw[g]
+        m.FUEL_BASED_GEN_TPS,
+        rule=lambda m, g, tp: m.DispatchGenRenewableMW[g, tp]
+        <= m.DispatchRenewableFlag[g, tp] * m.gen_capacity_limit_mw[g],
     )
 
     # prevent use of non-renewable fuels during renewable timepoints
     m.Enforce_DispatchRenewableFlag = Constraint(
         m.GEN_TP_FUELS,
-        rule=lambda m, g, tp, f:
-            Constraint.Skip if m.f_rps_eligible[f]
-            else (
-                m.GenFuelUseRate[g, tp, f]
-                <=
-                (1-m.DispatchRenewableFlag[g, tp]) * m.gen_capacity_limit_mw[g] * m.gen_full_load_heat_rate[g]
-            )
+        rule=lambda m, g, tp, f: Constraint.Skip
+        if m.f_rps_eligible[f]
+        else (
+            m.GenFuelUseRate[g, tp, f]
+            <= (1 - m.DispatchRenewableFlag[g, tp])
+            * m.gen_capacity_limit_mw[g]
+            * m.gen_full_load_heat_rate[g]
+        ),
     )
 
 
@@ -675,36 +762,34 @@ def advanced1_DispatchGenRenewableMW(m):
     # make sure this matches total production
     m.DispatchGenRenewableMW_Total = Constraint(
         m.FUEL_BASED_GEN_TPS,
-        rule=lambda m, g, tp:
-            sum(m.DispatchGenRenewableMW[g, tp, f] for f in m.FUELS_FOR_GEN[g])
-            ==
-            m.DispatchGen[g, tp]
+        rule=lambda m, g, tp: sum(
+            m.DispatchGenRenewableMW[g, tp, f] for f in m.FUELS_FOR_GEN[g]
+        )
+        == m.DispatchGen[g, tp],
     )
 
     # choose a single fuel to use during each timestep
     m.DispatchFuelFlag = Var(m.GEN_TP_FUELS, within=Binary)
     m.DispatchFuelFlag_Total = Constraint(
         m.FUEL_BASED_GEN_TPS,
-        rule=lambda m, g, tp:
-            sum(m.DispatchFuelFlag[g, tp, f] for f in m.FUELS_FOR_GEN[g])
-            ==
-            1
+        rule=lambda m, g, tp: sum(
+            m.DispatchFuelFlag[g, tp, f] for f in m.FUELS_FOR_GEN[g]
+        )
+        == 1,
     )
 
     # consume only the selected fuel and allocate all production to that fuel (big-M constraints)
     m.Allocate_Dispatch_Output = Constraint(
         m.GEN_TP_FUELS,
-        rule=lambda m, g, tp, f:
-            m.DispatchGenRenewableMW[g, tp, f]
-            <=
-            m.DispatchFuelFlag[g, tp, f] * m.gen_capacity_limit_mw[g]
+        rule=lambda m, g, tp, f: m.DispatchGenRenewableMW[g, tp, f]
+        <= m.DispatchFuelFlag[g, tp, f] * m.gen_capacity_limit_mw[g],
     )
     m.Allocate_Dispatch_Fuel = Constraint(
         m.GEN_TP_FUELS,
-        rule=lambda m, g, tp, f:
-            m.GenFuelUseRate[g, tp, f]
-            <=
-            m.DispatchFuelFlag[g, tp, f] * m.gen_capacity_limit_mw[g] * m.gen_full_load_heat_rate[g]
+        rule=lambda m, g, tp, f: m.GenFuelUseRate[g, tp, f]
+        <= m.DispatchFuelFlag[g, tp, f]
+        * m.gen_capacity_limit_mw[g]
+        * m.gen_full_load_heat_rate[g],
     )
 
     # note: in cases where a project has a single fuel, the presolver should force
@@ -738,6 +823,7 @@ def advanced1_DispatchGenRenewableMW(m):
     #         * m.GenFuelUseRate[g, t, f]
     # )
 
+
 def quadratic_DispatchGenRenewableMW(m):
     # choose how much power to obtain from renewables during each timepoint
     m.DispatchRenewableFraction = Var(m.FUEL_BASED_GEN_TPS, within=PercentFraction)
@@ -747,27 +833,21 @@ def quadratic_DispatchGenRenewableMW(m):
 
     # don't overcount renewable power production
     m.Set_DispatchRenewableFraction = Constraint(
-            m.FUEL_BASED_GEN_TPS,
-            rule=lambda m, g, tp:
-                 m.DispatchGenRenewableMW[g, tp]
-                 <=
-                 m.DispatchRenewableFraction[g, tp] * m.DispatchGen[g, tp]
+        m.FUEL_BASED_GEN_TPS,
+        rule=lambda m, g, tp: m.DispatchGenRenewableMW[g, tp]
+        <= m.DispatchRenewableFraction[g, tp] * m.DispatchGen[g, tp],
     )
     m.Enforce_DispatchRenewableFraction = Constraint(
         m.FUEL_BASED_GEN_TPS,
-        rule=lambda m, g, tp:
-            sum(
-                m.GenFuelUseRate[g, tp, f]
-                    for f in m.FUELS_FOR_GEN[g]
-                        if m.f_rps_eligible[f]
-            )
-            >=
-            m.DispatchRenewableFraction[g, tp] *
-            sum(
-                m.GenFuelUseRate[g, tp, f]
-                    for f in m.FUELS_FOR_GEN[g]
-            )
+        rule=lambda m, g, tp: sum(
+            m.GenFuelUseRate[g, tp, f]
+            for f in m.FUELS_FOR_GEN[g]
+            if m.f_rps_eligible[f]
+        )
+        >= m.DispatchRenewableFraction[g, tp]
+        * sum(m.GenFuelUseRate[g, tp, f] for f in m.FUELS_FOR_GEN[g]),
     )
+
 
 def quadratic1_DispatchGenRenewableMW(m):
     # Allocate the power produced during each timepoint among the fuels.
@@ -776,37 +856,39 @@ def quadratic1_DispatchGenRenewableMW(m):
     # make sure this matches total production
     m.DispatchGenRenewableMW_Total = Constraint(
         m.FUEL_BASED_GEN_TPS,
-        rule=lambda m, g, tp:
-            sum(m.DispatchGenRenewableMW[g, tp, f] for f in m.FUELS_FOR_GEN[g])
-            ==
-            m.DispatchGen[g, tp]
+        rule=lambda m, g, tp: sum(
+            m.DispatchGenRenewableMW[g, tp, f] for f in m.FUELS_FOR_GEN[g]
+        )
+        == m.DispatchGen[g, tp],
     )
 
     m.DispatchGenRenewableMW_Allocate = Constraint(
         m.GEN_TP_FUELS,
-        rule = lambda m, g, t, f:
-            m.DispatchGenRenewableMW[g, t, f]
-            * sum(m.GenFuelUseRate[g, t, _f] for _f in m.FUELS_FOR_GEN[g])
-            <=
-            m.DispatchGen[g, t]
-            * m.GenFuelUseRate[g, t, f]
+        rule=lambda m, g, t, f: m.DispatchGenRenewableMW[g, t, f]
+        * sum(m.GenFuelUseRate[g, t, _f] for _f in m.FUELS_FOR_GEN[g])
+        <= m.DispatchGen[g, t] * m.GenFuelUseRate[g, t, f],
     )
+
 
 def load_inputs(m, switch_data, inputs_dir):
     switch_data.load_aug(
         optional=True,
-        filename=os.path.join(inputs_dir, 'fuels.csv'),
-        select=('fuel', 'rps_eligible'),
-        param=(m.f_rps_eligible,))
+        filename=os.path.join(inputs_dir, "fuels.csv"),
+        select=("fuel", "rps_eligible"),
+        param=(m.f_rps_eligible,),
+    )
     if m.options.rps_targets is None:
         switch_data.load_aug(
             optional=True,
-            filename=os.path.join(inputs_dir, 'rps_targets.csv'),
+            filename=os.path.join(inputs_dir, "rps_targets.csv"),
             index=m.RPS_YEARS,
-            param=(m.rps_target,))
+            param=(m.rps_target,),
+        )
     else:
         # construct data from a target specified as 'year1 level1 year2 level2 ...'
         iterator = iter(m.options.rps_targets)
-        rps_targets = {int(year): float(target) for year, target in zip(iterator, iterator)}
-        switch_data.data()['RPS_YEARS'] = {None: sorted(rps_targets.keys())}
-        switch_data.data()['rps_target'] = rps_targets
+        rps_targets = {
+            int(year): float(target) for year, target in zip(iterator, iterator)
+        }
+        switch_data.data()["RPS_YEARS"] = {None: sorted(rps_targets.keys())}
+        switch_data.data()["rps_target"] = rps_targets

--- a/switch_model/hawaii/save_results.py
+++ b/switch_model/hawaii/save_results.py
@@ -26,26 +26,44 @@ from pyomo.environ import *
 import switch_model.hawaii.util as util
 import switch_model.financials as financials
 
+
 def define_components(m):
     # Make sure the model has a dual suffix
     if not hasattr(m, "dual"):
         m.dual = Suffix(direction=Suffix.IMPORT)
 
+
 def post_solve(m, outputs_dir):
     write_results(m, outputs_dir)
+
 
 def summary_headers(m):
     return (
         ("scenario", "max_demand_response_share", "total_cost", "cost_per_kwh")
-        +tuple('cost_per_kwh_'+str(p) for p in m.PERIODS)
-        +((("renewable_share_all_years",) + tuple('renewable_share_'+str(p) for p in m.PERIODS))
-            if hasattr(m, 'RPSEligiblePower') else tuple())
-        +((("biofuel_share_all_years",) + tuple('biofuel_share_'+str(p) for p in m.PERIODS))
-            if hasattr(m, 'RPSEligiblePower') else tuple())
+        + tuple("cost_per_kwh_" + str(p) for p in m.PERIODS)
+        + (
+            (
+                ("renewable_share_all_years",)
+                + tuple("renewable_share_" + str(p) for p in m.PERIODS)
+            )
+            if hasattr(m, "RPSEligiblePower")
+            else tuple()
+        )
+        + (
+            (
+                ("biofuel_share_all_years",)
+                + tuple("biofuel_share_" + str(p) for p in m.PERIODS)
+            )
+            if hasattr(m, "RPSEligiblePower")
+            else tuple()
+        )
     )
 
+
 def summary_values(m):
-    demand_components = [c for c in ('zone_demand_mw', 'ShiftDemand', 'ChargeEVs') if hasattr(m, c)]
+    demand_components = [
+        c for c in ("zone_demand_mw", "ShiftDemand", "ChargeEVs") if hasattr(m, c)
+    ]
     values = []
 
     # Cache SystemCostPerPeriod and SystemCost to speed up saving large models
@@ -59,54 +77,65 @@ def summary_values(m):
     SystemCost = sum(SystemCostPerPeriod[p] for p in m.PERIODS)
 
     # scenario name and looping variables
-    values.extend([
-        str(m.options.scenario_name),
-        m.demand_response_max_share if hasattr(m, 'demand_response_max_share') else 0.0,
-    ])
+    values.extend(
+        [
+            str(m.options.scenario_name),
+            m.demand_response_max_share
+            if hasattr(m, "demand_response_max_share")
+            else 0.0,
+        ]
+    )
 
     # total cost (all periods)
-    values.append(SystemCost) # m.SystemCost)
+    values.append(SystemCost)  # m.SystemCost)
 
     # NPV of total cost / NPV of kWh generated (equivalent to spreading
     # all costs uniformly over all generation)
     values.append(
-        SystemCost # m.SystemCost
+        SystemCost  # m.SystemCost
         / sum(
-            m.bring_timepoint_costs_to_base_year[t] * 1000.0 *
-            sum(getattr(m, c)[z, t] for c in demand_components for z in m.LOAD_ZONES)
+            m.bring_timepoint_costs_to_base_year[t]
+            * 1000.0
+            * sum(getattr(m, c)[z, t] for c in demand_components for z in m.LOAD_ZONES)
             for t in m.TIMEPOINTS
         )
     )
 
     #  total cost / kWh generated in each period
     # (both discounted to today, so the discounting cancels out)
-    values.extend([
-        SystemCostPerPeriod[p] # m.SystemCostPerPeriod[p]
-        / sum(
-            m.bring_timepoint_costs_to_base_year[t] * 1000.0 *
-            sum(getattr(m, c)[z, t] for c in demand_components for z in m.LOAD_ZONES)
-            for t in m.TPS_IN_PERIOD[p]
-        )
-        for p in m.PERIODS
-    ])
+    values.extend(
+        [
+            SystemCostPerPeriod[p]  # m.SystemCostPerPeriod[p]
+            / sum(
+                m.bring_timepoint_costs_to_base_year[t]
+                * 1000.0
+                * sum(
+                    getattr(m, c)[z, t] for c in demand_components for z in m.LOAD_ZONES
+                )
+                for t in m.TPS_IN_PERIOD[p]
+            )
+            for p in m.PERIODS
+        ]
+    )
 
-    if hasattr(m, 'RPSEligiblePower'):
+    if hasattr(m, "RPSEligiblePower"):
         # total renewable share over all periods
         values.append(
             sum(m.RPSEligiblePower[p] for p in m.PERIODS)
-            /sum(m.RPSTotalPower[p] for p in m.PERIODS)
+            / sum(m.RPSTotalPower[p] for p in m.PERIODS)
         )
         # renewable share during each period
-        values.extend([m.RPSEligiblePower[p]/m.RPSTotalPower[p] for p in m.PERIODS])
+        values.extend([m.RPSEligiblePower[p] / m.RPSTotalPower[p] for p in m.PERIODS])
         # total biofuel share over all periods
         values.append(
             sum(m.RPSFuelPower[p] for p in m.PERIODS)
-            /sum(m.RPSTotalPower[p] for p in m.PERIODS)
+            / sum(m.RPSTotalPower[p] for p in m.PERIODS)
         )
         # biofuel share during each period
-        values.extend([m.RPSFuelPower[p]/m.RPSTotalPower[p] for p in m.PERIODS])
+        values.extend([m.RPSFuelPower[p] / m.RPSTotalPower[p] for p in m.PERIODS])
 
     return values
+
 
 def annualize_present_value_period_cost(m, period, val):
     # convert a discounted, total cost per-period into an annual stream of costs
@@ -114,12 +143,16 @@ def annualize_present_value_period_cost(m, period, val):
         # this term is straight from financials.py
         # Conversion to lump sum at beginning of period
         financials.uniform_series_to_present_value(
-            m.discount_rate, m.period_length_years[period]) *
+            m.discount_rate, m.period_length_years[period]
+        )
+        *
         # Conversion to base year
         financials.future_to_present_value(
-            m.discount_rate, (m.period_start[period] - m.base_financial_year))
+            m.discount_rate, (m.period_start[period] - m.base_financial_year)
+        )
     )
     return val / discount_factor
+
 
 def DispatchGenByFuel(m, g, tp, fuel):
     """This is a replacement for mod.DispatchGenByFuel, which is only defined in
@@ -146,27 +179,29 @@ def DispatchGenByFuel(m, g, tp, fuel):
         result = value(m.GenFuelUseRate[g, tp, fuel]) * dispatch / total_fuel
     return result
 
+
 def write_results(m, outputs_dir):
     tag = "_" + m.options.scenario_name if m.options.scenario_name else ""
 
-    util.write_table(m,
+    util.write_table(
+        m,
         output_file=os.path.join(outputs_dir, "summary{t}.csv".format(t=tag)),
         headings=summary_headers(m),
-        values=lambda m: summary_values(m)
+        values=lambda m: summary_values(m),
     )
 
-    if hasattr(m, 'Spinning_Reserve_Up_Requirements'):
+    if hasattr(m, "Spinning_Reserve_Up_Requirements"):
         # pre-calculate amount of reserves provided and needed for each balancing area and timepoint
         spinning_reserve_provisions = defaultdict(float)
         spinning_reserve_requirements = defaultdict(float)
-        if hasattr(m, 'GEN_SPINNING_RESERVE_TYPES'): # advanced module
+        if hasattr(m, "GEN_SPINNING_RESERVE_TYPES"):  # advanced module
             for component in m.Spinning_Reserve_Up_Provisions:
                 for (rt, ba, tp), val in getattr(m, component).items():
                     spinning_reserve_provisions[ba, tp] += val
             for component in m.Spinning_Reserve_Up_Requirements:
                 for (rt, ba, tp), val in getattr(m, component).items():
                     spinning_reserve_requirements[ba, tp] += val
-        else: # basic module
+        else:  # basic module
             for component in m.Spinning_Reserve_Up_Provisions:
                 for (ba, tp), val in getattr(m, component).items():
                     spinning_reserve_provisions[ba, tp] += val
@@ -188,168 +223,205 @@ def write_results(m, outputs_dir):
     non_fuel_techs = tuple(sorted(set(m.gen_tech[g] for g in m.NON_FUEL_BASED_GENS)))
     # get a list of ad-hoc technologies (not included in standard generation projects)
     ad_hoc_sources = tuple(
-        s for s in m.Zone_Power_Injections
-        if s not in {'ZoneTotalCentralDispatch', 'ZoneTotalDistributedDispatch'}
+        s
+        for s in m.Zone_Power_Injections
+        if s not in {"ZoneTotalCentralDispatch", "ZoneTotalDistributedDispatch"}
     )
-    avg_ts_scale = float(sum(m.ts_scale_to_year[ts] for ts in m.TIMESERIES))/len(m.TIMESERIES)
+    avg_ts_scale = float(sum(m.ts_scale_to_year[ts] for ts in m.TIMESERIES)) / len(
+        m.TIMESERIES
+    )
     util.write_table(
-        m, m.LOAD_ZONES, m.TIMEPOINTS,
+        m,
+        m.LOAD_ZONES,
+        m.TIMEPOINTS,
         output_file=os.path.join(outputs_dir, "energy_sources{t}.csv".format(t=tag)),
-        headings=
-            ("load_zone", "period", "timepoint_label")
-            +tuple(m.FUELS)
-            +tuple(m.NON_FUEL_ENERGY_SOURCES)
-            +non_fuel_techs
-            +tuple("curtail_"+s for s in m.NON_FUEL_ENERGY_SOURCES)
-            +tuple(m.Zone_Power_Injections)
-            +tuple(m.Zone_Power_Withdrawals)
-            +("spinning_reserve_provision", "spinning_reserve_requirement")
-            +("marginal_cost", "peak_day"),
-        values=lambda m, z, t:
-            (z, m.tp_period[t], m.tp_timestamp[t])
-            +tuple(
-                sum(
-                    DispatchGenByFuel(m, p, t, f)
+        headings=("load_zone", "period", "timepoint_label")
+        + tuple(m.FUELS)
+        + tuple(m.NON_FUEL_ENERGY_SOURCES)
+        + non_fuel_techs
+        + tuple("curtail_" + s for s in m.NON_FUEL_ENERGY_SOURCES)
+        + tuple(m.Zone_Power_Injections)
+        + tuple(m.Zone_Power_Withdrawals)
+        + ("spinning_reserve_provision", "spinning_reserve_requirement")
+        + ("marginal_cost", "peak_day"),
+        values=lambda m, z, t: (z, m.tp_period[t], m.tp_timestamp[t])
+        + tuple(
+            sum(
+                DispatchGenByFuel(m, p, t, f)
+                for p in m.GENS_BY_FUEL[f]
+                if (p, t) in m.GEN_TPS and m.gen_load_zone[p] == z
+            )
+            for f in m.FUELS
+        )
+        + tuple(
+            sum(
+                util.get(m.DispatchGen, (p, t), 0.0)
+                for p in m.GENS_BY_NON_FUEL_ENERGY_SOURCE[s]
+                if m.gen_load_zone[p] == z
+            )
+            for s in m.NON_FUEL_ENERGY_SOURCES
+        )
+        + tuple(
+            sum(
+                util.get(m.DispatchGen, (g, t), 0.0)
+                for g in m.GENS_BY_TECHNOLOGY[tech]
+                if m.gen_load_zone[g] == z
+            )
+            for tech in non_fuel_techs
+        )
+        + tuple(
+            sum(
+                util.get(m.DispatchUpperLimit, (p, t), 0.0)
+                - util.get(m.DispatchGen, (p, t), 0.0)
+                for p in m.GENS_BY_NON_FUEL_ENERGY_SOURCE[s]
+                if m.gen_load_zone[p] == z
+            )
+            for s in m.NON_FUEL_ENERGY_SOURCES
+        )
+        + tuple(getattr(m, component)[z, t] for component in m.Zone_Power_Injections)
+        + tuple(getattr(m, component)[z, t] for component in m.Zone_Power_Withdrawals)
+        + (  # save spinning reserve requirements and provisions; note: this assumes one zone per balancing area
+            (
+                spinning_reserve_provisions[m.zone_balancing_area[z], t],
+                spinning_reserve_requirements[m.zone_balancing_area[z], t],
+            )
+            if hasattr(m, "Spinning_Reserve_Up_Requirements")
+            else (0.0, 0.0)
+        )
+        + (
+            (
+                (
+                    m.dual[m.Zone_Energy_Balance[z, t]]
+                    / m.bring_timepoint_costs_to_base_year[t]
+                )
+                if m.Zone_Energy_Balance[z, t] in m.dual
+                else ""  # no dual available, e.g., with glpk solver
+            ),
+            "peak" if m.ts_scale_to_year[m.tp_ts[t]] < avg_ts_scale else "typical",
+        ),
+    )
+
+    if hasattr(m, "Spinning_Reserve_Up_Requirements") and hasattr(
+        m, "GEN_SPINNING_RESERVE_TYPES"
+    ):  # advanced module
+        # write the reserve values
+        util.write_table(
+            m,
+            m.BALANCING_AREAS,
+            m.TIMEPOINTS,
+            output_file=os.path.join(
+                outputs_dir, "up_reserve_sources{t}.csv".format(t=tag)
+            ),
+            headings=("balancing_area", "period", "timepoint_label")
+            + tuple(m.FUELS)
+            + tuple(m.NON_FUEL_ENERGY_SOURCES)
+            + tuple(m.Spinning_Reserve_Up_Provisions)
+            + tuple(m.Spinning_Reserve_Up_Requirements)
+            + tuple(
+                "marginal_cost_" + rt
+                for rt in sorted(m.SPINNING_RESERVE_TYPES_FROM_GENS)
+            )
+            + ("peak_day",),
+            values=lambda m, ba, t: (ba, m.tp_period[t], m.tp_timestamp[t])
+            + tuple(
+                (
+                    sum(
+                        # total reserve production
+                        sum(
+                            m.CommitGenSpinningReservesUp[rt, p, t]
+                            for rt in m.SPINNING_RESERVE_TYPES_FOR_GEN[p]
+                        )
+                        # prorated by energy source used
+                        * DispatchGenByFuel(m, p, t, f) / m.DispatchGen[p, t]
                         for p in m.GENS_BY_FUEL[f]
-                        if (p, t) in m.GEN_TPS and m.gen_load_zone[p] == z
+                        if (p, t) in m.GEN_TPS
+                        and m.zone_balancing_area[m.gen_load_zone[p]] == ba
+                    )
                 )
                 for f in m.FUELS
             )
-            +tuple(
+            + tuple(
                 sum(
-                    util.get(m.DispatchGen, (p, t), 0.0)
+                    m.CommitGenSpinningReservesUp[rt, p, t]
                     for p in m.GENS_BY_NON_FUEL_ENERGY_SOURCE[s]
-                    if m.gen_load_zone[p] == z
+                    if (p, t) in m.SPINNING_RESERVE_CAPABLE_GEN_TPS
+                    and m.zone_balancing_area[m.gen_load_zone[p]] == ba
+                    for rt in m.SPINNING_RESERVE_TYPES_FOR_GEN[p]
                 )
                 for s in m.NON_FUEL_ENERGY_SOURCES
             )
-            +tuple(
+            + tuple(
                 sum(
-                    util.get(m.DispatchGen, (g, t), 0.0)
-                    for g in m.GENS_BY_TECHNOLOGY[tech]
-                    if m.gen_load_zone[g] == z
+                    util.get(getattr(m, component), (rt, ba, t), 0.0)
+                    for rt in m.SPINNING_RESERVE_TYPES_FROM_GENS
                 )
-                for tech in non_fuel_techs
+                for component in m.Spinning_Reserve_Up_Provisions
             )
-            +tuple(
+            + tuple(
                 sum(
-                    util.get(m.DispatchUpperLimit, (p, t), 0.0) - util.get(m.DispatchGen, (p, t), 0.0)
-                    for p in m.GENS_BY_NON_FUEL_ENERGY_SOURCE[s]
-                    if m.gen_load_zone[p] == z
+                    util.get(getattr(m, component), (rt, ba, t), 0.0)
+                    for rt in m.SPINNING_RESERVE_TYPES_FROM_GENS
                 )
-                for s in m.NON_FUEL_ENERGY_SOURCES
+                for component in m.Spinning_Reserve_Up_Requirements
             )
-            +tuple(getattr(m, component)[z, t] for component in m.Zone_Power_Injections)
-            +tuple(getattr(m, component)[z, t] for component in m.Zone_Power_Withdrawals)
-            +(  # save spinning reserve requirements and provisions; note: this assumes one zone per balancing area
-                (spinning_reserve_provisions[m.zone_balancing_area[z], t], spinning_reserve_requirements[m.zone_balancing_area[z], t])
-                if hasattr(m, 'Spinning_Reserve_Up_Requirements')
-                else (0.0, 0.0)
-            )
-            +(
+            + tuple(
                 (
-                    (
-                        m.dual[m.Zone_Energy_Balance[z, t]]
-                        / m.bring_timepoint_costs_to_base_year[t]
-                    )
-                    if m.Zone_Energy_Balance[z, t] in m.dual
-                    else '' # no dual available, e.g., with glpk solver
-                ),
-                'peak' if m.ts_scale_to_year[m.tp_ts[t]] < avg_ts_scale else 'typical'
-            )
-    )
-
-    if hasattr(m, 'Spinning_Reserve_Up_Requirements') and hasattr(m, 'GEN_SPINNING_RESERVE_TYPES'): # advanced module
-        # write the reserve values
-        util.write_table(
-            m, m.BALANCING_AREAS, m.TIMEPOINTS,
-            output_file=os.path.join(outputs_dir, "up_reserve_sources{t}.csv".format(t=tag)),
-            headings=
-                ("balancing_area", "period", "timepoint_label")
-                +tuple(m.FUELS)
-                +tuple(m.NON_FUEL_ENERGY_SOURCES)
-                +tuple(m.Spinning_Reserve_Up_Provisions)
-                +tuple(m.Spinning_Reserve_Up_Requirements)
-                +tuple("marginal_cost_"+rt for rt in sorted(m.SPINNING_RESERVE_TYPES_FROM_GENS))
-                +("peak_day",),
-            values=lambda m, ba, t:
-                (ba, m.tp_period[t], m.tp_timestamp[t])
-                +tuple(
-                    (
-                        sum(
-                            # total reserve production
-                            sum(
-                                m.CommitGenSpinningReservesUp[rt, p, t]
-                                for rt in m.SPINNING_RESERVE_TYPES_FOR_GEN[p]
-                            )
-                            # prorated by energy source used
-                            * DispatchGenByFuel(m, p, t, f) / m.DispatchGen[p, t]
-                            for p in m.GENS_BY_FUEL[f]
-                            if (p, t) in m.GEN_TPS and m.zone_balancing_area[m.gen_load_zone[p]] == ba
-                        )
-                    )
-                    for f in m.FUELS
+                    ""
+                    if val is None  # no dual available, i.e., with glpk solver
+                    else val / m.bring_timepoint_costs_to_base_year[t]
                 )
-                +tuple(
-                    sum(
-                        m.CommitGenSpinningReservesUp[rt, p, t]
-                        for p in m.GENS_BY_NON_FUEL_ENERGY_SOURCE[s]
-                        if (p, t) in m.SPINNING_RESERVE_CAPABLE_GEN_TPS and m.zone_balancing_area[m.gen_load_zone[p]] == ba
-                        for rt in m.SPINNING_RESERVE_TYPES_FOR_GEN[p]
-                    )
-                    for s in m.NON_FUEL_ENERGY_SOURCES
-                )
-                +tuple(
-                    sum(util.get(getattr(m, component), (rt, ba, t), 0.0) for rt in m.SPINNING_RESERVE_TYPES_FROM_GENS)
-                    for component in m.Spinning_Reserve_Up_Provisions
-                )
-                +tuple(
-                    sum(util.get(getattr(m, component), (rt, ba, t), 0.0) for rt in m.SPINNING_RESERVE_TYPES_FROM_GENS)
-                    for component in m.Spinning_Reserve_Up_Requirements
-                )
-                +tuple(
-                    (
-                        '' if val is None # no dual available, i.e., with glpk solver
-                        else val / m.bring_timepoint_costs_to_base_year[t]
-                    )
-                    for val in [
+                for val in [
+                    util.get(
+                        m.dual,
                         util.get(
-                            m.dual,
-                            util.get(
-                                m.Satisfy_Spinning_Reserve_Up_Requirement,
-                                (rt, ba, t),
-                                None
-                            ),
-                            None
-                        )
-                        for rt in sorted(m.SPINNING_RESERVE_TYPES_FROM_GENS)
-                    ]
-                )
-                +(('peak' if m.ts_scale_to_year[m.tp_ts[t]] < avg_ts_scale else 'typical'),)
+                            m.Satisfy_Spinning_Reserve_Up_Requirement, (rt, ba, t), None
+                        ),
+                        None,
+                    )
+                    for rt in sorted(m.SPINNING_RESERVE_TYPES_FROM_GENS)
+                ]
+            )
+            + (
+                (
+                    "peak"
+                    if m.ts_scale_to_year[m.tp_ts[t]] < avg_ts_scale
+                    else "typical"
+                ),
+            ),
         )
 
     sorted_projects = tuple(sorted(g for g in m.GENERATION_PROJECTS))
     util.write_table(
-        m, m.TIMEPOINTS,
+        m,
+        m.TIMEPOINTS,
         output_file=os.path.join(outputs_dir, "gen_dispatch{t}.csv".format(t=tag)),
-        headings=("period", "timepoint_label")+sorted_projects,
-        values=lambda m, t:
-            (m.tp_period[t], m.tp_timestamp[t])
-            + tuple(util.get(m.DispatchGen, (p, t), 0.0) for p in sorted_projects)
+        headings=("period", "timepoint_label") + sorted_projects,
+        values=lambda m, t: (m.tp_period[t], m.tp_timestamp[t])
+        + tuple(util.get(m.DispatchGen, (p, t), 0.0) for p in sorted_projects),
     )
 
     # installed capacity information
     def gen_energy_source(g):
         return (
-            '/'.join(sorted(m.FUELS_FOR_GEN[g]))
+            "/".join(sorted(m.FUELS_FOR_GEN[g]))
             if m.gen_uses_fuel[g]
             else m.gen_energy_source[g]
         )
-    built_gens = tuple(sorted(set(
-        g for pe in m.PERIODS for g in m.GENERATION_PROJECTS if value(m.GenCapacity[g, pe]) > 0.001
-    )))
+
+    built_gens = tuple(
+        sorted(
+            set(
+                g
+                for pe in m.PERIODS
+                for g in m.GENERATION_PROJECTS
+                if value(m.GenCapacity[g, pe]) > 0.001
+            )
+        )
+    )
     active_periods_for_gen = defaultdict(set)
-    used_cap = getattr(m, 'CommitGen', m.DispatchGen) # use CommitGen if available, otherwise DispatchGen
+    used_cap = getattr(
+        m, "CommitGen", m.DispatchGen
+    )  # use CommitGen if available, otherwise DispatchGen
     for (g, tp) in m.GEN_TPS:
         if value(used_cap[g, tp]) > 0.001:
             active_periods_for_gen[g].add(m.tp_period[tp])
@@ -362,109 +434,171 @@ def write_results(m, outputs_dir):
             if start <= p <= end and value(m.GenCapacity[g, p]) > 0:
                 operate_gen_in_period.add((g, p))
 
-    storage_gens = getattr(m, 'STORAGE_GENS', set())
+    storage_gens = getattr(m, "STORAGE_GENS", set())
     built_tech = tuple(sorted(set(m.gen_tech[g] for g in built_gens)))
-    build_tech_and_storage = tuple(sorted(
-        set(built_tech)
-        | set(m.gen_tech[g]+'_MWh' for g in built_gens if g in storage_gens)
-    ) + ['hydro', 'fuel cells'])
+    build_tech_and_storage = tuple(
+        sorted(
+            set(built_tech)
+            | set(m.gen_tech[g] + "_MWh" for g in built_gens if g in storage_gens)
+        )
+        + ["hydro", "fuel cells"]
+    )
 
     built_energy_source = tuple(sorted(set(gen_energy_source(g) for g in built_gens)))
 
     tech_cap = defaultdict(float)
     for (g, p), cap in m.GenCapacity.items():
         tech_cap[m.gen_load_zone[g], m.gen_tech[g], p] += cap
-    if hasattr(m, 'StorageEnergyCapacity'):
+    if hasattr(m, "StorageEnergyCapacity"):
         for (g, p), cap in m.StorageEnergyCapacity.items():
-            tech_cap[m.gen_load_zone[g], m.gen_tech[g] + '_MWh', p] += cap
-    if hasattr(m, 'Pumped_Hydro_Capacity_MW'):
+            tech_cap[m.gen_load_zone[g], m.gen_tech[g] + "_MWh", p] += cap
+    if hasattr(m, "Pumped_Hydro_Capacity_MW"):
         for (z, p), cap in m.Pumped_Hydro_Capacity_MW.items():
-            tech_cap[z, 'hydro', p] += cap
-    if hasattr(m, 'FuelCellCapacityMW'):
+            tech_cap[z, "hydro", p] += cap
+    if hasattr(m, "FuelCellCapacityMW"):
         for (z, p), cap in m.FuelCellCapacityMW.items():
-            tech_cap[z, 'fuel cells', p] += cap
+            tech_cap[z, "fuel cells", p] += cap
 
-    util.write_table(m, m.LOAD_ZONES, m.PERIODS,
-        output_file=os.path.join(outputs_dir, "capacity_by_technology{t}.csv".format(t=tag)),
+    util.write_table(
+        m,
+        m.LOAD_ZONES,
+        m.PERIODS,
+        output_file=os.path.join(
+            outputs_dir, "capacity_by_technology{t}.csv".format(t=tag)
+        ),
         headings=("load_zone", "period") + build_tech_and_storage,
         values=lambda m, z, pe: (
             (z, pe) + tuple(tech_cap[z, t, pe] for t in build_tech_and_storage)
-        )
+        ),
     )
 
-    util.write_table(m, m.LOAD_ZONES, build_tech_and_storage, m.PERIODS,
-        output_file=os.path.join(outputs_dir, "capacity_by_technology_vertical{t}.csv".format(t=tag)),
+    util.write_table(
+        m,
+        m.LOAD_ZONES,
+        build_tech_and_storage,
+        m.PERIODS,
+        output_file=os.path.join(
+            outputs_dir, "capacity_by_technology_vertical{t}.csv".format(t=tag)
+        ),
         headings=("load_zone", "technology", "period", "capacity"),
-        values=lambda m, z, t, pe: (z, t, pe, tech_cap[z, t, pe])
+        values=lambda m, z, t, pe: (z, t, pe, tech_cap[z, t, pe]),
     )
 
-    util.write_table(m, m.LOAD_ZONES, m.PERIODS,
-        output_file=os.path.join(outputs_dir, "capacity_used_by_technology{t}.csv".format(t=tag)),
+    util.write_table(
+        m,
+        m.LOAD_ZONES,
+        m.PERIODS,
+        output_file=os.path.join(
+            outputs_dir, "capacity_used_by_technology{t}.csv".format(t=tag)
+        ),
         headings=("load_zone", "period") + built_tech + ("hydro", "fuel cells"),
-        values=lambda m, z, pe: (z, pe,) + tuple(
+        values=lambda m, z, pe: (
+            z,
+            pe,
+        )
+        + tuple(
             sum(
                 (m.GenCapacity[g, pe] if ((g, pe) in operate_gen_in_period) else 0.0)
-                    for g in built_gens
-                        if m.gen_tech[g] == t and m.gen_load_zone[g] == z
+                for g in built_gens
+                if m.gen_tech[g] == t and m.gen_load_zone[g] == z
             )
             for t in built_tech
-        ) + (
-            m.Pumped_Hydro_Capacity_MW[z, pe] if hasattr(m, "Pumped_Hydro_Capacity_MW") else 0,
-            m.FuelCellCapacityMW[z, pe] if hasattr(m, "FuelCellCapacityMW") else 0
         )
+        + (
+            m.Pumped_Hydro_Capacity_MW[z, pe]
+            if hasattr(m, "Pumped_Hydro_Capacity_MW")
+            else 0,
+            m.FuelCellCapacityMW[z, pe] if hasattr(m, "FuelCellCapacityMW") else 0,
+        ),
     )
 
-    util.write_table(m, m.LOAD_ZONES, m.PERIODS,
-        output_file=os.path.join(outputs_dir, "capacity_by_energy_source{t}.csv".format(t=tag)),
-        headings=("load_zone", "period") + built_energy_source + ("hydro", "fuel cells"),
-        values=lambda m, z, pe: (z, pe,) + tuple(
+    util.write_table(
+        m,
+        m.LOAD_ZONES,
+        m.PERIODS,
+        output_file=os.path.join(
+            outputs_dir, "capacity_by_energy_source{t}.csv".format(t=tag)
+        ),
+        headings=("load_zone", "period")
+        + built_energy_source
+        + ("hydro", "fuel cells"),
+        values=lambda m, z, pe: (
+            z,
+            pe,
+        )
+        + tuple(
             sum(
                 m.GenCapacity[g, pe]
                 for g in built_gens
                 if gen_energy_source(g) == s and m.gen_load_zone[g] == z
             )
             for s in built_energy_source
-        ) + (
-            m.Pumped_Hydro_Capacity_MW[z, pe] if hasattr(m, "Pumped_Hydro_Capacity_MW") else 0,
-            m.FuelCellCapacityMW[z, pe] if hasattr(m, "FuelCellCapacityMW") else 0
         )
+        + (
+            m.Pumped_Hydro_Capacity_MW[z, pe]
+            if hasattr(m, "Pumped_Hydro_Capacity_MW")
+            else 0,
+            m.FuelCellCapacityMW[z, pe] if hasattr(m, "FuelCellCapacityMW") else 0,
+        ),
     )
-    util.write_table(m, m.LOAD_ZONES, m.PERIODS,
-        output_file=os.path.join(outputs_dir, "capacity_used_by_energy_source{t}.csv".format(t=tag)),
-        headings=("load_zone", "period") + built_energy_source + ("hydro", "fuel cells"),
-        values=lambda m, z, pe: (z, pe,) + tuple(
+    util.write_table(
+        m,
+        m.LOAD_ZONES,
+        m.PERIODS,
+        output_file=os.path.join(
+            outputs_dir, "capacity_used_by_energy_source{t}.csv".format(t=tag)
+        ),
+        headings=("load_zone", "period")
+        + built_energy_source
+        + ("hydro", "fuel cells"),
+        values=lambda m, z, pe: (
+            z,
+            pe,
+        )
+        + tuple(
             sum(
                 (m.GenCapacity[g, pe] if ((g, pe) in operate_gen_in_period) else 0.0)
-                    for g in built_gens
-                        if gen_energy_source(g) == s and m.gen_load_zone[g] == z
+                for g in built_gens
+                if gen_energy_source(g) == s and m.gen_load_zone[g] == z
             )
             for s in built_energy_source
-        ) + (
-            m.Pumped_Hydro_Capacity_MW[z, pe] if hasattr(m, "Pumped_Hydro_Capacity_MW") else 0,
-            m.FuelCellCapacityMW[z, pe] if hasattr(m, "FuelCellCapacityMW") else 0
         )
+        + (
+            m.Pumped_Hydro_Capacity_MW[z, pe]
+            if hasattr(m, "Pumped_Hydro_Capacity_MW")
+            else 0,
+            m.FuelCellCapacityMW[z, pe] if hasattr(m, "FuelCellCapacityMW") else 0,
+        ),
     )
 
-    util.write_table(m, m.LOAD_ZONES, m.PERIODS,
-        output_file=os.path.join(outputs_dir, "production_by_technology{t}.csv".format(t=tag)),
+    util.write_table(
+        m,
+        m.LOAD_ZONES,
+        m.PERIODS,
+        output_file=os.path.join(
+            outputs_dir, "production_by_technology{t}.csv".format(t=tag)
+        ),
         headings=("load_zone", "period") + built_tech + ad_hoc_sources,
-        values=lambda m, z, pe:
-            (z, pe,)
-            + tuple(
-                sum(
-                    m.DispatchGen[g, tp] * m.tp_weight_in_year[tp] * 0.001 # MWh -> GWh
-                    for g in built_gens if m.gen_tech[g] == t and m.gen_load_zone[g] == z
-                    for tp in m.TPS_FOR_GEN_IN_PERIOD[g, pe]
-                )
-                for t in built_tech
+        values=lambda m, z, pe: (
+            z,
+            pe,
+        )
+        + tuple(
+            sum(
+                m.DispatchGen[g, tp] * m.tp_weight_in_year[tp] * 0.001  # MWh -> GWh
+                for g in built_gens
+                if m.gen_tech[g] == t and m.gen_load_zone[g] == z
+                for tp in m.TPS_FOR_GEN_IN_PERIOD[g, pe]
             )
-            + tuple(  # ad hoc techs: hydrogen, pumped storage, etc.
-                sum(
-                    comp[z, tp] * m.tp_weight_in_year[tp] * 0.001
-                    for tp in m.TPS_IN_PERIOD[pe]
-                )
-                for comp in [getattr(m, cname) for cname in ad_hoc_sources]
+            for t in built_tech
+        )
+        + tuple(  # ad hoc techs: hydrogen, pumped storage, etc.
+            sum(
+                comp[z, tp] * m.tp_weight_in_year[tp] * 0.001
+                for tp in m.TPS_IN_PERIOD[pe]
             )
+            for comp in [getattr(m, cname) for cname in ad_hoc_sources]
+        ),
     )
 
     # option 1: make separate tables of production_by_technology and production_by_energy_source,
@@ -475,43 +609,49 @@ def write_results(m, outputs_dir):
     # use a database format rather than a table format, which will then require post-processing
     # by pandas or an Excel pivot table.
     # For now, we go with option 1.
-    util.write_table(m, m.LOAD_ZONES, m.PERIODS,
-        output_file=os.path.join(outputs_dir, "production_by_energy_source{t}.csv".format(t=tag)),
-        headings=
-            ("load_zone", "period")
-            + tuple(m.FUELS)
-            + tuple(m.NON_FUEL_ENERGY_SOURCES)
-            + ad_hoc_sources,
-        values=lambda m, z, pe:
-            (z, pe,)
-            + tuple(
-                sum(
-                    DispatchGenByFuel(m, g, tp, f) * m.tp_weight_in_year[tp] * 0.001 # MWh -> GWh
-                    for g in m.GENS_BY_FUEL[f]
-                    if m.gen_load_zone[g] == z
-                    for tp in m.TPS_FOR_GEN_IN_PERIOD[g, pe]
-                )
-                for f in m.FUELS
+    util.write_table(
+        m,
+        m.LOAD_ZONES,
+        m.PERIODS,
+        output_file=os.path.join(
+            outputs_dir, "production_by_energy_source{t}.csv".format(t=tag)
+        ),
+        headings=("load_zone", "period")
+        + tuple(m.FUELS)
+        + tuple(m.NON_FUEL_ENERGY_SOURCES)
+        + ad_hoc_sources,
+        values=lambda m, z, pe: (
+            z,
+            pe,
+        )
+        + tuple(
+            sum(
+                DispatchGenByFuel(m, g, tp, f)
+                * m.tp_weight_in_year[tp]
+                * 0.001  # MWh -> GWh
+                for g in m.GENS_BY_FUEL[f]
+                if m.gen_load_zone[g] == z
+                for tp in m.TPS_FOR_GEN_IN_PERIOD[g, pe]
             )
-            + tuple(
-                sum(
-                    m.DispatchGen[g, tp] * m.tp_weight_in_year[tp] * 0.001 # MWh -> GWh
-                    for g in m.GENS_BY_NON_FUEL_ENERGY_SOURCE[s]
-                    if m.gen_load_zone[g] == z
-                    for tp in m.TPS_FOR_GEN_IN_PERIOD[g, pe]
-                )
-                for s in m.NON_FUEL_ENERGY_SOURCES
+            for f in m.FUELS
+        )
+        + tuple(
+            sum(
+                m.DispatchGen[g, tp] * m.tp_weight_in_year[tp] * 0.001  # MWh -> GWh
+                for g in m.GENS_BY_NON_FUEL_ENERGY_SOURCE[s]
+                if m.gen_load_zone[g] == z
+                for tp in m.TPS_FOR_GEN_IN_PERIOD[g, pe]
             )
-            + tuple(  # ad hoc techs: hydrogen, pumped storage, etc.
-                sum(
-                    comp[z, tp] * m.tp_weight_in_year[tp] * 0.001
-                    for tp in m.TPS_IN_PERIOD[pe]
-                )
-                for comp in [getattr(m, cname) for cname in ad_hoc_sources]
+            for s in m.NON_FUEL_ENERGY_SOURCES
+        )
+        + tuple(  # ad hoc techs: hydrogen, pumped storage, etc.
+            sum(
+                comp[z, tp] * m.tp_weight_in_year[tp] * 0.001
+                for tp in m.TPS_IN_PERIOD[pe]
             )
+            for comp in [getattr(m, cname) for cname in ad_hoc_sources]
+        ),
     )
-
-
 
     # def cost_breakdown_details(m, z, pe):
     #     values = [z, pe]
@@ -643,14 +783,14 @@ def write_results(m, outputs_dir):
     #     values=lambda m, pe: (pe,) + tuple(m.GenCapacity[g, pe] for g in built_gens)
     # )
 
-
-    if hasattr(m, 'RFMSupplyTierActivate'):
-        util.write_table(m, m.RFM_SUPPLY_TIERS,
+    if hasattr(m, "RFMSupplyTierActivate"):
+        util.write_table(
+            m,
+            m.RFM_SUPPLY_TIERS,
             output_file=os.path.join(outputs_dir, "rfm_activate{t}.csv".format(t=tag)),
             headings=("market", "period", "tier", "activate"),
-            values=lambda m, r, p, st: (r, p, st, m.RFMSupplyTierActivate[r, p, st])
+            values=lambda m, r, p, st: (r, p, st, m.RFMSupplyTierActivate[r, p, st]),
         )
-
 
     # import pprint
     # b=[(g, pe, value(m.BuildGen[g, pe]), m.gen_tech[g], m.gen_overnight_cost[g, pe]) for (g, pe) in m.BuildGen if value(m.BuildGen[g, pe]) > 0]

--- a/switch_model/hawaii/scenarios.py
+++ b/switch_model/hawaii/scenarios.py
@@ -3,10 +3,14 @@ from switch_model.utilities import string_types
 
 try:
     import fcntl
+
     def flock(f):
         fcntl.flock(f, fcntl.LOCK_EX)
+
     def funlock(f):
         fcntl.flock(f, fcntl.LOCK_UN)
+
+
 except ImportError:
     # probably using windows
     # rely on opportunistic file writing (hope that scenarios aren't
@@ -15,8 +19,10 @@ except ImportError:
     # https://www.safaribooksonline.com/library/view/python-cookbook/0596001673/ch04s25.html
     def flock(f):
         pass
+
     def funlock(f):
         pass
+
 
 def iterify(item):
     """Return an iterable for the one or more items passed."""
@@ -30,15 +36,18 @@ def iterify(item):
             i = iter([item])
     return i
 
+
 class AddModuleAction(argparse.Action):
     def __call__(self, parser, namespace, values, option_string=None):
         for m in iterify(values):
             setattr(namespace, m, True)
 
+
 class RemoveModuleAction(argparse.Action):
     def __call__(self, parser, namespace, values, option_string=None):
         for m in iterify(values):
             setattr(namespace, m, False)
+
 
 class AddListAction(argparse.Action):
     def __call__(self, parser, namespace, values, option_string=None):
@@ -46,32 +55,44 @@ class AddListAction(argparse.Action):
             setattr(namespace, self.dest, list())
         getattr(namespace, self.dest).extend(iterify(values))
 
+
 # define a standard argument parser, which can be used to setup scenarios
 # NOTE: you can't safely use default values here, because those end up being
 # assigned to cmd_line_args(), and then they override any values set for the
 # standard scenarios.
-parser = argparse.ArgumentParser(description='Solve one or more Switch-Hawaii scenarios.')
-parser.add_argument('--inputs', dest='inputs_dir')
-parser.add_argument('--inputs-subdir')
-parser.add_argument('--outputs', dest='outputs_dir')
-parser.add_argument('--scenario', action=AddListAction, dest='scenario_to_run')
-parser.add_argument('--scenarios', action=AddListAction, nargs='+', dest='scenario_to_run')
-parser.add_argument('--scenario-name')
-parser.add_argument('--exclude', action=AddModuleAction, dest='exclude_module', nargs='+')
-parser.add_argument('-n', action=RemoveModuleAction, dest='exclude_module')
-parser.add_argument('--include', action=AddModuleAction, dest='include_module', nargs='+')
-parser.add_argument('-y', action=AddModuleAction, dest='include_module')
-parser.add_argument(action=AddModuleAction, dest='include_module', nargs='*')
+parser = argparse.ArgumentParser(
+    description="Solve one or more Switch-Hawaii scenarios."
+)
+parser.add_argument("--inputs", dest="inputs_dir")
+parser.add_argument("--inputs-subdir")
+parser.add_argument("--outputs", dest="outputs_dir")
+parser.add_argument("--scenario", action=AddListAction, dest="scenario_to_run")
+parser.add_argument(
+    "--scenarios", action=AddListAction, nargs="+", dest="scenario_to_run"
+)
+parser.add_argument("--scenario-name")
+parser.add_argument(
+    "--exclude", action=AddModuleAction, dest="exclude_module", nargs="+"
+)
+parser.add_argument("-n", action=RemoveModuleAction, dest="exclude_module")
+parser.add_argument(
+    "--include", action=AddModuleAction, dest="include_module", nargs="+"
+)
+parser.add_argument("-y", action=AddModuleAction, dest="include_module")
+parser.add_argument(action=AddModuleAction, dest="include_module", nargs="*")
+
 
 def args_dict(*a):
     """call the parser to get the args, then return them as a dictionary, omitting None's'"""
     return {k: v for k, v in vars(parser.parse_args(*a)).items() if v is not None}
+
 
 # report current command line arguments for use by various functions
 # This is a function instead of a constant, so users can call
 # scenarios.parser.add_argument() to add arguments of their own before evaluation
 def cmd_line_args():
     return args_dict()
+
 
 def get_required_scenario_names():
     """Return list of names of scenario(s) that were requested or defined from the command line
@@ -80,11 +101,11 @@ def get_required_scenario_names():
     a = cmd_line_args()
     if "scenario_to_run" in a:
         return a["scenario_to_run"]
-    elif "scenario_name" in a or not os.path.isfile('scenarios_to_run.txt'):
+    elif "scenario_name" in a or not os.path.isfile("scenarios_to_run.txt"):
         # They have defined one specific scenario on the command line, which is not based on any standard scenario,
         # or there are no standard scenarios.
         # Return a no-name scenario, which indicates to build the scenario without referring to any standard scenario.
-        return ['']
+        return [""]
     else:
         # no specific scenarios were requested on the command line; run the standard scenarios instead
         return []
@@ -101,12 +122,13 @@ def start_next_standard_scenario():
             continue
         else:
             return merge_scenarios(args, cmd_line_args())
-    return None     # no more scenarios to run
+    return None  # no more scenarios to run
+
 
 def get_scenario_args(scenario):
     """Return the arguments for the specified standard scenario, amended with any command-line arguments.
     This may also be called with an empty scenario name ('') to define a scenario using only command-line arguments."""
-    if scenario == '':
+    if scenario == "":
         return merge_scenarios(cmd_line_args())
     else:
         scenario_list = get_standard_scenarios_dict()
@@ -115,49 +137,55 @@ def get_scenario_args(scenario):
         else:
             return merge_scenarios(scenario_list[scenario], cmd_line_args())
 
+
 def get_standard_scenarios_dict():
     """Return collection of standard scenarios, as defined in scenarios_to_run.txt.
     They are returned as an OrderedDict with keys equal to the scenario names and values
     that are each a dictionary of arguments for that scenario."""
     # note: we read the list from the disk each time so that we get a fresher version
     # if the standard list is changed during a long solution effort.
-    with open('scenarios_to_run.txt', 'r') as f:
+    with open("scenarios_to_run.txt", "r") as f:
         # wait for exclusive access to the file (to avoid reading while the file is being changed)
         flock(f)
-        scenarios_list = list(f.read().splitlines())    # note: ignores presence/absence of \n at end of file
+        scenarios_list = list(
+            f.read().splitlines()
+        )  # note: ignores presence/absence of \n at end of file
         funlock(f)
-    args_list = [args_dict(s.split(' ')) for s in scenarios_list]
+    args_list = [args_dict(s.split(" ")) for s in scenarios_list]
     return collections.OrderedDict([(s["scenario_name"], s) for s in args_list])
+
 
 def merge_scenarios(*scenarios):
     # combine scenarios: start with the first and then apply most settings from later ones
     # but concatenate "tag" entries and remove "scenario_to_run" entries
-    d = dict(tag='')
+    d = dict(tag="")
     for s in scenarios:
         t1 = d["tag"]
         t2 = s.get("tag", "")
         s["tag"] = t1 + ("" if t1 == "" or t2 == "" else "_") + t2
         d.update(s)
-    if 'scenario_to_run' in d:
-        del d['scenario_to_run']
+    if "scenario_to_run" in d:
+        del d["scenario_to_run"]
     return d
+
 
 def report_completed_scenario(scenario):
     scenario_already_run(scenario)
 
+
 def scenario_already_run(scenario):
     """Add the specified scenario to the list in completed_scenarios.txt.
     Return False if it wasn't there already."""
-    with open('completed_scenarios.txt', 'a+') as f:
+    with open("completed_scenarios.txt", "a+") as f:
         # wait for exclusive access to the list (to avoid writing the same scenario twice in a race condition)
         flock(f)
         # file starts with pointer at end; move to start
         f.seek(0, 0)
-        if scenario + '\n' in f:
+        if scenario + "\n" in f:
             already_run = True
         else:
             already_run = False
             # append name to the list (will always go at end, because file was opened in 'a' mode)
-            f.write(scenario + '\n')
+            f.write(scenario + "\n")
         funlock(f)
     return already_run

--- a/switch_model/hawaii/smooth_dispatch.py
+++ b/switch_model/hawaii/smooth_dispatch.py
@@ -21,14 +21,20 @@ from switch_model.utilities import iteritems
 # should be placed high in the module list so that the post-solve smoothing code
 # will run before the post-solve reporting code in other modules.
 def define_dynamic_components(m):
-    if m.options.solver in ('cplex', 'cplexamp', 'gurobi', 'gurobi_ampl'):
+    if m.options.solver in ("cplex", "cplexamp", "gurobi", "gurobi_ampl"):
         m.options.smooth_dispatch = True
     else:
         # glpk and cbc can't handle quadratic problem used for smoothing
         m.options.smooth_dispatch = False
         if m.options.verbose:
-            print("Not smoothing dispatch because {} cannot solve a quadratic model.".format(m.options.solver))
-            print("Remove hawaii.smooth_dispatch from modules.txt and iterate.txt to avoid this message.")
+            print(
+                "Not smoothing dispatch because {} cannot solve a quadratic model.".format(
+                    m.options.solver
+                )
+            )
+            print(
+                "Remove hawaii.smooth_dispatch from modules.txt and iterate.txt to avoid this message."
+            )
 
     # add an alternative objective function that smoothes out time-shiftable energy sources and sinks
     if m.options.smooth_dispatch:
@@ -36,10 +42,15 @@ def define_dynamic_components(m):
         # these should each have timepoint as their final index component
         # They should also be in order from most-smoothed to least-smoothed
         components_to_smooth = [
-            'ShiftDemand', 'ChargeEVs',
-            'RunElectrolyzerMW', 'LiquifyHydrogenMW', 'DispatchFuelCellMW',
-            'ChargeBattery', 'ChargeStorage',
-            'DischargeBattery', 'DispatchGen',
+            "ShiftDemand",
+            "ChargeEVs",
+            "RunElectrolyzerMW",
+            "LiquifyHydrogenMW",
+            "DispatchFuelCellMW",
+            "ChargeBattery",
+            "ChargeStorage",
+            "DischargeBattery",
+            "DispatchGen",
         ]
 
         def add_smoothing_entry(m, d, component, key, weight=1.0):
@@ -54,7 +65,7 @@ def define_dynamic_components(m):
             tp = key[-1]
             prev_tp = m.TPS_IN_TS[m.tp_ts[tp]].prevw(tp)
             entry_key = str((component.name,) + key)
-            entry_val = component[key] - component[key[:-1]+(prev_tp,)]
+            entry_val = component[key] - component[key[:-1] + (prev_tp,)]
             d[entry_key] = weight * entry_val
 
         def rule(m):
@@ -69,7 +80,9 @@ def define_dynamic_components(m):
                     continue
                 print("Will smooth {} with weight {}.".format(c, weight))
                 for key in comp:
-                    add_smoothing_entry(m, m.component_smoothing_dict, comp, key, weight)
+                    add_smoothing_entry(
+                        m, m.component_smoothing_dict, comp, key, weight
+                    )
             # # smooth standard storage generators
             # if hasattr(m, 'STORAGE_GEN_TPS'):
             #     print "Will smooth charging and discharging of standard storage."
@@ -77,6 +90,7 @@ def define_dynamic_components(m):
             #         comp = getattr(m, c)
             #         for key in m.STORAGE_GEN_TPS:
             #             add_smoothing_entry(m, m.component_smoothing_dict, comp, key)
+
         m.make_component_smoothing_dict = BuildAction(rule=rule)
 
         # Force IncreaseSmoothedValue to equal any step-up in a smoothed value
@@ -84,23 +98,27 @@ def define_dynamic_components(m):
         m.IncreaseSmoothedValue = Var(m.ISV_INDEX, within=NonNegativeReals)
         m.Calculate_IncreaseSmoothedValue = Constraint(
             m.ISV_INDEX,
-            rule=lambda m, k: m.IncreaseSmoothedValue[k] >= m.component_smoothing_dict[k]
+            rule=lambda m, k: m.IncreaseSmoothedValue[k]
+            >= m.component_smoothing_dict[k],
         )
 
         def Smooth_Free_Variables_obj_rule(m):
             # minimize production (i.e., maximize curtailment / minimize losses)
             obj = sum(
                 getattr(m, component)[z, t]
-                    for z in m.LOAD_ZONES
-                        for t in m.TIMEPOINTS
-                            for component in m.Zone_Power_Injections)
+                for z in m.LOAD_ZONES
+                for t in m.TIMEPOINTS
+                for component in m.Zone_Power_Injections
+            )
             # also maximize up reserves, which will (a) minimize arbitrary burning off of renewables
             # (e.g., via storage) and (b) give better representation of the amount of reserves actually available
-            if hasattr(m, 'Spinning_Reserve_Up_Provisions') and hasattr(m, 'GEN_SPINNING_RESERVE_TYPES'): # advanced module
+            if hasattr(m, "Spinning_Reserve_Up_Provisions") and hasattr(
+                m, "GEN_SPINNING_RESERVE_TYPES"
+            ):  # advanced module
                 print("Will maximize provision of up reserves.")
                 reserve_weight = {
                     m.options.contingency_reserve_type: 0.9,
-                    m.options.regulating_reserve_type: 1.1
+                    m.options.regulating_reserve_type: 1.1,
                 }
                 for comp_name in m.Spinning_Reserve_Up_Provisions:
                     component = getattr(m, comp_name)
@@ -111,7 +129,9 @@ def define_dynamic_components(m):
             # also minimize contingency up reserve requirements to avoid
             # spuriously high contingency requirements (they can be
             # any feasible value above the largest contingency)
-            if hasattr(m, 'Spinning_Reserve_Up_Requirements') and hasattr(m, 'GEN_SPINNING_RESERVE_TYPES'): # advanced module
+            if hasattr(m, "Spinning_Reserve_Up_Requirements") and hasattr(
+                m, "GEN_SPINNING_RESERVE_TYPES"
+            ):  # advanced module
                 print("Will minimize requirement for contingency up reserves.")
                 for comp_name in m.Spinning_Reserve_Up_Requirements:
                     component = getattr(m, comp_name)
@@ -123,7 +143,10 @@ def define_dynamic_components(m):
             # minimize absolute value of changes in the smoothed variables
             obj += sum(v for v in m.IncreaseSmoothedValue.values())
             return obj
-        m.Smooth_Free_Variables = Objective(rule=Smooth_Free_Variables_obj_rule, sense=minimize)
+
+        m.Smooth_Free_Variables = Objective(
+            rule=Smooth_Free_Variables_obj_rule, sense=minimize
+        )
 
         # constrain smoothing objective to find unbounded ray
         # m.Bound_Obj = Constraint(rule=lambda m: Smooth_Free_Variables_obj_rule(m) <= 1e12)
@@ -140,58 +163,67 @@ def pre_iterate(m):
         elif m.iteration_number == 1:
             pre_smooth_solve(m)
         else:
-            raise RuntimeError("Reached unexpected iteration number {} in module {}.".format(m.iteration_number, __name__))
+            raise RuntimeError(
+                "Reached unexpected iteration number {} in module {}.".format(
+                    m.iteration_number, __name__
+                )
+            )
 
     return None  # no comment on convergence
+
 
 def post_iterate(m):
     if hasattr(m, "ChargeBattery"):
         double_charge = [
-            (
-                z, t,
-                m.ChargeBattery[z, t].value,
-                m.DischargeBattery[z, t].value
-            )
-                for z in m.LOAD_ZONES
-                    for t in m.TIMEPOINTS
-                        if m.ChargeBattery[z, t].value > 0
-                            and m.DischargeBattery[z, t].value > 0
+            (z, t, m.ChargeBattery[z, t].value, m.DischargeBattery[z, t].value)
+            for z in m.LOAD_ZONES
+            for t in m.TIMEPOINTS
+            if m.ChargeBattery[z, t].value > 0 and m.DischargeBattery[z, t].value > 0
         ]
         if len(double_charge) > 0:
             print("")
-            print("WARNING: batteries are simultaneously charged and discharged in some hours.")
+            print(
+                "WARNING: batteries are simultaneously charged and discharged in some hours."
+            )
             print("This is usually done to relax the biofuel limit.")
             for (z, t, c, d) in double_charge:
-                print('ChargeBattery[{z}, {t}]={c}, DischargeBattery[{z}, {t}]={d}'.format(
-                    z=z, t=m.tp_timestamp[t],
-                    c=c, d=d
-                ))
+                print(
+                    "ChargeBattery[{z}, {t}]={c}, DischargeBattery[{z}, {t}]={d}".format(
+                        z=z, t=m.tp_timestamp[t], c=c, d=d
+                    )
+                )
 
     if m.options.smooth_dispatch:
         # setup model for next iteration
         if m.iteration_number == 0:
-            done = False # we'll have to run again to do the smoothing
+            done = False  # we'll have to run again to do the smoothing
         elif m.iteration_number == 1:
             # finished smoothing the model
             post_smooth_solve(m)
             # now we're done
             done = True
         else:
-            raise RuntimeError("Reached unexpected iteration number {} in module {}.".format(m.iteration_number, __name__))
+            raise RuntimeError(
+                "Reached unexpected iteration number {} in module {}.".format(
+                    m.iteration_number, __name__
+                )
+            )
     else:
         # not smoothing the dispatch
         done = True
 
     return done
 
+
 def post_solve(m, outputs_dir):
     """ Smooth dispatch if it wasn't already done during an iterative solution. """
-    if m.options.smooth_dispatch and not getattr(m, 'iterated_smooth_dispatch', False):
+    if m.options.smooth_dispatch and not getattr(m, "iterated_smooth_dispatch", False):
         pre_smooth_solve(m)
         # re-solve and load results
         m.preprocess()
         solve(m)
         post_smooth_solve(m)
+
 
 def pre_smooth_solve(m):
     """ store model state and prepare for smoothing """
@@ -201,15 +233,19 @@ def pre_smooth_solve(m):
     m.Smooth_Free_Variables.activate()
     print("smoothing free variables...")
 
+
 def solve(m):
     try:
         switch_model.solve.solve(m)
     except RuntimeError as e:
-        if str(e).lower() == 'infeasible model':
+        if str(e).lower() == "infeasible model":
             # show a warning, but don't abort the overall post_solve process
-            print('WARNING: model became infeasible when smoothing; reverting to original solution.')
+            print(
+                "WARNING: model became infeasible when smoothing; reverting to original solution."
+            )
         else:
             raise
+
 
 def post_smooth_solve(m):
     """ restore original model state """
@@ -223,47 +259,51 @@ def post_smooth_solve(m):
 
 
 def save_duals(m):
-    if hasattr(m, 'dual'):
+    if hasattr(m, "dual"):
         m.old_dual_dict = m.dual._dict.copy()
-    if hasattr(m, 'rc'):
+    if hasattr(m, "rc"):
         m.old_rc_dict = m.rc._dict.copy()
 
+
 def restore_duals(m):
-    if hasattr(m, 'dual'):
+    if hasattr(m, "dual"):
         m.dual._dict = m.old_dual_dict
-    if hasattr(m, 'rc'):
+    if hasattr(m, "rc"):
         m.rc._dict = m.old_rc_dict
+
 
 def fix_obj_expression(e, status=True):
     """Recursively fix all variables included in an objective expression."""
     # note: this contains code to work with various versions of Pyomo,
     # e.g., _potentially_variable in 5.1, is_potentially_variable in 5.6
-    if hasattr(e, 'fixed'):
-        e.fixed = status      # see p. 171 of the Pyomo book
-    elif hasattr(e, '_numerator'):
+    if hasattr(e, "fixed"):
+        e.fixed = status  # see p. 171 of the Pyomo book
+    elif hasattr(e, "_numerator"):
         for e2 in e._numerator:
             fix_obj_expression(e2, status)
         for e2 in e._denominator:
             fix_obj_expression(e2, status)
-    elif hasattr(e, 'args'):  # SumExpression; can't actually see where this is defined in Pyomo though
+    elif hasattr(
+        e, "args"
+    ):  # SumExpression; can't actually see where this is defined in Pyomo though
         for e2 in e.args:
             fix_obj_expression(e2, status)
-    elif hasattr(e, '_args'): # switched to 'args' and/or '_args_' in Pyomo 5
+    elif hasattr(e, "_args"):  # switched to 'args' and/or '_args_' in Pyomo 5
         for e2 in e._args:
             fix_obj_expression(e2, status)
-    elif hasattr(e, 'expr'):
+    elif hasattr(e, "expr"):
         fix_obj_expression(e.expr, status)
     # below here are parameters or constants, no need to fix
-    elif hasattr(e, 'is_potentially_variable') and not e.is_potentially_variable():
+    elif hasattr(e, "is_potentially_variable") and not e.is_potentially_variable():
         pass
-    elif hasattr(e, '_potentially_variable') and not e._potentially_variable():
+    elif hasattr(e, "_potentially_variable") and not e._potentially_variable():
         pass
-    elif hasattr(e, 'is_constant') and e.is_constant():
+    elif hasattr(e, "is_constant") and e.is_constant():
         pass
     elif type(e) in native_numeric_types:
         pass
     else:
         raise ValueError(
-            'Expression {} does not have an expr, fixed or args property, '
-            'so it cannot be fixed.'.format(e)
+            "Expression {} does not have an expr, fixed or args property, "
+            "so it cannot be fixed.".format(e)
         )

--- a/switch_model/hawaii/smooth_dispatch_quadratic.py
+++ b/switch_model/hawaii/smooth_dispatch_quadratic.py
@@ -5,62 +5,86 @@ from __future__ import print_function
 from pyomo.environ import *
 import switch_model.solve
 
+
 def define_components(m):
-    if m.options.solver in ('cplex', 'cplexamp', 'gurobi', 'gurobi_ampl'):
+    if m.options.solver in ("cplex", "cplexamp", "gurobi", "gurobi_ampl"):
         m.options.smooth_dispatch = True
     else:
         # glpk and cbc can't handle quadratic problem used for smoothing
         m.options.smooth_dispatch = False
         if m.options.verbose:
-            print("Not smoothing dispatch because {} cannot solve a quadratic model.".format(m.options.solver))
-            print("Remove hawaii.smooth_dispatch from modules.txt and iterate.txt to avoid this message.")
+            print(
+                "Not smoothing dispatch because {} cannot solve a quadratic model.".format(
+                    m.options.solver
+                )
+            )
+            print(
+                "Remove hawaii.smooth_dispatch from modules.txt and iterate.txt to avoid this message."
+            )
 
     # add an alternative objective function that smoothes out time-shiftable energy sources and sinks
     if m.options.smooth_dispatch:
-        if hasattr(m, 'ChargeEVs') and isinstance(m.ChargeEVs, Expression):
+        if hasattr(m, "ChargeEVs") and isinstance(m.ChargeEVs, Expression):
             # Create a variable bound to the ChargeEVs expression
             # that can be squared in the objective function without creating
             # a non-positive-definite problem.
             m.ChargeEVsVar = Var(m.ChargeEVs.index_set())
             m.ChargeEVsVar_fix = Constraint(
                 m.ChargeEVs.index_set(),
-                rule=lambda m, *key: m.ChargeEVsVar[key] == m.ChargeEVs[key]
+                rule=lambda m, *key: m.ChargeEVsVar[key] == m.ChargeEVs[key],
             )
 
         def Smooth_Free_Variables_obj_rule(m):
             # minimize production (i.e., maximize curtailment / minimize losses)
             obj = sum(
                 getattr(m, component)[z, t]
-                    for z in m.LOAD_ZONES
-                        for t in m.TIMEPOINTS
-                            for component in m.Zone_Power_Injections)
+                for z in m.LOAD_ZONES
+                for t in m.TIMEPOINTS
+                for component in m.Zone_Power_Injections
+            )
 
             # minimize the variability of various slack responses
             components_to_smooth = [
-                'ShiftDemand', 'ChargeBattery', 'DischargeBattery',
-                'RunElectrolyzerMW', 'LiquifyHydrogenMW', 'DispatchFuelCellMW',
+                "ShiftDemand",
+                "ChargeBattery",
+                "DischargeBattery",
+                "RunElectrolyzerMW",
+                "LiquifyHydrogenMW",
+                "DispatchFuelCellMW",
             ]
-            if hasattr(m, 'ChargeEVsVar'):
-                components_to_smooth.append('ChargeEVsVar')
+            if hasattr(m, "ChargeEVsVar"):
+                components_to_smooth.append("ChargeEVsVar")
             else:
-                components_to_smooth.append('ChargeEVs')
+                components_to_smooth.append("ChargeEVs")
 
             for var in components_to_smooth:
                 if hasattr(m, var):
                     if m.options.verbose:
                         print("Will smooth {}.".format(var))
                     comp = getattr(m, var)
-                    obj += sum(comp[z, t]*comp[z, t] for z in m.LOAD_ZONES for t in m.TIMEPOINTS)
+                    obj += sum(
+                        comp[z, t] * comp[z, t]
+                        for z in m.LOAD_ZONES
+                        for t in m.TIMEPOINTS
+                    )
             # include standard storage generators too
-            if hasattr(m, 'STORAGE_GEN_TPS'):
+            if hasattr(m, "STORAGE_GEN_TPS"):
                 print("Will smooth charging and discharging of standard storage.")
-                obj += sum(m.ChargeStorage[g, tp]*m.ChargeStorage[g, tp] for g, tp in m.STORAGE_GEN_TPS)
-                obj += sum(m.DispatchGen[g, tp]*m.DispatchGen[g, tp] for g, tp in m.STORAGE_GEN_TPS)
+                obj += sum(
+                    m.ChargeStorage[g, tp] * m.ChargeStorage[g, tp]
+                    for g, tp in m.STORAGE_GEN_TPS
+                )
+                obj += sum(
+                    m.DispatchGen[g, tp] * m.DispatchGen[g, tp]
+                    for g, tp in m.STORAGE_GEN_TPS
+                )
             # also maximize up reserves, which will (a) minimize arbitrary burning off of renewables
             # (e.g., via storage) and (b) give better representation of the amount of reserves actually available
-            if hasattr(m, 'Spinning_Reserve_Up_Provisions') and hasattr(m, 'GEN_SPINNING_RESERVE_TYPES'): # advanced module
+            if hasattr(m, "Spinning_Reserve_Up_Provisions") and hasattr(
+                m, "GEN_SPINNING_RESERVE_TYPES"
+            ):  # advanced module
                 print("Will maximize provision of up reserves.")
-                reserve_weight = {'contingency': 0.9, 'regulation': 1.1}
+                reserve_weight = {"contingency": 0.9, "regulation": 1.1}
                 for comp_name in m.Spinning_Reserve_Up_Provisions:
                     component = getattr(m, comp_name)
                     obj += -0.1 * sum(
@@ -68,7 +92,10 @@ def define_components(m):
                         for rt, ba, tp in component
                     )
             return obj
-        m.Smooth_Free_Variables = Objective(rule=Smooth_Free_Variables_obj_rule, sense=minimize)
+
+        m.Smooth_Free_Variables = Objective(
+            rule=Smooth_Free_Variables_obj_rule, sense=minimize
+        )
         # leave standard objective in effect for now
         m.Smooth_Free_Variables.deactivate()
 
@@ -80,6 +107,7 @@ def define_components(m):
         #     m.Minimize_System_Cost.activate()
         # m.Fix_Obj = BuildAction(rule=Fix_Obj_rule)
 
+
 def pre_iterate(m):
     if m.options.smooth_dispatch:
         if m.iteration_number == 0:
@@ -88,58 +116,67 @@ def pre_iterate(m):
         elif m.iteration_number == 1:
             pre_smooth_solve(m)
         else:
-            raise RuntimeError("Reached unexpected iteration number {} in module {}.".format(m.iteration_number, __name__))
+            raise RuntimeError(
+                "Reached unexpected iteration number {} in module {}.".format(
+                    m.iteration_number, __name__
+                )
+            )
 
     return None  # no comment on convergence
+
 
 def post_iterate(m):
     if hasattr(m, "ChargeBattery"):
         double_charge = [
-            (
-                z, t,
-                m.ChargeBattery[z, t].value,
-                m.DischargeBattery[z, t].value
-            )
-                for z in m.LOAD_ZONES
-                    for t in m.TIMEPOINTS
-                        if m.ChargeBattery[z, t].value > 0
-                            and m.DischargeBattery[z, t].value > 0
+            (z, t, m.ChargeBattery[z, t].value, m.DischargeBattery[z, t].value)
+            for z in m.LOAD_ZONES
+            for t in m.TIMEPOINTS
+            if m.ChargeBattery[z, t].value > 0 and m.DischargeBattery[z, t].value > 0
         ]
         if len(double_charge) > 0:
             print("")
-            print("WARNING: batteries are simultaneously charged and discharged in some hours.")
+            print(
+                "WARNING: batteries are simultaneously charged and discharged in some hours."
+            )
             print("This is usually done to relax the biofuel limit.")
             for (z, t, c, d) in double_charge:
-                print('ChargeBattery[{z}, {t}]={c}, DischargeBattery[{z}, {t}]={d}'.format(
-                    z=z, t=m.tp_timestamp[t],
-                    c=c, d=d
-                ))
+                print(
+                    "ChargeBattery[{z}, {t}]={c}, DischargeBattery[{z}, {t}]={d}".format(
+                        z=z, t=m.tp_timestamp[t], c=c, d=d
+                    )
+                )
 
     if m.options.smooth_dispatch:
         # setup model for next iteration
         if m.iteration_number == 0:
-            done = False # we'll have to run again to do the smoothing
+            done = False  # we'll have to run again to do the smoothing
         elif m.iteration_number == 1:
             # finished smoothing the model
             post_smooth_solve(m)
             # now we're done
             done = True
         else:
-            raise RuntimeError("Reached unexpected iteration number {} in module {}.".format(m.iteration_number, __name__))
+            raise RuntimeError(
+                "Reached unexpected iteration number {} in module {}.".format(
+                    m.iteration_number, __name__
+                )
+            )
     else:
         # not smoothing the dispatch
         done = True
 
     return done
 
+
 def post_solve(m, outputs_dir):
     """ Smooth dispatch if it wasn't already done during an iterative solution. """
-    if m.options.smooth_dispatch and not getattr(m, 'iterated_smooth_dispatch', False):
+    if m.options.smooth_dispatch and not getattr(m, "iterated_smooth_dispatch", False):
         pre_smooth_solve(m)
         # re-solve and load results
         m.preprocess()
         switch_model.solve.solve(m)
         post_smooth_solve(m)
+
 
 def pre_smooth_solve(m):
     """ store model state and prepare for smoothing """
@@ -148,6 +185,7 @@ def pre_smooth_solve(m):
     m.Minimize_System_Cost.deactivate()
     m.Smooth_Free_Variables.activate()
     print("smoothing free variables...")
+
 
 def post_smooth_solve(m):
     """ restore original model state """
@@ -161,36 +199,38 @@ def post_smooth_solve(m):
 
 
 def save_duals(m):
-    if hasattr(m, 'dual'):
+    if hasattr(m, "dual"):
         m.old_dual_dict = m.dual._dict.copy()
-    if hasattr(m, 'rc'):
+    if hasattr(m, "rc"):
         m.old_rc_dict = m.rc._dict.copy()
 
+
 def restore_duals(m):
-    if hasattr(m, 'dual'):
+    if hasattr(m, "dual"):
         m.dual._dict = m.old_dual_dict
-    if hasattr(m, 'rc'):
+    if hasattr(m, "rc"):
         m.rc._dict = m.old_rc_dict
+
 
 def fix_obj_expression(e, status=True):
     """Recursively fix all variables included in an objective expression."""
-    if hasattr(e, 'fixed'):
-        e.fixed = status      # see p. 171 of the Pyomo book
-    elif hasattr(e, '_numerator'):
+    if hasattr(e, "fixed"):
+        e.fixed = status  # see p. 171 of the Pyomo book
+    elif hasattr(e, "_numerator"):
         for e2 in e._numerator:
             fix_obj_expression(e2, status)
         for e2 in e._denominator:
             fix_obj_expression(e2, status)
-    elif hasattr(e, '_args'):
+    elif hasattr(e, "_args"):
         for e2 in e._args:
             fix_obj_expression(e2, status)
-    elif hasattr(e, 'expr'):
+    elif hasattr(e, "expr"):
         fix_obj_expression(e.expr, status)
-    elif hasattr(e, 'is_constant'):
+    elif hasattr(e, "is_constant"):
         # parameter; we don't actually care if it's mutable or not
         pass
     else:
         raise ValueError(
-            'Expression {e} does not have an exg, fixed or _args property, ' +
-            'so it cannot be fixed.'.format(e=e)
+            "Expression {e} does not have an exg, fixed or _args property, "
+            + "so it cannot be fixed.".format(e=e)
         )

--- a/switch_model/hawaii/switch_patch.py
+++ b/switch_model/hawaii/switch_patch.py
@@ -1,7 +1,9 @@
 from pyomo.environ import *
 
+
 def define_components(m):
     """Make various changes to the model to support hawaii-specific modules."""
+
 
 # # TODO: combine the following changes into a pull request for Pyomo
 # # patch Pyomo's table-reading function to allow .csv files with headers but no data

--- a/switch_model/hawaii/unserved_load.py
+++ b/switch_model/hawaii/unserved_load.py
@@ -4,9 +4,15 @@ This is often useful when the model is constrained to the edge of infeasibility,
 spurious reports of infeasibility."""
 from pyomo.environ import *
 
+
 def define_arguments(argparser):
-    argparser.add_argument("--unserved-load-penalty", type=float, default=None,
-        help="Penalty to charge per MWh of unserved load. Usually set high enough to force unserved load to zero (default is $10,000/MWh).")
+    argparser.add_argument(
+        "--unserved-load-penalty",
+        type=float,
+        default=None,
+        help="Penalty to charge per MWh of unserved load. Usually set high enough to force unserved load to zero (default is $10,000/MWh).",
+    )
+
 
 def define_components(m):
     # create an unserved load variable with a high penalty cost,
@@ -15,7 +21,9 @@ def define_components(m):
     # cost per MWh for unserved load (high)
     if m.options.unserved_load_penalty is not None:
         # always use penalty factor supplied on the command line, if any
-        m.unserved_load_penalty_per_mwh = Param(initialize=m.options.unserved_load_penalty)
+        m.unserved_load_penalty_per_mwh = Param(
+            initialize=m.options.unserved_load_penalty
+        )
     else:
         # no penalty on the command line, use whatever is in the parameter files, or 10000
         m.unserved_load_penalty_per_mwh = Param(default=10000)
@@ -23,25 +31,30 @@ def define_components(m):
     # amount of unserved load during each timepoint
     m.UnservedLoad = Var(m.LOAD_ZONES, m.TIMEPOINTS, within=NonNegativeReals)
     # total cost for unserved load
-    m.UnservedLoadPenalty = Expression(m.TIMEPOINTS, rule=lambda m, tp:
-        m.tp_duration_hrs[tp]
-        * sum(m.UnservedLoad[z, tp] * m.unserved_load_penalty_per_mwh for z in m.LOAD_ZONES)
+    m.UnservedLoadPenalty = Expression(
+        m.TIMEPOINTS,
+        rule=lambda m, tp: m.tp_duration_hrs[tp]
+        * sum(
+            m.UnservedLoad[z, tp] * m.unserved_load_penalty_per_mwh
+            for z in m.LOAD_ZONES
+        ),
     )
     # add the unserved load to the model's energy balance
-    m.Zone_Power_Injections.append('UnservedLoad')
+    m.Zone_Power_Injections.append("UnservedLoad")
     # add the unserved load penalty to the model's objective function
-    m.Cost_Components_Per_TP.append('UnservedLoadPenalty')
+    m.Cost_Components_Per_TP.append("UnservedLoadPenalty")
 
     # amount of unserved reserves during each timepoint
     m.UnservedUpReserves = Var(m.TIMEPOINTS, within=NonNegativeReals)
     m.UnservedDownReserves = Var(m.TIMEPOINTS, within=NonNegativeReals)
     # total cost for unserved reserves (90% as high as cost of unserved load,
     # to make the model prefer to serve load when possible)
-    m.UnservedReservePenalty = Expression(m.TIMEPOINTS, rule=lambda m, tp:
-        m.tp_duration_hrs[tp]
+    m.UnservedReservePenalty = Expression(
+        m.TIMEPOINTS,
+        rule=lambda m, tp: m.tp_duration_hrs[tp]
         * 0.9
         * m.unserved_load_penalty_per_mwh
-        * (m.UnservedUpReserves[tp] + m.UnservedDownReserves[tp])
+        * (m.UnservedUpReserves[tp] + m.UnservedDownReserves[tp]),
     )
     # add the unserved load penalty to the model's objective function
-    m.Cost_Components_Per_TP.append('UnservedReservePenalty')
+    m.Cost_Components_Per_TP.append("UnservedReservePenalty")

--- a/switch_model/hawaii/util.py
+++ b/switch_model/hawaii/util.py
@@ -6,25 +6,30 @@ import __main__ as main
 
 # check whether this is an interactive session
 # (if not, there will be no __main__.__file__)
-interactive_session = not hasattr(main, '__file__')
+interactive_session = not hasattr(main, "__file__")
 
-csv.register_dialect("switch-csv",
+csv.register_dialect(
+    "switch-csv",
     delimiter=",",
     lineterminator="\n",
-    doublequote=False, escapechar="\\",
-    quotechar='"', quoting=csv.QUOTE_MINIMAL,
-    skipinitialspace = False
+    doublequote=False,
+    escapechar="\\",
+    quotechar='"',
+    quoting=csv.QUOTE_MINIMAL,
+    skipinitialspace=False,
 )
+
 
 def create_table(**kwargs):
     """Create an empty output table and write the headings."""
     output_file = kwargs["output_file"]
     headings = kwargs["headings"]
 
-    with open(output_file, 'w') as f:
+    with open(output_file, "w") as f:
         w = csv.writer(f, dialect="switch-csv")
         # write header row
         w.writerow(list(headings))
+
 
 def append_table(model, *indexes, **kwargs):
     """Add rows to an output table, iterating over the indexes specified,
@@ -35,22 +40,22 @@ def append_table(model, *indexes, **kwargs):
     # create a master indexing set
     # this is a list of lists, even if only one list was specified
     idx = itertools.product(*indexes)
-    with open(output_file, 'a') as f:
+    with open(output_file, "a") as f:
         w = csv.writer(f, dialect="switch-csv")
         # write the data
         # import pdb
         # if 'rfm' in output_file:
         #     pdb.set_trace()
         w.writerows(
-            tuple(value(v) for v in values(model, *unpack_elements(x)))
-            for x in idx
+            tuple(value(v) for v in values(model, *unpack_elements(x))) for x in idx
         )
+
 
 def unpack_elements(tup):
     """Unpack any multi-element objects within tup, to make a single flat tuple.
     Note: this is not recursive.
     This is used to flatten the product of a multi-dimensional index with anything else."""
-    l=[]
+    l = []
     for t in tup:
         if isinstance(t, string_types):
             l.append(t)
@@ -64,29 +69,34 @@ def unpack_elements(tup):
                 l.append(t)
     return tuple(l)
 
+
 def write_table(model, *indexes, **kwargs):
     """Write an output table in one shot - headers and body."""
     output_file = kwargs["output_file"]
 
-    print("Writing {file} ...".format(file=output_file), end=' ')
+    print("Writing {file} ...".format(file=output_file), end=" ")
     sys.stdout.flush()  # display the part line to the user
-    start=time.time()
+    start = time.time()
 
     create_table(**kwargs)
     append_table(model, *indexes, **kwargs)
 
-    print("time taken: {dur:.2f}s".format(dur=time.time()-start))
+    print("time taken: {dur:.2f}s".format(dur=time.time() - start))
+
 
 def get(component, index, default=None):
     """Return an element from an indexed component, or the default value if the index is invalid."""
     return component[index] if index in component else default
 
+
 def log(msg):
     sys.stdout.write(msg)
     sys.stdout.flush()  # display output to the user, even a partial line
 
+
 def tic():
     tic.start_time = time.time()
 
+
 def toc():
-    log("time taken: {dur:.2f}s\n".format(dur=time.time()-tic.start_time))
+    log("time taken: {dur:.2f}s\n".format(dur=time.time() - tic.start_time))

--- a/switch_model/main.py
+++ b/switch_model/main.py
@@ -9,6 +9,7 @@ import switch_model
 
 # print "running {} as {}.".format(__file__, __name__)
 
+
 def main():
     cmds = ["solve", "solve-scenarios", "test", "upgrade", "--version"]
     if len(sys.argv) >= 2 and sys.argv[1] in cmds:
@@ -38,8 +39,13 @@ def main():
             from switch_model.upgrade import main
         main()
     else:
-        print("Usage: {} {{{}}} ...".format(os.path.basename(sys.argv[0]), ", ".join(cmds)))
+        print(
+            "Usage: {} {{{}}} ...".format(
+                os.path.basename(sys.argv[0]), ", ".join(cmds)
+            )
+        )
         print("Use one of these commands with --help for more information.")
+
 
 if __name__ == "__main__":
     main()

--- a/switch_model/policies/carbon_policies.py
+++ b/switch_model/policies/carbon_policies.py
@@ -22,26 +22,39 @@ import os
 from pyomo.environ import Set, Param, Expression, Constraint, Suffix
 import switch_model.reporting as reporting
 
+
 def define_components(model):
-    model.carbon_cap_tco2_per_yr = Param(model.PERIODS, default=float('inf'), doc=(
-        "Emissions from this model must be less than this cap. "
-        "This is specified in metric tonnes of CO2 per year."))
-    model.Enforce_Carbon_Cap = Constraint(model.PERIODS,
-        rule=lambda m, p:
-            Constraint.Skip if m.carbon_cap_tco2_per_yr[p] == float('inf')
-            else m.AnnualEmissions[p] <= m.carbon_cap_tco2_per_yr[p],
-        doc=("Enforces the carbon cap for generation-related emissions."))
+    model.carbon_cap_tco2_per_yr = Param(
+        model.PERIODS,
+        default=float("inf"),
+        doc=(
+            "Emissions from this model must be less than this cap. "
+            "This is specified in metric tonnes of CO2 per year."
+        ),
+    )
+    model.Enforce_Carbon_Cap = Constraint(
+        model.PERIODS,
+        rule=lambda m, p: Constraint.Skip
+        if m.carbon_cap_tco2_per_yr[p] == float("inf")
+        else m.AnnualEmissions[p] <= m.carbon_cap_tco2_per_yr[p],
+        doc=("Enforces the carbon cap for generation-related emissions."),
+    )
     # Make sure the model has a dual suffix for determining implicit carbon costs
     if not hasattr(model, "dual"):
         model.dual = Suffix(direction=Suffix.IMPORT)
 
-    model.carbon_cost_dollar_per_tco2 = Param(model.PERIODS, default=0.0,
-        doc="The cost adder applied to emissions, in future dollars per metric tonne of CO2.")
-    model.EmissionsCosts = Expression(model.PERIODS,
-        rule=lambda model, period: \
-            model.AnnualEmissions[period] * model.carbon_cost_dollar_per_tco2[period],
-        doc=("Enforces the carbon cap for generation-related emissions."))
-    model.Cost_Components_Per_Period.append('EmissionsCosts')
+    model.carbon_cost_dollar_per_tco2 = Param(
+        model.PERIODS,
+        default=0.0,
+        doc="The cost adder applied to emissions, in future dollars per metric tonne of CO2.",
+    )
+    model.EmissionsCosts = Expression(
+        model.PERIODS,
+        rule=lambda model, period: model.AnnualEmissions[period]
+        * model.carbon_cost_dollar_per_tco2[period],
+        doc=("Enforces the carbon cap for generation-related emissions."),
+    )
+    model.Cost_Components_Per_Period.append("EmissionsCosts")
 
 
 def load_inputs(model, switch_data, inputs_dir):
@@ -56,10 +69,14 @@ def load_inputs(model, switch_data, inputs_dir):
 
     """
     switch_data.load_aug(
-        filename=os.path.join(inputs_dir, 'carbon_policies.csv'),
+        filename=os.path.join(inputs_dir, "carbon_policies.csv"),
         optional=True,
-        optional_params=(model.carbon_cap_tco2_per_yr, model.carbon_cost_dollar_per_tco2),
-        param=(model.carbon_cap_tco2_per_yr, model.carbon_cost_dollar_per_tco2))
+        optional_params=(
+            model.carbon_cap_tco2_per_yr,
+            model.carbon_cost_dollar_per_tco2,
+        ),
+        param=(model.carbon_cap_tco2_per_yr, model.carbon_cost_dollar_per_tco2),
+    )
 
 
 def post_solve(model, outdir):
@@ -73,25 +90,42 @@ def post_solve(model, outdir):
     discrete unit commitment, or other integer decision variables, the dual
     values will not be exported.
     """
+
     def get_row(model, period):
-        row = [period, model.AnnualEmissions[period],
-               model.carbon_cap_tco2_per_yr[period]]
+        row = [
+            period,
+            model.AnnualEmissions[period],
+            model.carbon_cap_tco2_per_yr[period],
+        ]
         # Only print the carbon cap dual value if it exists and if the problem
         # is purely linear.
-        if not model.has_discrete_variables() and model.Enforce_Carbon_Cap[period] in model.dual:
-            row.append(model.dual[model.Enforce_Carbon_Cap[period]] /
-                       model.bring_annual_costs_to_base_year[period])
+        if (
+            not model.has_discrete_variables()
+            and model.Enforce_Carbon_Cap[period] in model.dual
+        ):
+            row.append(
+                model.dual[model.Enforce_Carbon_Cap[period]]
+                / model.bring_annual_costs_to_base_year[period]
+            )
         else:
-            row.append('.')
+            row.append(".")
         row.append(model.carbon_cost_dollar_per_tco2[period])
-        row.append(model.carbon_cost_dollar_per_tco2[period] * \
-                   model.AnnualEmissions[period])
+        row.append(
+            model.carbon_cost_dollar_per_tco2[period] * model.AnnualEmissions[period]
+        )
         return row
 
     reporting.write_table(
-        model, model.PERIODS,
+        model,
+        model.PERIODS,
         output_file=os.path.join(outdir, "emissions.csv"),
-        headings=("PERIOD", "AnnualEmissions_tCO2_per_yr",
-                  "carbon_cap_tco2_per_yr", "carbon_cap_dual_future_dollar_per_tco2",
-                  "carbon_cost_dollar_per_tco2", "carbon_cost_annual_total"),
-        values=get_row)
+        headings=(
+            "PERIOD",
+            "AnnualEmissions_tCO2_per_yr",
+            "carbon_cap_tco2_per_yr",
+            "carbon_cap_dual_future_dollar_per_tco2",
+            "carbon_cost_dollar_per_tco2",
+            "carbon_cost_annual_total",
+        ),
+        values=get_row,
+    )

--- a/switch_model/policies/rps_simple.py
+++ b/switch_model/policies/rps_simple.py
@@ -1,4 +1,5 @@
 from __future__ import division
+
 # Copyright (c) 2015-2020 The Switch Authors. All rights reserved.
 # Licensed under the Apache License, Version 2, which is in the LICENSE file.
 
@@ -22,6 +23,7 @@ TODO:
 Allow the usage of the commit module.
 
 """
+
 
 def define_components(mod):
     """
@@ -62,54 +64,59 @@ def define_components(mod):
 
     """
 
-    mod.f_rps_eligible = Param(
-        mod.FUELS,
-        within=Boolean,
-        default=False)
+    mod.f_rps_eligible = Param(mod.FUELS, within=Boolean, default=False)
     mod.RPS_ENERGY_SOURCES = Set(
-        initialize=lambda m: set(m.NON_FUEL_ENERGY_SOURCES) | \
-            set(f for f in m.FUELS if m.f_rps_eligible[f]))
+        initialize=lambda m: set(m.NON_FUEL_ENERGY_SOURCES)
+        | set(f for f in m.FUELS if m.f_rps_eligible[f])
+    )
 
-    mod.RPS_PERIODS = Set(
-        validate=lambda m, p: p in m.PERIODS)
-    mod.rps_target = Param(
-        mod.RPS_PERIODS,
-        within=PercentFraction)
+    mod.RPS_PERIODS = Set(validate=lambda m, p: p in m.PERIODS)
+    mod.rps_target = Param(mod.RPS_PERIODS, within=PercentFraction)
 
     mod.RPSFuelEnergy = Expression(
         mod.RPS_PERIODS,
         rule=lambda m, p: sum(
-            m.tp_weight[t] *
-            sum(
+            m.tp_weight[t]
+            * sum(
                 m.GenFuelUseRate[g, t, f]
                 for f in m.FUELS_FOR_GEN[g]
                 if m.f_rps_eligible[f]
-            ) / m.gen_full_load_heat_rate[g]
+            )
+            / m.gen_full_load_heat_rate[g]
             for g in m.FUEL_BASED_GENS
-            for t in m.TPS_FOR_GEN_IN_PERIOD[g, p])
-        )
+            for t in m.TPS_FOR_GEN_IN_PERIOD[g, p]
+        ),
+    )
     mod.RPSNonFuelEnergy = Expression(
         mod.RPS_PERIODS,
-        rule=lambda m, p: sum(m.DispatchGen[g, t] * m.tp_weight[t]
+        rule=lambda m, p: sum(
+            m.DispatchGen[g, t] * m.tp_weight[t]
             for g in m.NON_FUEL_BASED_GENS
-                for t in m.TPS_FOR_GEN_IN_PERIOD[g, p]))
+            for t in m.TPS_FOR_GEN_IN_PERIOD[g, p]
+        ),
+    )
 
     mod.RPS_Enforce_Target = Constraint(
         mod.RPS_PERIODS,
-        rule=lambda m, p: (m.RPSFuelEnergy[p] + m.RPSNonFuelEnergy[p] >=
-            m.rps_target[p] * total_demand_in_period(m, p)))
+        rule=lambda m, p: (
+            m.RPSFuelEnergy[p] + m.RPSNonFuelEnergy[p]
+            >= m.rps_target[p] * total_demand_in_period(m, p)
+        ),
+    )
 
 
 def total_generation_in_period(model, period):
     return sum(
         model.DispatchGen[g, t] * model.tp_weight[t]
         for g in model.GENERATION_PROJECTS
-            for t in model.TPS_FOR_GEN_IN_PERIOD[g, period])
+        for t in model.TPS_FOR_GEN_IN_PERIOD[g, period]
+    )
 
 
 def total_demand_in_period(model, period):
-    return sum(model.zone_total_demand_in_period_mwh[zone, period]
-               for zone in model.LOAD_ZONES)
+    return sum(
+        model.zone_total_demand_in_period_mwh[zone, period] for zone in model.LOAD_ZONES
+    )
 
 
 def load_inputs(mod, switch_data, inputs_dir):
@@ -130,14 +137,16 @@ def load_inputs(mod, switch_data, inputs_dir):
     """
 
     switch_data.load_aug(
-        filename=os.path.join(inputs_dir, 'fuels.csv'),
-        select=('fuel','f_rps_eligible'),
-        optional_params=['f_rps_eligible'],
-        param=(mod.f_rps_eligible,))
+        filename=os.path.join(inputs_dir, "fuels.csv"),
+        select=("fuel", "f_rps_eligible"),
+        optional_params=["f_rps_eligible"],
+        param=(mod.f_rps_eligible,),
+    )
     switch_data.load_aug(
-        filename=os.path.join(inputs_dir, 'rps_targets.csv'),
+        filename=os.path.join(inputs_dir, "rps_targets.csv"),
         index=mod.RPS_PERIODS,
-        param=(mod.rps_target,))
+        param=(mod.rps_target,),
+    )
 
 
 def post_solve(instance, outdir):
@@ -147,21 +156,34 @@ def post_solve(instance, outdir):
     """
 
     import switch_model.reporting as reporting
+
     def get_row(m, p):
         row = (p,)
         row += (m.RPSFuelEnergy[p] / 1000,)
         row += (m.RPSNonFuelEnergy[p] / 1000,)
-        row += (total_generation_in_period(m,p) / 1000,)
-        row += ((m.RPSFuelEnergy[p] + m.RPSNonFuelEnergy[p]) /
-            total_generation_in_period(m,p),)
+        row += (total_generation_in_period(m, p) / 1000,)
+        row += (
+            (m.RPSFuelEnergy[p] + m.RPSNonFuelEnergy[p])
+            / total_generation_in_period(m, p),
+        )
         row += (total_demand_in_period(m, p),)
-        row += ((m.RPSFuelEnergy[p] + m.RPSNonFuelEnergy[p]) /
-            total_demand_in_period(m, p),)
+        row += (
+            (m.RPSFuelEnergy[p] + m.RPSNonFuelEnergy[p]) / total_demand_in_period(m, p),
+        )
         return row
+
     reporting.write_table(
-        instance, instance.RPS_PERIODS,
+        instance,
+        instance.RPS_PERIODS,
         output_file=os.path.join(outdir, "rps_energy.csv"),
-        headings=("PERIOD", "RPSFuelEnergyGWh", "RPSNonFuelEnergyGWh",
-            "TotalGenerationInPeriodGWh", "RPSGenFraction",
-            "TotalSalesInPeriodGWh", "RPSSalesFraction"),
-        values=get_row)
+        headings=(
+            "PERIOD",
+            "RPSFuelEnergyGWh",
+            "RPSNonFuelEnergyGWh",
+            "TotalGenerationInPeriodGWh",
+            "RPSGenFraction",
+            "TotalSalesInPeriodGWh",
+            "RPSSalesFraction",
+        ),
+        values=get_row,
+    )

--- a/switch_model/reporting/__init__.py
+++ b/switch_model/reporting/__init__.py
@@ -20,12 +20,14 @@ dependency on load_zones.
 """
 from __future__ import print_function
 from switch_model.utilities import string_types
-dependencies = 'switch_model.financials'
+
+dependencies = "switch_model.financials"
 
 
 import os
 import csv
 import itertools
+
 try:
     # Python 2
     import cPickle as pickle
@@ -38,25 +40,39 @@ csv.register_dialect(
     "switch-csv",
     delimiter=",",
     lineterminator="\n",
-    doublequote=False, escapechar="\\",
-    quotechar='"', quoting=csv.QUOTE_MINIMAL,
-    skipinitialspace=False
+    doublequote=False,
+    escapechar="\\",
+    quotechar='"',
+    quoting=csv.QUOTE_MINIMAL,
+    skipinitialspace=False,
 )
+
 
 def define_arguments(argparser):
     argparser.add_argument(
-        "--sorted-output", default=False, action='store_true',
-        dest='sorted_output',
-        help='Write generic variable result values in sorted order')
-    argparser.add_argument(
-        "--skip-generic-output", default=False, action='store_true',
-        dest='skip_generic_output',
-        help='Skip exporting generic variable results')
-    argparser.add_argument(
-        "--save-expressions", "--save-expression", dest="save_expressions", nargs='+',
-        default=[], action='extend',
-        help="List of expressions to save in addition to variables; can also be 'all' or 'none'."
+        "--sorted-output",
+        default=False,
+        action="store_true",
+        dest="sorted_output",
+        help="Write generic variable result values in sorted order",
     )
+    argparser.add_argument(
+        "--skip-generic-output",
+        default=False,
+        action="store_true",
+        dest="skip_generic_output",
+        help="Skip exporting generic variable results",
+    )
+    argparser.add_argument(
+        "--save-expressions",
+        "--save-expression",
+        dest="save_expressions",
+        nargs="+",
+        default=[],
+        action="extend",
+        help="List of expressions to save in addition to variables; can also be 'all' or 'none'.",
+    )
+
 
 def write_table(instance, *indexes, **kwargs):
     # there must be a way to accept specific named keyword arguments and
@@ -65,9 +81,9 @@ def write_table(instance, *indexes, **kwargs):
     output_file = kwargs["output_file"]
     headings = kwargs["headings"]
     values = kwargs["values"]
-    digits = kwargs.get('digits', 6)
+    digits = kwargs.get("digits", 6)
 
-    with open(output_file, 'w') as f:
+    with open(output_file, "w") as f:
         w = csv.writer(f, dialect="switch-csv")
         # write header row
         w.writerow(list(headings))
@@ -88,7 +104,7 @@ def write_table(instance, *indexes, **kwargs):
                 format_row(row=values(instance, *unpack_elements(x)))
                 for x in itertools.product(*indexes)
             )
-        except TypeError: # lambda got wrong number of arguments
+        except TypeError:  # lambda got wrong number of arguments
             # use old code, which doesn't unpack the indices
             w.writerows(
                 # TODO: flatten x (unpack tuples) like Pyomo before calling values()
@@ -96,23 +112,30 @@ def write_table(instance, *indexes, **kwargs):
                 format_row(row=values(instance, *x))
                 for x in itertools.product(*indexes)
             )
-            print("DEPRECATION WARNING: switch_model.reporting.write_table() was called with a function")
-            print("that expects multidimensional index values to be stored in tuples, but Switch now unpacks")
-            print("these tuples automatically. Please update your code to work with unpacked index values.")
+            print(
+                "DEPRECATION WARNING: switch_model.reporting.write_table() was called with a function"
+            )
+            print(
+                "that expects multidimensional index values to be stored in tuples, but Switch now unpacks"
+            )
+            print(
+                "these tuples automatically. Please update your code to work with unpacked index values."
+            )
             print("Problem occured with {}.".format(values.__code__))
+
 
 def unpack_elements(items):
     """Unpack any multi-element objects within items, to make a single flat list.
     Note: this is not recursive.
     This is used to flatten the product of a multi-dimensional index with anything else."""
-    l=[]
+    l = []
     for x in items:
         if isinstance(x, string_types):
             l.append(x)
         else:
             try:
                 l.extend(x)
-            except TypeError: # x isn't iterable
+            except TypeError:  # x isn't iterable
                 l.append(x)
     return l
 
@@ -130,30 +153,35 @@ def post_solve(instance, outdir):
 def save_generic_results(instance, outdir, sorted_output):
     components = list(instance.component_objects(Var))
     # add Expression objects that should be saved, if any
-    if 'none' in instance.options.save_expressions:
+    if "none" in instance.options.save_expressions:
         # drop everything up till the last 'none' (users may have added more after that)
-        last_none = (
-            len(instance.options.save_expressions)
-            - instance.options.save_expressions[::-1].index('none')
-        )
-        instance.options.save_expressions = instance.options.save_expressions[last_none:]
+        last_none = len(
+            instance.options.save_expressions
+        ) - instance.options.save_expressions[::-1].index("none")
+        instance.options.save_expressions = instance.options.save_expressions[
+            last_none:
+        ]
 
-    if 'all' in instance.options.save_expressions:
+    if "all" in instance.options.save_expressions:
         components += list(instance.component_objects(Expression))
     else:
         components += [getattr(instance, c) for c in instance.options.save_expressions]
 
     missing_val_list = []
     for var in components:
-        output_file = os.path.join(outdir, '%s.csv' % var.name)
-        with open(output_file, 'w') as fh:
-            writer = csv.writer(fh, dialect='switch-csv')
+        output_file = os.path.join(outdir, "%s.csv" % var.name)
+        with open(output_file, "w") as fh:
+            writer = csv.writer(fh, dialect="switch-csv")
             if var.is_indexed():
                 index_name = var.index_set().name
                 # Write column headings
-                writer.writerow(['%s_%d' % (index_name, i + 1)
-                                 for i in range(var.index_set().dimen)] +
-                                [var.name])
+                writer.writerow(
+                    [
+                        "%s_%d" % (index_name, i + 1)
+                        for i in range(var.index_set().dimen)
+                    ]
+                    + [var.name]
+                )
                 # Results are saved in a random order by default for
                 # increased speed. Sorting is available if wanted.
                 items = sorted(var.items()) if sorted_output else list(var.items())
@@ -172,11 +200,11 @@ def save_generic_results(instance, outdir, sorted_output):
             "{}.".format(
                 len(missing_val_list),
                 (
-                    'variable has not been assigned a value'
-                    if len(missing_val_list) == 1 else
-                    'variables have not been assigned values'
+                    "variable has not been assigned a value"
+                    if len(missing_val_list) == 1
+                    else "variables have not been assigned values"
                 ),
-                missing_val_list[:10]
+                missing_val_list[:10],
             )
         )
         try:
@@ -191,7 +219,7 @@ def get_value(obj, missing_val_list=[]):
     Retrieve value of one element of a Variable or Expression, converting
     division-by-zero to nan and uninitialized values to None.
     """
-    if getattr(obj, 'value', 0) is None:
+    if getattr(obj, "value", 0) is None:
         # If variables are not used in constraints or the objective function,
         # they will never get values, and give a ValueError if accessed.
         # Accessing obj.value may be undocumented, but avoids using value(obj),
@@ -212,8 +240,8 @@ def get_value(obj, missing_val_list=[]):
 
 
 def save_total_cost_value(instance, outdir):
-    with open(os.path.join(outdir, 'total_cost.txt'), 'w') as fh:
-        fh.write('{}\n'.format(value(instance.SystemCost)))
+    with open(os.path.join(outdir, "total_cost.txt"), "w") as fh:
+        fh.write("{}\n".format(value(instance.SystemCost)))
 
 
 def save_cost_components(m, outdir):
@@ -225,22 +253,24 @@ def save_cost_components(m, outdir):
         cost = getattr(m, annual_cost)
         # note: storing value() instead of the expression may save
         # some memory while this function runs
-        cost_dict[annual_cost] = value(sum(
-            cost[p] * m.bring_annual_costs_to_base_year[p]
-            for p in m.PERIODS
-        ))
+        cost_dict[annual_cost] = value(
+            sum(cost[p] * m.bring_annual_costs_to_base_year[p] for p in m.PERIODS)
+        )
     for tp_cost in m.Cost_Components_Per_TP:
         cost = getattr(m, tp_cost)
-        cost_dict[tp_cost] = value(sum(
-            cost[t] * m.tp_weight_in_year[t]
-            * m.bring_annual_costs_to_base_year[m.tp_period[t]]
-            for t in m.TIMEPOINTS
-        ))
+        cost_dict[tp_cost] = value(
+            sum(
+                cost[t]
+                * m.tp_weight_in_year[t]
+                * m.bring_annual_costs_to_base_year[m.tp_period[t]]
+                for t in m.TIMEPOINTS
+            )
+        )
     write_table(
         m,
         list(cost_dict.keys()),
         output_file=os.path.join(outdir, "cost_components.csv"),
-        headings=('component', 'npv_cost'),
+        headings=("component", "npv_cost"),
         values=lambda m, c: (c, cost_dict[c]),
-        digits=16
+        digits=16,
     )

--- a/switch_model/reporting/basic_exports.py
+++ b/switch_model/reporting/basic_exports.py
@@ -13,7 +13,11 @@ import os, time, sys
 from csv import reader
 from itertools import cycle
 from pyomo.environ import Var
-from switch_model.financials import uniform_series_to_present_value, future_to_present_value
+from switch_model.financials import (
+    uniform_series_to_present_value,
+    future_to_present_value,
+)
+
 
 def define_arguments(argparser):
     # argparser.add_argument(
@@ -21,32 +25,44 @@ def define_arguments(argparser):
     #     help="Exports energy marginal costs in US$/MWh per load zone and timepoint, calculated as dual variable values from the energy balance constraint."
     # )
     argparser.add_argument(
-        "--export-capacities", action='store_true', default=False,
+        "--export-capacities",
+        action="store_true",
+        default=False,
         help="Exports cummulative installed generating capacity in MW per \
-        technology per period."
+        technology per period.",
     )
     argparser.add_argument(
-        "--export-transmission", action='store_true', default=False,
+        "--export-transmission",
+        action="store_true",
+        default=False,
         help="Exports cummulative installed transmission capacity in MW per \
-        path per period."
+        path per period.",
     )
     argparser.add_argument(
-        "--export-tech-dispatch", action='store_true', default=False,
+        "--export-tech-dispatch",
+        action="store_true",
+        default=False,
         help="Exports dispatched capacity per generator technology in MW per \
-        timepoint."
+        timepoint.",
     )
     argparser.add_argument(
-        "--export-reservoirs", action='store_true', default=False,
-        help="Exports final reservoir volumes in cubic meters per timepoint."
+        "--export-reservoirs",
+        action="store_true",
+        default=False,
+        help="Exports final reservoir volumes in cubic meters per timepoint.",
     )
     argparser.add_argument(
-        "--export-all", action='store_true', default=False,
+        "--export-all",
+        action="store_true",
+        default=False,
         help="Exports all tables and plots. Sets all other export options to \
-        True."
+        True.",
     )
     argparser.add_argument(
-        "--export-load-blocks", action='store_true', default=False,
-        help="Exports tables and plots for load block formulation."
+        "--export-load-blocks",
+        action="store_true",
+        default=False,
+        help="Exports tables and plots for load block formulation.",
     )
 
 
@@ -65,9 +81,10 @@ def post_solve(mod, outdir):
     import matplotlib.pyplot as plt
     from cycler import cycler
     from matplotlib.backends.backend_pdf import PdfPages
+
     nan = float("nan")
 
-    summaries_dir = os.path.join(outdir,"Summaries")
+    summaries_dir = os.path.join(outdir, "Summaries")
     if not os.path.exists(summaries_dir):
         os.makedirs(summaries_dir)
     else:
@@ -75,12 +92,12 @@ def post_solve(mod, outdir):
         for f in os.listdir(summaries_dir):
             os.unlink(os.path.join(summaries_dir, f))
 
-    color_map = plt.get_cmap('gist_rainbow')
-    styles = cycle(['-','--','-.',':'])
+    color_map = plt.get_cmap("gist_rainbow")
+    styles = cycle(["-", "--", "-.", ":"])
 
     #####
     # Round doubles to the first decimal
-    #for var in mod.component_objects():
+    # for var in mod.component_objects():
     #    if not isinstance(var, Var):
     #        continue
     #    for key, obj in var.items():
@@ -112,34 +129,38 @@ def post_solve(mod, outdir):
 
         """
         if by_period:
-            df = pd.DataFrame(tab[1:],
-                columns = tab[0]).set_index(ind).transpose()
+            df = pd.DataFrame(tab[1:], columns=tab[0]).set_index(ind).transpose()
             stack = False
-            num_col = int(n_data)/10
+            num_col = int(n_data) / 10
         else:
-            df = pd.DataFrame(tab[1:], columns = tab[0]).set_index(ind)
+            df = pd.DataFrame(tab[1:], columns=tab[0]).set_index(ind)
             stack = True
-            num_col = int(n_data)/2
+            num_col = int(n_data) / 2
         fig = plt.figure()
         inv_ax = fig.add_subplot(111)
         inv_ax.grid(b=False)
         # You have to play with the color map and the line style list to
         # get enough combinations for your particular plot
-        inv_ax.set_prop_cycle(cycler('color',
-                        [color_map(i/n_data) for i in range(0, n_data+1)]))
+        inv_ax.set_prop_cycle(
+            cycler("color", [color_map(i / n_data) for i in range(0, n_data + 1)])
+        )
         # To locate the legend: "loc" is the point of the legend for which you
         # will specify coordinates. These coords are specified in
         # bbox_to_anchor (can be only 1 point or couple)
-        inv_plot = df.plot(kind='bar', ax=inv_ax,
-            stacked=stack).legend(loc='lower left', fontsize=8,
-            bbox_to_anchor=(0.,1.015,1.,1.015), ncol=num_col, mode="expand")
+        inv_plot = df.plot(kind="bar", ax=inv_ax, stacked=stack).legend(
+            loc="lower left",
+            fontsize=8,
+            bbox_to_anchor=(0.0, 1.015, 1.0, 1.015),
+            ncol=num_col,
+            mode="expand",
+        )
         if by_period:
             plt.xticks(rotation=0, fontsize=10)
-            fname = summaries_dir+'/'+name+'.pdf'
+            fname = summaries_dir + "/" + name + ".pdf"
         else:
             plt.xticks(rotation=90, fontsize=9)
-            fname = summaries_dir+'/'+name+'_stacked_by_p.pdf'
-        plt.savefig(fname, bbox_extra_artists=(inv_plot,), bbox_inches='tight')
+            fname = summaries_dir + "/" + name + "_stacked_by_p.pdf"
+        plt.savefig(fname, bbox_extra_artists=(inv_plot,), bbox_inches="tight")
         plt.close()
 
     def plot_dis_decision(name, tab, n_data, ind):
@@ -163,68 +184,86 @@ def post_solve(mod, outdir):
 
         """
 
-        plots = PdfPages(os.path.join(outdir,"Summaries",name)+'.pdf')
+        plots = PdfPages(os.path.join(outdir, "Summaries", name) + ".pdf")
 
-        df = pd.DataFrame(tab[1:], columns = tab[0])
+        df = pd.DataFrame(tab[1:], columns=tab[0])
 
         n_scen = mod.SCENARIOS.__len__()
-        #num_col = int(n_data * n_scen)/8
+        # num_col = int(n_data * n_scen)/8
         num_col = 6
 
-        for p in ['all']+[p for p in mod.PERIODS]:
-            fig = plt.figure(figsize=(17,8), dpi=100)
+        for p in ["all"] + [p for p in mod.PERIODS]:
+            fig = plt.figure(figsize=(17, 8), dpi=100)
             dis_ax = fig.add_subplot(111)
             dis_ax.grid(b=False)
             # You have to play with the color map and the line style list to
             # get enough combinations for your particular plot.
             # Set up different x axis labels if all periods are being plotted
-            if p == 'all':
-                dis_ax.set_xticks([
-                    i*24 for i in range(int(len(mod.TIMEPOINTS)/24) + 1)
-                ])
-                dis_ax.set_xticklabels([
-                    mod.tp_timestamp[mod.TIMEPOINTS[i*24+1]]
-                    for i in range(int(len(mod.TIMEPOINTS)/24))
-                ])
+            if p == "all":
+                dis_ax.set_xticks(
+                    [i * 24 for i in range(int(len(mod.TIMEPOINTS) / 24) + 1)]
+                )
+                dis_ax.set_xticklabels(
+                    [
+                        mod.tp_timestamp[mod.TIMEPOINTS[i * 24 + 1]]
+                        for i in range(int(len(mod.TIMEPOINTS) / 24))
+                    ]
+                )
                 # Technologies have different linestyles and scenarios have
                 # different colors
-                dis_ax.set_prop_cycle(cycler('color',
-                    [color_map(i/float(n_data-1)) for i in range(n_data)]) *
-                    cycler('linestyle',[next(styles) for i in range(n_scen)]))
-                df_to_plot = df.drop([ind], axis=1).replace('', nan)
+                dis_ax.set_prop_cycle(
+                    cycler(
+                        "color",
+                        [color_map(i / float(n_data - 1)) for i in range(n_data)],
+                    )
+                    * cycler("linestyle", [next(styles) for i in range(n_scen)])
+                )
+                df_to_plot = df.drop([ind], axis=1).replace("", nan)
             else:
                 n_scen = mod.PERIOD_SCENARIOS[p].__len__()
-                dis_ax.set_xticks([
-                    i*6 for i in range(int(len(mod.PERIOD_TPS[p])/6) + 1)
-                ])
-                dis_ax.set_xticklabels([
-                    mod.tp_timestamp[mod.PERIOD_TPS[p][t*6+1]]
-                    for t in range(int(len(mod.PERIOD_TPS[p])/6))
-                ])
+                dis_ax.set_xticks(
+                    [i * 6 for i in range(int(len(mod.PERIOD_TPS[p]) / 6) + 1)]
+                )
+                dis_ax.set_xticklabels(
+                    [
+                        mod.tp_timestamp[mod.PERIOD_TPS[p][t * 6 + 1]]
+                        for t in range(int(len(mod.PERIOD_TPS[p]) / 6))
+                    ]
+                )
                 # Technologies have different colors and scenarios have
                 # different line styles
-                dis_ax.set_prop_cycle(cycler('color',
-                    [color_map(i/float(n_data-1)) for i in range(n_data)]) *
-                    cycler('linestyle', [next(styles) for i in range(n_scen)]))
+                dis_ax.set_prop_cycle(
+                    cycler(
+                        "color",
+                        [color_map(i / float(n_data - 1)) for i in range(n_data)],
+                    )
+                    * cycler("linestyle", [next(styles) for i in range(n_scen)])
+                )
                 # Before plotting, data must be filtered by period
-                period_tps = [mod.tp_timestamp[tp]
-                            for tp in mod.PERIOD_TPS[p].value]
-                df_to_plot = df.loc[df[ind].isin(period_tps)].drop([ind],
-                    axis=1).reset_index(drop=True).dropna(axis=1, how='all')
+                period_tps = [mod.tp_timestamp[tp] for tp in mod.PERIOD_TPS[p].value]
+                df_to_plot = (
+                    df.loc[df[ind].isin(period_tps)]
+                    .drop([ind], axis=1)
+                    .reset_index(drop=True)
+                    .dropna(axis=1, how="all")
+                )
             # To locate the legend: "loc" is the point of the legend for which
             # you will specify coordinates. These coords are specified in
             # bbox_to_anchor (can be only 1 point or couple)
-            dis_plot = df_to_plot.plot(ax=dis_ax,
-                linewidth=1.6).legend(loc='lower left', fontsize=8,
-                bbox_to_anchor=(0., 1.015, 1., 1.015), ncol=num_col,
-                mode="expand")
+            dis_plot = df_to_plot.plot(ax=dis_ax, linewidth=1.6).legend(
+                loc="lower left",
+                fontsize=8,
+                bbox_to_anchor=(0.0, 1.015, 1.0, 1.015),
+                ncol=num_col,
+                mode="expand",
+            )
             plt.xticks(rotation=90, fontsize=9)
-            plots.savefig(bbox_extra_artists=(dis_plot,), bbox_inches='tight')
+            plots.savefig(bbox_extra_artists=(dis_plot,), bbox_inches="tight")
             plt.close()
         plots.close()
 
     print("Printing summaries:\n===================")
-    start=time.time()
+    start = time.time()
 
     # print "renewable energy production"
     # rpsenergy = {s:0.0 for s in mod.SCENARIOS}
@@ -267,93 +306,137 @@ def post_solve(mod, outdir):
 
     if mod.options.export_capacities:
         n_elements = mod.GENERATION_TECHNOLOGIES.__len__()
-        index = 'gentech'
+        index = "gentech"
 
         table_name = "cummulative_capacity_by_tech_periods"
-        print(table_name+" ...")
+        print(table_name + " ...")
         table = export.write_table(
-            mod, mod.GENERATION_TECHNOLOGIES,
-            output_file=os.path.join(summaries_dir, table_name+".csv"),
-            headings=(index, 'legacy') + tuple(p
-                for p in mod.PERIODS),
-            values=lambda m, gt: (gt, sum(m.BuildGen[g, bldyr]
-                for (g, bldyr) in m.GEN_BLD_YRS
-                if m.gen_tech[g] == gt and bldyr not in m.PERIODS)) +
-            tuple( sum(m.GenCapacity[g, p] for g in m.GENERATION_PROJECTS
-                if m.gen_tech[g] == gt) for p in m.PERIODS))
+            mod,
+            mod.GENERATION_TECHNOLOGIES,
+            output_file=os.path.join(summaries_dir, table_name + ".csv"),
+            headings=(index, "legacy") + tuple(p for p in mod.PERIODS),
+            values=lambda m, gt: (
+                gt,
+                sum(
+                    m.BuildGen[g, bldyr]
+                    for (g, bldyr) in m.GEN_BLD_YRS
+                    if m.gen_tech[g] == gt and bldyr not in m.PERIODS
+                ),
+            )
+            + tuple(
+                sum(
+                    m.GenCapacity[g, p]
+                    for g in m.GENERATION_PROJECTS
+                    if m.gen_tech[g] == gt
+                )
+                for p in m.PERIODS
+            ),
+        )
         plot_inv_decision(table_name, table, n_elements, index, True)
 
         table_name = "capacity_installed_by_tech_periods"
-        print(table_name+" ...")
+        print(table_name + " ...")
         table = export.write_table(
-            mod, mod.GENERATION_TECHNOLOGIES,
-            output_file=os.path.join(summaries_dir, table_name+".csv"),
-            headings=(index, 'legacy') + tuple(p
-                for p in mod.PERIODS),
-            values=lambda m, gt: (gt, sum(m.BuildGen[g, bldyr]
-                for (g, bldyr) in m.GEN_BLD_YRS
-                if m.gen_tech[g] == gt and bldyr not in m.PERIODS)) +
-            tuple( sum(m.BuildGen[g, p] for g in m.GENERATION_PROJECTS
-                if m.gen_tech[g] == gt) for p in m.PERIODS))
+            mod,
+            mod.GENERATION_TECHNOLOGIES,
+            output_file=os.path.join(summaries_dir, table_name + ".csv"),
+            headings=(index, "legacy") + tuple(p for p in mod.PERIODS),
+            values=lambda m, gt: (
+                gt,
+                sum(
+                    m.BuildGen[g, bldyr]
+                    for (g, bldyr) in m.GEN_BLD_YRS
+                    if m.gen_tech[g] == gt and bldyr not in m.PERIODS
+                ),
+            )
+            + tuple(
+                sum(
+                    m.BuildGen[g, p]
+                    for g in m.GENERATION_PROJECTS
+                    if m.gen_tech[g] == gt
+                )
+                for p in m.PERIODS
+            ),
+        )
         plot_inv_decision(table_name, table, n_elements, index, False)
 
     if mod.options.export_transmission:
         n_elements = mod.TRANSMISSION_LINES.__len__()
-        index = 'path'
+        index = "path"
 
         table_name = "cummulative_transmission_by_path_periods"
-        print(table_name+" ...")
+        print(table_name + " ...")
         table = export.write_table(
-            mod, True, mod.TRANSMISSION_LINES,
-            output_file=os.path.join(summaries_dir, table_name+".csv"),
-            headings=(index, 'legacy') + tuple(p for p in mod.PERIODS),
-            values=lambda m, tx: (tx, m.existing_trans_cap[tx]) +
-                tuple(m.TransCapacity[tx, p] for p in m.PERIODS))
-        #plot_inv_decision(table_name, table, n_elements, index, True)
+            mod,
+            True,
+            mod.TRANSMISSION_LINES,
+            output_file=os.path.join(summaries_dir, table_name + ".csv"),
+            headings=(index, "legacy") + tuple(p for p in mod.PERIODS),
+            values=lambda m, tx: (tx, m.existing_trans_cap[tx])
+            + tuple(m.TransCapacity[tx, p] for p in m.PERIODS),
+        )
+        # plot_inv_decision(table_name, table, n_elements, index, True)
 
         table_name = "transmission_installation_by_path_periods"
-        print(table_name+" ...")
+        print(table_name + " ...")
         table = export.write_table(
-            mod, True, mod.TRANSMISSION_LINES,
-            output_file=os.path.join(summaries_dir, table_name+".csv"),
-            headings=(index, 'legacy') + tuple(p for p in mod.PERIODS),
-            values=lambda m, tx: (tx, m.existing_trans_cap[tx]) +
-                tuple(m.BuildTrans[tx, p] for p in m.PERIODS))
+            mod,
+            True,
+            mod.TRANSMISSION_LINES,
+            output_file=os.path.join(summaries_dir, table_name + ".csv"),
+            headings=(index, "legacy") + tuple(p for p in mod.PERIODS),
+            values=lambda m, tx: (tx, m.existing_trans_cap[tx])
+            + tuple(m.BuildTrans[tx, p] for p in m.PERIODS),
+        )
         plot_inv_decision(table_name, table, n_elements, index, False)
-
 
     if mod.options.export_tech_dispatch:
         n_elements = mod.GENERATION_TECHNOLOGIES.__len__()
-        index = 'timepoints'
+        index = "timepoints"
 
         gen_projects = {}
         for g in mod.GENERATION_TECHNOLOGIES:
             gen_projects[g] = []
             for prj in mod.PROJECTS:
-                if mod.proj_gen_tech[prj]==g:
+                if mod.proj_gen_tech[prj] == g:
                     gen_projects[g].append(prj)
+
         def print_dis(m, tp):
             tup = (m.tp_timestamp[tp],)
             for g in m.GENERATION_TECHNOLOGIES:
                 for s in m.SCENARIOS:
                     if s in m.PERIOD_SCENARIOS[m.tp_period[tp]]:
-                        tup += (sum(m.DispatchProj[proj, tp, s] for proj in gen_projects[g] if (proj,tp,s) in m.PROJ_DISPATCH_POINTS),)
+                        tup += (
+                            sum(
+                                m.DispatchProj[proj, tp, s]
+                                for proj in gen_projects[g]
+                                if (proj, tp, s) in m.PROJ_DISPATCH_POINTS
+                            ),
+                        )
                     else:
-                        tup += ('',)
+                        tup += ("",)
             return tup
 
         table_name = "dispatch_proj_by_tech_tps"
-        print(table_name+" ...")
+        print(table_name + " ...")
         table = export.write_table(
-            mod, True, mod.TIMEPOINTS,
-            output_file=os.path.join(summaries_dir, table_name+".csv"),
-            headings=("timepoints",) + tuple(str(g)+"-"+str(mod.scenario_stamp[s]) for g in mod.GENERATION_TECHNOLOGIES for s in mod.SCENARIOS),
-            values=print_dis)
+            mod,
+            True,
+            mod.TIMEPOINTS,
+            output_file=os.path.join(summaries_dir, table_name + ".csv"),
+            headings=("timepoints",)
+            + tuple(
+                str(g) + "-" + str(mod.scenario_stamp[s])
+                for g in mod.GENERATION_TECHNOLOGIES
+                for s in mod.SCENARIOS
+            ),
+            values=print_dis,
+        )
         plot_dis_decision(table_name, table, n_elements, index)
 
     if mod.options.export_reservoirs:
         n_elements = mod.RESERVOIRS.__len__()
-        index = 'timepoints'
+        index = "timepoints"
 
         def print_res(m, tp):
             tup = (m.tp_timestamp[tp],)
@@ -362,28 +445,34 @@ def post_solve(mod, outdir):
                     if s in m.PERIOD_SCENARIOS[m.tp_period[tp]]:
                         tup += (m.ReservoirVol[r, tp, s] - m.initial_res_vol[r],)
                     else:
-                        tup += ('',)
+                        tup += ("",)
             return tup
 
         table_name = "reservoir_final_vols_tp"
-        print(table_name+" ...")
+        print(table_name + " ...")
         table = export.write_table(
-            mod, True, mod.TIMEPOINTS,
-            output_file=os.path.join(summaries_dir, table_name+".csv"),
-            headings=("timepoints",) + tuple(str(r)+"-"+
-                str(mod.scenario_stamp[s]) for r in mod.RESERVOIRS
-                for s in mod.SCENARIOS),
-            values=print_res)
+            mod,
+            True,
+            mod.TIMEPOINTS,
+            output_file=os.path.join(summaries_dir, table_name + ".csv"),
+            headings=("timepoints",)
+            + tuple(
+                str(r) + "-" + str(mod.scenario_stamp[s])
+                for r in mod.RESERVOIRS
+                for s in mod.SCENARIOS
+            ),
+            values=print_res,
+        )
         plot_dis_decision(table_name, table, n_elements, index)
 
         ##############################################################
         # The following is a custom export to get dispatch for certain
         # Chile load zones
-        lzs_to_print = ['charrua','ancoa']
+        lzs_to_print = ["charrua", "ancoa"]
 
         lz_hprojs = {}
         for lz in lzs_to_print:
-            lz_hprojs[lz]=[]
+            lz_hprojs[lz] = []
             for proj in mod.LZ_PROJECTS[lz]:
                 if proj in mod.HYDRO_PROJECTS:
                     lz_hprojs[lz].append(proj)
@@ -393,135 +482,192 @@ def post_solve(mod, outdir):
             for lz in lzs_to_print:
                 for s in m.SCENARIOS:
                     if s in m.PERIOD_SCENARIOS[m.tp_period[tp]]:
-                        tup += (sum(m.DispatchProj[proj, tp, s] for proj in lz_hprojs[lz] if (proj,tp,s) in m.HYDRO_PROJ_DISPATCH_POINTS),)
+                        tup += (
+                            sum(
+                                m.DispatchProj[proj, tp, s]
+                                for proj in lz_hprojs[lz]
+                                if (proj, tp, s) in m.HYDRO_PROJ_DISPATCH_POINTS
+                            ),
+                        )
                     else:
-                        tup += ('',)
+                        tup += ("",)
             return tup
 
         table_name = "hydro_dispatch_special_nodes_tp"
-        print(table_name+" ...")
+        print(table_name + " ...")
         table = export.write_table(
-            mod, True, mod.TIMEPOINTS,
-            output_file=os.path.join(summaries_dir, table_name+".csv"),
-            headings=("timepoints",) + tuple(str(lz)+"-"+str(
-                mod.scenario_stamp[s]) for lz in lzs_to_print
-                for s in mod.SCENARIOS),
-            values=print_hgen)
-        #plot_dis_decision(table_name, table, n_elements, index)
+            mod,
+            True,
+            mod.TIMEPOINTS,
+            output_file=os.path.join(summaries_dir, table_name + ".csv"),
+            headings=("timepoints",)
+            + tuple(
+                str(lz) + "-" + str(mod.scenario_stamp[s])
+                for lz in lzs_to_print
+                for s in mod.SCENARIOS
+            ),
+            values=print_hgen,
+        )
+        # plot_dis_decision(table_name, table, n_elements, index)
 
     if mod.options.export_load_blocks:
+
         def print_res(m, ym):
             tup = (ym,)
             for r in m.RESERVOIRS:
                 for s in m.SCENARIOS:
-                    if s in m.PERIOD_SCENARIOS[m.tp_period[next(iter(m.ym_timepoints[ym]))]]:
+                    if (
+                        s
+                        in m.PERIOD_SCENARIOS[
+                            m.tp_period[next(iter(m.ym_timepoints[ym]))]
+                        ]
+                    ):
                         tup += (m.ReservoirVol[r, ym, s] - m.initial_res_vol[r],)
                     else:
-                        tup += ('',)
+                        tup += ("",)
             return tup
-        table_name = "reservoir_vols_load_block"
-        print(table_name+" ...")
-        tab = export.write_table(
-            mod, True, mod.YEARMONTHS,
-            output_file=os.path.join(summaries_dir, table_name+".csv"),
-            headings=("yearmonth",) + tuple(str(r)+"-"+
-                str(mod.scenario_stamp[s]) for r in mod.RESERVOIRS
-                for s in mod.SCENARIOS),
-            values=print_res)
-        n_data = mod.RESERVOIRS.__len__()
-        ind = 'yearmonth'
-        plots = PdfPages(os.path.join(outdir,"Summaries",table_name)+'.pdf')
 
-        df = pd.DataFrame(tab[1:], columns = tab[0])
+        table_name = "reservoir_vols_load_block"
+        print(table_name + " ...")
+        tab = export.write_table(
+            mod,
+            True,
+            mod.YEARMONTHS,
+            output_file=os.path.join(summaries_dir, table_name + ".csv"),
+            headings=("yearmonth",)
+            + tuple(
+                str(r) + "-" + str(mod.scenario_stamp[s])
+                for r in mod.RESERVOIRS
+                for s in mod.SCENARIOS
+            ),
+            values=print_res,
+        )
+        n_data = mod.RESERVOIRS.__len__()
+        ind = "yearmonth"
+        plots = PdfPages(os.path.join(outdir, "Summaries", table_name) + ".pdf")
+
+        df = pd.DataFrame(tab[1:], columns=tab[0])
 
         n_scen = mod.SCENARIOS.__len__()
-        #num_col = int(n_data * n_scen)/8
+        # num_col = int(n_data * n_scen)/8
         num_col = 6
 
-        for p in ['all']+[p for p in mod.PERIODS]:
-            fig = plt.figure(figsize=(17,8), dpi=100)
+        for p in ["all"] + [p for p in mod.PERIODS]:
+            fig = plt.figure(figsize=(17, 8), dpi=100)
             dis_ax = fig.add_subplot(111)
             dis_ax.grid(b=False)
             # You have to play with the color map and the line style list to
             # get enough combinations for your particular plot.
             # Set up different x axis labels if all periods are being plotted
-            if p == 'all':
-                dis_ax.set_xticks([
-                    i*5
-                    for i in range(int(len(mod.YEARMONTHS)/5) + 1)
-                ])
-                dis_ax.set_xticklabels([
-                    mod.YEARMONTHS[i*5+1]
-                    for i in range(int(len(mod.YEARMONTHS)/5))
-                ])
+            if p == "all":
+                dis_ax.set_xticks(
+                    [i * 5 for i in range(int(len(mod.YEARMONTHS) / 5) + 1)]
+                )
+                dis_ax.set_xticklabels(
+                    [
+                        mod.YEARMONTHS[i * 5 + 1]
+                        for i in range(int(len(mod.YEARMONTHS) / 5))
+                    ]
+                )
                 # Technologies have different linestyles and scenarios have
                 # different colors
-                dis_ax.set_prop_cycle(cycler('color',
-                    [color_map(i/float(n_data-1)) for i in range(n_data)]) *
-                    cycler('linestyle',[next(styles) for i in range(n_scen)]))
-                df_to_plot = df.drop([ind], axis=1).replace('', nan)
+                dis_ax.set_prop_cycle(
+                    cycler(
+                        "color",
+                        [color_map(i / float(n_data - 1)) for i in range(n_data)],
+                    )
+                    * cycler("linestyle", [next(styles) for i in range(n_scen)])
+                )
+                df_to_plot = df.drop([ind], axis=1).replace("", nan)
             else:
                 n_scen = mod.PERIOD_SCENARIOS[p].__len__()
-                dis_ax.set_xticks([i*5 for i in range(0,24)])
-                dis_ax.set_xticklabels([mod.YEARMONTHS[i]
-                    for i in range(1,25)])
+                dis_ax.set_xticks([i * 5 for i in range(0, 24)])
+                dis_ax.set_xticklabels([mod.YEARMONTHS[i] for i in range(1, 25)])
                 # Technologies have different colors and scenarios have
                 # different line styles
-                dis_ax.set_prop_cycle(cycler('color',
-                    [color_map(i/float(n_data-1)) for i in range(n_data)]) *
-                    cycler('linestyle', [next(styles) for i in range(n_scen)]))
+                dis_ax.set_prop_cycle(
+                    cycler(
+                        "color",
+                        [color_map(i / float(n_data - 1)) for i in range(n_data)],
+                    )
+                    * cycler("linestyle", [next(styles) for i in range(n_scen)])
+                )
                 # Before plotting, data must be filtered by period
-                period_yms = [(p+y)*100+i for y in [0,1] for i in range(1,13)]
-                df_to_plot = df.loc[df[ind].isin(period_yms)].drop([ind],
-                    axis=1).reset_index(drop=True).dropna(axis=1, how='all')
+                period_yms = [(p + y) * 100 + i for y in [0, 1] for i in range(1, 13)]
+                df_to_plot = (
+                    df.loc[df[ind].isin(period_yms)]
+                    .drop([ind], axis=1)
+                    .reset_index(drop=True)
+                    .dropna(axis=1, how="all")
+                )
             # To locate the legend: "loc" is the point of the legend for which
             # you will specify coordinates. These coords are specified in
             # bbox_to_anchor (can be only 1 point or couple)
-            dis_plot = df_to_plot.plot(ax=dis_ax,
-                linewidth=1.6).legend(loc='lower left', fontsize=8,
-                bbox_to_anchor=(0., 1.015, 1., 1.015), ncol=num_col,
-                mode="expand")
+            dis_plot = df_to_plot.plot(ax=dis_ax, linewidth=1.6).legend(
+                loc="lower left",
+                fontsize=8,
+                bbox_to_anchor=(0.0, 1.015, 1.0, 1.015),
+                ncol=num_col,
+                mode="expand",
+            )
             plt.xticks(rotation=90, fontsize=9)
-            plots.savefig(bbox_extra_artists=(dis_plot,), bbox_inches='tight')
+            plots.savefig(bbox_extra_artists=(dis_plot,), bbox_inches="tight")
             plt.close()
         plots.close()
     ##############################################################
 
     def calc_tp_costs_in_period_one_scenario(m, p, s):
-        return (sum(sum(
-            # This are total costs in each tp for a scenario
-            getattr(m, tp_cost)[t, s].expr() * m.tp_weight_in_year[t]
-                    for tp_cost in m.cost_components_tp)
-                    # Now, summation over timepoints
-                        for t in m.PERIOD_TPS[p]) *
+        return (
+            sum(
+                sum(
+                    # This are total costs in each tp for a scenario
+                    getattr(m, tp_cost)[t, s].expr() * m.tp_weight_in_year[t]
+                    for tp_cost in m.cost_components_tp
+                )
+                # Now, summation over timepoints
+                for t in m.PERIOD_TPS[p]
+            )
+            *
             # Conversion to lump sum at beginning of period
-            uniform_series_to_present_value(
-                0, m.period_length_years[p]) *
+            uniform_series_to_present_value(0, m.period_length_years[p])
+            *
             # Conversion to base year
             future_to_present_value(
-                m.discount_rate, (m.period_start[p] - m.base_financial_year)))
+                m.discount_rate, (m.period_start[p] - m.base_financial_year)
+            )
+        )
 
     """
     Writing Objective Function value.
     """
     print("total_system_costs.txt...")
-    with open(os.path.join(summaries_dir, "total_system_costs.txt"),'w+') as f:
+    with open(os.path.join(summaries_dir, "total_system_costs.txt"), "w+") as f:
         f.write("Total Expected System Costs: %.2f \n" % mod.SystemCost())
-        f.write("Total Investment Costs: %.2f \n" % sum(
-            mod.AnnualCostPerPeriod[p].expr() for p in mod.PERIODS))
-        f.write("Total Expected Operations Costs: %.2f \n" % sum(
-            mod.TpCostPerPeriod[p].expr() for p in mod.PERIODS))
+        f.write(
+            "Total Investment Costs: %.2f \n"
+            % sum(mod.AnnualCostPerPeriod[p].expr() for p in mod.PERIODS)
+        )
+        f.write(
+            "Total Expected Operations Costs: %.2f \n"
+            % sum(mod.TpCostPerPeriod[p].expr() for p in mod.PERIODS)
+        )
         for p in mod.PERIODS:
             f.write("PERIOD %s\n" % p)
             f.write("  Investment Costs: %.2f \n" % mod.AnnualCostPerPeriod[p].expr())
-            f.write("  Expected Operations Costs: %.2f \n" % mod.TpCostPerPeriod[p].expr())
+            f.write(
+                "  Expected Operations Costs: %.2f \n" % mod.TpCostPerPeriod[p].expr()
+            )
             for s in mod.PERIOD_SCENARIOS[p]:
-                f.write("    Operational Costs of scenario %s with probability %s: %.2f\n" % (s, mod.scenario_probability[s], calc_tp_costs_in_period_one_scenario(mod, p, s)))
+                f.write(
+                    "    Operational Costs of scenario %s with probability %s: %.2f\n"
+                    % (
+                        s,
+                        mod.scenario_probability[s],
+                        calc_tp_costs_in_period_one_scenario(mod, p, s),
+                    )
+                )
 
-
-    print("\nTime taken writing summaries: %.2f s." % (time.time()-start))
-
-
+    print("\nTime taken writing summaries: %.2f s." % (time.time() - start))
 
     # if mod.options.export_marginal_costs:
     #     """

--- a/switch_model/reporting/dump.py
+++ b/switch_model/reporting/dump.py
@@ -10,12 +10,21 @@ environment.
 """
 import os, sys
 
+
 def define_arguments(argparser):
-    argparser.add_argument("--dump-level", type=int, default=2,
-        help="Use 1 for an abbreviated dump via instance.display(), or 2 " +
-             "for a complete dump via instance.pprint().")
-    argparser.add_argument("--dump-to-screen", action='store_true', default=False,
-        help="Print the model dump to screen as well as an export file.")
+    argparser.add_argument(
+        "--dump-level",
+        type=int,
+        default=2,
+        help="Use 1 for an abbreviated dump via instance.display(), or 2 "
+        + "for a complete dump via instance.pprint().",
+    )
+    argparser.add_argument(
+        "--dump-to-screen",
+        action="store_true",
+        default=False,
+        help="Print the model dump to screen as well as an export file.",
+    )
 
 
 def _print_output(instance):
@@ -33,7 +42,9 @@ def post_solve(instance, outdir):
     instance.display() or instance.pprint(), depending on the value of
     dump-level. Default is pprint().
     """
-    stdout_copy = sys.stdout  # make a copy of current sys.stdout to return to eventually
+    stdout_copy = (
+        sys.stdout
+    )  # make a copy of current sys.stdout to return to eventually
     out_path = os.path.join(outdir, "model_dump.txt")
     out_file = open(out_path, "w", buffering=1)
     sys.stdout = out_file

--- a/switch_model/reporting/example_export.py
+++ b/switch_model/reporting/example_export.py
@@ -13,7 +13,8 @@ remove this file.
 import os
 from switch_model.reporting import write_table
 
-dependencies = 'switch_model.timescales', 'switch_model.balancing.load_zones'
+dependencies = "switch_model.timescales", "switch_model.balancing.load_zones"
+
 
 def post_solve(instance, outdir):
     """
@@ -21,13 +22,21 @@ def post_solve(instance, outdir):
     a different file name (load_balance2.csv).
     """
     write_table(
-        instance, instance.LOAD_ZONES, instance.TIMEPOINTS,
+        instance,
+        instance.LOAD_ZONES,
+        instance.TIMEPOINTS,
         output_file=os.path.join(outdir, "load_balance2.csv"),
-        headings=("load_zone", "timestamp",) + tuple(
-            instance.Zone_Power_Injections +
-            instance.Zone_Power_Withdrawals),
-        values=lambda m, z, t: (z, m.tp_timestamp[t],) + tuple(
+        headings=(
+            "load_zone",
+            "timestamp",
+        )
+        + tuple(instance.Zone_Power_Injections + instance.Zone_Power_Withdrawals),
+        values=lambda m, z, t: (
+            z,
+            m.tp_timestamp[t],
+        )
+        + tuple(
             getattr(m, component)[z, t]
-            for component in (
-                m.Zone_Power_Injections +
-                m.Zone_Power_Withdrawals)))
+            for component in (m.Zone_Power_Injections + m.Zone_Power_Withdrawals)
+        ),
+    )

--- a/switch_model/solve.py
+++ b/switch_model/solve.py
@@ -5,8 +5,10 @@ from __future__ import print_function
 
 import logging
 import sys, os, time, shlex, re, inspect, textwrap, types, threading, json
+
 try:
     import IPython
+
     has_ipython = True
 except ImportError:
     has_ipython = False
@@ -29,8 +31,13 @@ import pyomo.version
 
 import switch_model
 from switch_model.utilities import (
-    create_model, _ArgumentParser, StepTimer, make_iterable, LogOutput,
-    warn, unwrap
+    create_model,
+    _ArgumentParser,
+    StepTimer,
+    make_iterable,
+    LogOutput,
+    warn,
+    unwrap,
 )
 from switch_model.upgrade import do_inputs_need_upgrade, upgrade_inputs
 
@@ -49,8 +56,10 @@ def main(args=None, return_model=False, return_instance=False):
     # turn on post-mortem debugging mode if requested
     # (from http://stackoverflow.com/a/1237407 ; more options available there)
     if pre_module_options.debug:
+
         def debug(type, value, tb):
             import traceback
+
             try:
                 from ipdb import pm
             except ImportError:
@@ -58,6 +67,7 @@ def main(args=None, return_model=False, return_instance=False):
             traceback.print_exception(type, value, tb)
             report_model_in_traceback(tb)
             pm()
+
         sys.excepthook = debug
 
     # Create a unique logger for this model (other models may have different
@@ -75,20 +85,30 @@ def main(args=None, return_model=False, return_instance=False):
     if pre_module_options.log_run_to_file:
         logs_dir = pre_module_options.logs_dir
     else:
-        logs_dir = None # disables logging
+        logs_dir = None  # disables logging
 
     with LogOutput(logs_dir):
-        logger.info("\n=======================================================================")
-        logger.info("Switch {}, http://switch-model.org".format(switch_model.__version__))
-        logger.info("=======================================================================")
+        logger.info(
+            "\n======================================================================="
+        )
+        logger.info(
+            "Switch {}, http://switch-model.org".format(switch_model.__version__)
+        )
+        logger.info(
+            "======================================================================="
+        )
 
         # Warn users about deprecated flags; we know this earlier but don't have
         # a working logger to report it until here.
-        if '--verbose' in args or '--quiet' in args:
-            logger.warn(unwrap("""
+        if "--verbose" in args or "--quiet" in args:
+            logger.warn(
+                unwrap(
+                    """
                 The --verbose and --quiet flags will be removed in a future
                 version of Switch. Please use --log-level instead.
-            """))
+            """
+                )
+            )
 
         # Check for outdated inputs. This has to happen before modules.txt is
         # parsed to avoid errors from incompatible files.
@@ -96,31 +116,44 @@ def main(args=None, return_model=False, return_instance=False):
         add_module_args(parser)
         module_options = parser.parse_known_args(args=args)[0]
 
-        if (os.path.exists(module_options.inputs_dir) and
-                do_inputs_need_upgrade(module_options.inputs_dir)):
-            if '--help' in args or '-h' in args:
+        if os.path.exists(module_options.inputs_dir) and do_inputs_need_upgrade(
+            module_options.inputs_dir
+        ):
+            if "--help" in args or "-h" in args:
                 # don't prompt to upgrade if they're looking for help
-                print(unwrap("""
+                print(
+                    unwrap(
+                        """
                     Limited help is available because the inputs directory
                     needs to be upgraded. Module-specific help will be
                     available after upgrading the inputs directory via "switch
                     solve" or "switch upgrade".
-                """))
+                """
+                    )
+                )
                 parser.print_help()
                 return 0
 
-            do_upgrade = query_yes_no(unwrap("""
+            do_upgrade = query_yes_no(
+                unwrap(
+                    """
                 Warning! Your inputs directory needs to be upgraded. Do you
                 want to auto-upgrade now? We'll keep a backup of this current
                 version.
-            """))
+            """
+                )
+            )
             if do_upgrade:
                 upgrade_inputs(module_options.inputs_dir)
             else:
-                print(unwrap("""
+                print(
+                    unwrap(
+                        """
                     Inputs need to be upgraded. Consider using "switch upgrade
                     --help". Exiting.
-                """))
+                """
+                    )
+                )
                 return -1
 
         # build a module list based on configuration options, and add
@@ -146,25 +179,32 @@ def main(args=None, return_model=False, return_instance=False):
             # TODO: allow a directory to be specified after --reload-prior-solution,
             # otherwise use outputs_dir.
             prior_solution_file = os.path.join(
-                model.options.outputs_dir, 'results.pickle'
+                model.options.outputs_dir, "results.pickle"
             )
             if not os.path.exists(prior_solution_file):
                 raise IOError(
-                    "Prior solution {} does not exist."
-                    .format(prior_solution_file)
+                    "Prior solution {} does not exist.".format(prior_solution_file)
                 )
 
         # get a list of modules to iterate through
         iterate_modules = get_iteration_list(model)
 
         if model.options.verbose:
-            print("\n=======================================================================")
+            print(
+                "\n======================================================================="
+            )
             print("Arguments:")
-            print(", ".join(k+"="+repr(v) for k, v in vars(model.options).items() if v))
-            print("Modules:\n"+", ".join(m for m in modules))
+            print(
+                ", ".join(
+                    k + "=" + repr(v) for k, v in vars(model.options).items() if v
+                )
+            )
+            print("Modules:\n" + ", ".join(m for m in modules))
             if iterate_modules:
                 print("Iteration modules:", iterate_modules)
-            print("=======================================================================\n")
+            print(
+                "=======================================================================\n"
+            )
             print("Model created in {:.2f} s.".format(timer.step_time()))
             print("Loading inputs...")
 
@@ -175,7 +215,11 @@ def main(args=None, return_model=False, return_instance=False):
 
         instance.pre_solve()
         if instance.options.verbose:
-            print("Total time spent constructing model: {:.2f} s.\n".format(timer.step_time()))
+            print(
+                "Total time spent constructing model: {:.2f} s.\n".format(
+                    timer.step_time()
+                )
+            )
 
         # return the instance as-is if requested
         if return_instance:
@@ -194,12 +238,13 @@ def main(args=None, return_model=False, return_instance=False):
                 raise
 
         if instance.options.reload_prior_solution:
-            print('Loading prior solution...')
+            print("Loading prior solution...")
             reload_prior_solution_from_pickle(instance, prior_solution_file)
             if instance.options.verbose:
                 print(
-                    'Loaded previous results into model instance in {:.2f} s.'
-                    .format(timer.step_time())
+                    "Loaded previous results into model instance in {:.2f} s.".format(
+                        timer.step_time()
+                    )
                 )
         else:
             # solve the model (reports time for each step as it goes)
@@ -211,28 +256,35 @@ def main(args=None, return_model=False, return_instance=False):
                 results = solve(instance)
                 if instance.options.verbose:
                     print("")
-                    print("Optimization termination condition was {}.".format(
-                        results.solver.termination_condition))
-                    if str(results.solver.message) != '<undefined>':
-                        print('Solver message: {}'.format(results.solver.message))
+                    print(
+                        "Optimization termination condition was {}.".format(
+                            results.solver.termination_condition
+                        )
+                    )
+                    if str(results.solver.message) != "<undefined>":
+                        print("Solver message: {}".format(results.solver.message))
                     print("")
 
                 if instance.options.verbose:
-                    timer.step_time() # restart counter for next step
+                    timer.step_time()  # restart counter for next step
 
             # save model configuration for future reference
-            file = os.path.join(instance.options.outputs_dir, 'model_config.json')
-            with open(file, 'w') as f:
-                json.dump({
-                    'options': vars(instance.options),
-                    'modules': modules,
-                    'iterate_modules': iterate_modules
-                }, f, indent=4)
+            file = os.path.join(instance.options.outputs_dir, "model_config.json")
+            with open(file, "w") as f:
+                json.dump(
+                    {
+                        "options": vars(instance.options),
+                        "modules": modules,
+                        "iterate_modules": iterate_modules,
+                    },
+                    f,
+                    indent=4,
+                )
 
             if not instance.options.no_save_solution:
                 save_results(instance, instance.options.outputs_dir)
                 if instance.options.verbose:
-                    print('Saved results in {:.2f} s.'.format(timer.step_time()))
+                    print("Saved results in {:.2f} s.".format(timer.step_time()))
 
         # report results
         # (repeated if model is reloaded, to automatically run any new export code)
@@ -241,23 +293,30 @@ def main(args=None, return_model=False, return_instance=False):
                 print("Executing post solve functions...")
             instance.post_solve()
             if instance.options.verbose:
-                print("Post solve processing completed in {:.2f} s.".format(timer.step_time()))
+                print(
+                    "Post solve processing completed in {:.2f} s.".format(
+                        timer.step_time()
+                    )
+                )
 
     # end of LogOutput block
 
     if instance.options.interact:
         m = instance  # present the solved model as 'm' for convenience
-        banner = '\n'.join([
-            "",
-            "="*60,
-            "Entering interactive {} shell."
-                .format("IPython" if has_ipython else "Python"),
-            "Abstract model is in 'model' variable;",
-            "Solved instance is in 'instance' and 'm' variables.",
-            "Type ctrl-d or exit() to exit shell.",
-            "="*60,
-            ""
-        ])
+        banner = "\n".join(
+            [
+                "",
+                "=" * 60,
+                "Entering interactive {} shell.".format(
+                    "IPython" if has_ipython else "Python"
+                ),
+                "Abstract model is in 'model' variable;",
+                "Solved instance is in 'instance' and 'm' variables.",
+                "Type ctrl-d or exit() to exit shell.",
+                "=" * 60,
+                "",
+            ]
+        )
         # IPython support is disabled until they fix
         # https://github.com/ipython/ipython/issues/12199
         if has_ipython and False:
@@ -265,25 +324,30 @@ def main(args=None, return_model=False, return_instance=False):
             IPython.embed(
                 banner1=banner,
                 exit_msg="Leaving interactive interpreter, returning to program.",
-                colors=instance.options.interact_color)
+                colors=instance.options.interact_color,
+            )
         else:
             import code
+
             code.interact(
                 banner=banner,
-                local=dict(list(globals().items()) + list(locals().items())))
+                local=dict(list(globals().items()) + list(locals().items())),
+            )
 
     # return solved model for users who want to do other things with it
     return instance
 
 
 def reload_prior_solution_from_pickle(instance, pickle_file):
-    with open(pickle_file, 'rb') as fh:
-         results = pickle.load(fh)
+    with open(pickle_file, "rb") as fh:
+        results = pickle.load(fh)
     instance.solutions.load_from(results)
     return instance
 
 
 patched_pyomo = False
+
+
 def patch_pyomo():
     global patched_pyomo
     if not patched_pyomo:
@@ -300,11 +364,13 @@ def patch_pyomo():
             if hasattr(m.e, "_init_rule") and m.e._init_rule is None:
                 # add a deprecation warning here when we stop supporting Pyomo 4.2 or 4.3
                 old_construct = pyomo.environ.Expression.construct
+
                 def new_construct(self, *args, **kwargs):
                     # save rule, call the function, then restore it
                     _init_rule = self._init_rule
                     old_construct(self, *args, **kwargs)
                     self._init_rule = _init_rule
+
                 pyomo.environ.Expression.construct = new_construct
             del m
 
@@ -334,18 +400,21 @@ def patch_pyomo():
                         cache[obj.getname(fully_qualified=True, name_buffer=buf)] = obj"""
 
         from pyomo.core.base.PyomoModel import ModelSolutions
+
         add_solution_code = inspect.getsource(ModelSolutions.add_solution)
         if old_code in add_solution_code:
             # create and inject a new version of the method
             add_solution_code = add_solution_code.replace(old_code, new_code)
-            replace_method(ModelSolutions, 'add_solution', add_solution_code)
+            replace_method(ModelSolutions, "add_solution", add_solution_code)
         else:
             print(
                 "NOTE: The patch to pyomo.core.base.PyomoModel.ModelSolutions.add_solution "
                 "has been deactivated because the Pyomo source code has changed. "
-                "Check whether this patch is still needed and edit {} accordingly."
-                .format(__file__)
+                "Check whether this patch is still needed and edit {} accordingly.".format(
+                    __file__
+                )
             )
+
 
 def replace_method(class_ref, method_name, new_source_code):
     """
@@ -362,7 +431,7 @@ def replace_method(class_ref, method_name, new_source_code):
         orig_method.__globals__,
         orig_method.__name__,
         orig_method.__defaults__,
-        orig_method.__closure__
+        orig_method.__closure__,
     )
     # note: this normal function will be automatically converted to an unbound
     # method when it is assigned as an attribute of a class
@@ -375,9 +444,10 @@ def reload_prior_solution_from_csvs(instance):
     previous solution. (Not currently used.)
     """
     import csv
+
     var_objects = instance.component_objects(Var)
     for var in var_objects:
-        var_file = os.path.join(instance.options.outputs_dir, '{}.csv'.format(var.name))
+        var_file = os.path.join(instance.options.outputs_dir, "{}.csv".format(var.name))
         if not os.path.isfile(var_file):
             raise RuntimeError(
                 "Tab output file for variable {} cannot be found in outputs "
@@ -388,19 +458,20 @@ def reload_prior_solution_from_csvs(instance):
             key_types = [type(i) for i in make_iterable(next(var.iterkeys()))]
         except StopIteration:
             key_types = []  # no keys
-        with open(var_file,'r') as f:
-            reader = csv.reader(f, delimiter=',')
-            next(reader) # skip headers
+        with open(var_file, "r") as f:
+            reader = csv.reader(f, delimiter=",")
+            next(reader)  # skip headers
             for row in reader:
                 index = tuple(t(k) for t, k in zip(key_types, row[:-1]))
                 try:
                     v = var[index]
                 except KeyError:
                     raise KeyError(
-                        "Unable to set value for {}[{}]; index is invalid."
-                        .format(var.name, keys)
+                        "Unable to set value for {}[{}]; index is invalid.".format(
+                            var.name, keys
+                        )
                     )
-                if row[-1] == '':
+                if row[-1] == "":
                     # Variables that are not used in the model end up with no
                     # value after the solve and get saved as blanks; we skip those.
                     continue
@@ -409,7 +480,7 @@ def reload_prior_solution_from_csvs(instance):
                     val = int(val)
                 v.value = val
         if instance.options.verbose:
-            print('Loaded variable {} values into instance.'.format(var.name))
+            print("Loaded variable {} values into instance.".format(var.name))
 
 
 def iterate(m, iterate_modules, depth=0):
@@ -450,8 +521,7 @@ def iterate(m, iterate_modules, depth=0):
             except KeyError:
                 raise ValueError(
                     "Module {} specified in iterate.txt has not been loaded. "
-                    "It should be added to modules.txt as well."
-                    .format(module_name)
+                    "It should be added to modules.txt as well.".format(module_name)
                 )
 
         j = 0
@@ -467,23 +537,32 @@ def iterate(m, iterate_modules, depth=0):
             m.iteration_number = j
             m.iteration_node = m.iteration_node[:depth] + (j,)
             for module in current_modules:
-                converged = iterate_module_func(m, module, 'pre_iterate', converged)
+                converged = iterate_module_func(m, module, "pre_iterate", converged)
 
             # converge the deeper-level modules, if any (inner loop)
-            iterate(m, iterate_modules, depth=depth+1)
+            iterate(m, iterate_modules, depth=depth + 1)
 
             # post-iterate modules at this level
-            m.iteration_number = j      # may have been changed during iterate()
+            m.iteration_number = j  # may have been changed during iterate()
             m.iteration_node = m.iteration_node[:depth] + (j,)
             for module in current_modules:
-                converged = iterate_module_func(m, module, 'post_iterate', converged)
+                converged = iterate_module_func(m, module, "post_iterate", converged)
 
             j += 1
         if converged:
-            print("Iteration of {ms} was completed after {j} rounds.".format(ms=iterate_modules[depth], j=j))
+            print(
+                "Iteration of {ms} was completed after {j} rounds.".format(
+                    ms=iterate_modules[depth], j=j
+                )
+            )
         else:
-            print("Iteration of {ms} was stopped after {j} iterations without convergence.".format(ms=iterate_modules[depth], j=j))
+            print(
+                "Iteration of {ms} was stopped after {j} iterations without convergence.".format(
+                    ms=iterate_modules[depth], j=j
+                )
+            )
     return
+
 
 def iterate_module_func(m, module, func, converged):
     """Call function func() in specified module (if available) and use the result to
@@ -512,100 +591,140 @@ def define_arguments(argparser):
 
     # iteration options
     argparser.add_argument(
-        "--iterate-list", dest="iterate_list", default=None, help="""
+        "--iterate-list",
+        dest="iterate_list",
+        default=None,
+        help="""
             Text file with a list of modules to iterate until converged
             (default is iterate.txt). Each row is one level of iteration, and
             there can be multiple modules on each row.
-        """
+        """,
     )
     argparser.add_argument(
-        "--max-iter", dest="max_iter", type=int, default=None, help="""
+        "--max-iter",
+        dest="max_iter",
+        type=int,
+        default=None,
+        help="""
             Maximum number of iterations to complete at each level for iterated
             models
-        """
+        """,
     )
 
     # scenario information
     argparser.add_argument(
-        "--scenario-name", dest="scenario_name", default="",
-        help="Name of research scenario represented by this model"
+        "--scenario-name",
+        dest="scenario_name",
+        default="",
+        help="Name of research scenario represented by this model",
     )
 
     # note: pyomo has a --solver-suffix option but it is not clear
     # whether that does the same thing as --suffix defined here,
     # so we don't reuse the same name.
     argparser.add_argument(
-        "--suffixes", "--suffix", dest="suffixes", nargs="+", action='extend',
-        default=[], help="""
+        "--suffixes",
+        "--suffix",
+        dest="suffixes",
+        nargs="+",
+        action="extend",
+        default=[],
+        help="""
             Extra suffixes to add to the model and exchange with the solver
             (e.g., iis, rc, dual, or slack)
-        """
+        """,
     )
 
     # Define solver-related arguments
     # These are a subset of the arguments offered by "pyomo solve --solver=cplex --help"
     argparser.add_argument(
-        "--solver", default="glpk",
-        help='Name of Pyomo solver to use for the model (default is "glpk")'
+        "--solver",
+        default="glpk",
+        help='Name of Pyomo solver to use for the model (default is "glpk")',
     )
     argparser.add_argument(
-        "--solver-manager", dest="solver_manager", default="serial", help="""
+        "--solver-manager",
+        dest="solver_manager",
+        default="serial",
+        help="""
             Name of Pyomo solver manager to use for the model ("neos" to use
             remote NEOS server)
-        """
+        """,
     )
     argparser.add_argument(
-        "--solver-io", dest="solver_io", default=None,
-        help="Method for Pyomo to use to communicate with solver"
+        "--solver-io",
+        dest="solver_io",
+        default=None,
+        help="Method for Pyomo to use to communicate with solver",
     )
     # note: pyomo has a --solver-options option but it is not clear
     # whether that does the same thing as --solver-options-string so we don't reuse the same name.
     argparser.add_argument(
-        "--solver-options-string", dest="solver_options_string", default=None,
+        "--solver-options-string",
+        dest="solver_options_string",
+        default=None,
         help="""
             A quoted string of options to pass to the model solver. Each option
             must be of the form option=value. (e.g., --solver-options-string
             "mipgap=0.001 primalopt='' advance=2 threads=1")
-        """
+        """,
     )
     argparser.add_argument(
-        "--keepfiles", action='store_true', default=None, help="""
+        "--keepfiles",
+        action="store_true",
+        default=None,
+        help="""
             Keep temporary files produced by the solver (may be useful with
             --symbolic-solver-labels)
-        """
+        """,
     )
     argparser.add_argument(
-        "--stream-output", "--stream-solver", action='store_true', dest="tee",
-        default=None, help="""
+        "--stream-output",
+        "--stream-solver",
+        action="store_true",
+        dest="tee",
+        default=None,
+        help="""
             Display information from the solver about its progress (usually
             combined with a suitable --solver-options-string)
-        """
+        """,
     )
     argparser.add_argument(
-        "--no-stream-output", "--no-stream-solver", action='store_false',
-        dest="tee", default=None,
-        help="Don't display information from the solver about its progress"
+        "--no-stream-output",
+        "--no-stream-solver",
+        action="store_false",
+        dest="tee",
+        default=None,
+        help="Don't display information from the solver about its progress",
     )
     argparser.add_argument(
-        "--symbolic-solver-labels", action='store_true', dest='symbolic_solver_labels',
-        default=None, help="""
+        "--symbolic-solver-labels",
+        action="store_true",
+        dest="symbolic_solver_labels",
+        default=None,
+        help="""
             Use symbol names derived from the model when interfacing with the
             solver. See "pyomo solve --solver=x --help" for more details.
-        """
+        """,
     )
     argparser.add_argument(
-        "--tempdir", default=None, help="""
+        "--tempdir",
+        default=None,
+        help="""
             The name of a directory to hold temporary files produced by the
             solver. This is usually paired with --keepfiles and
             --symbolic-solver-labels.
-        """
+        """,
     )
     argparser.add_argument(
-        '--retrieve-cplex-mip-duals', dest="retrieve_cplex_mip_duals",
-        default=False, action='store_true', help="""
+        "--retrieve-cplex-mip-duals",
+        dest="retrieve_cplex_mip_duals",
+        default=False,
+        action="store_true",
+        help="""
             Patch Pyomo's solver script for cplex to re-solve and retrieve dual
             values for mixed-integer programs.
-        """
+        """,
     )
 
     # General purpose arguments
@@ -616,69 +735,99 @@ def define_arguments(argparser):
     # note: --inputs-dir is defined in add_module_args, because it may specify the
     # location of the module list (deprecated)
     argparser.add_argument(
-        '--input-alias', '--input-aliases', dest='input_aliases',
-        nargs='+', default=[], action='extend', help="""
+        "--input-alias",
+        "--input-aliases",
+        dest="input_aliases",
+        nargs="+",
+        default=[],
+        action="extend",
+        help="""
             List of input file substitutions, in form of
             standard_file.csv=alternative_file.csv, useful for sensitivity
             studies with alternative inputs.
-        """
+        """,
     )
     argparser.add_argument(
-        '--outputs-dir', default='outputs',
-        help='Directory to write output files (default is "outputs")'
+        "--outputs-dir",
+        default="outputs",
+        help='Directory to write output files (default is "outputs")',
     )
     argparser.add_argument(
-        '--no-post-solve', default=False, action='store_true', help="""
+        "--no-post-solve",
+        default=False,
+        action="store_true",
+        help="""
             Don't run post-solve code on the completed model (i.e., reporting
             functions).
-        """
+        """,
     )
     argparser.add_argument(
-        '--reload-prior-solution', default=False, action='store_true',
+        "--reload-prior-solution",
+        default=False,
+        action="store_true",
         help="""
             Load a previously saved solution; useful for re-running
             post-solve code or interactively exploring the model (with
             --interact).
-        """
+        """,
     )
     argparser.add_argument(
-        '--no-save-solution', default=False, action='store_true',
-        help="Don't save solution after model is solved."
+        "--no-save-solution",
+        default=False,
+        action="store_true",
+        help="Don't save solution after model is solved.",
     )
     argparser.add_argument(
-        '--interact', default=False, action='store_true', help="""
+        "--interact",
+        default=False,
+        action="store_true",
+        help="""
             Enter interactive shell after solving the instance to enable
             inspection of the solved model.
-        """
+        """,
     )
     if has_ipython:
         argparser.add_argument(
-            '--interact-color', dest="interact_color", default="NoColor",
-            choices=['NoColor', 'LightBG', 'Linux'],
-            help='Color scheme to use with the IPython interactive shell.'
+            "--interact-color",
+            dest="interact_color",
+            default="NoColor",
+            choices=["NoColor", "LightBG", "Linux"],
+            help="Color scheme to use with the IPython interactive shell.",
         )
 
 
 def add_module_args(parser):
     parser.add_argument(
-        "--module-list", default=None,
-        help='Text file with a list of modules to include in the model (default is "modules.txt")'
+        "--module-list",
+        default=None,
+        help='Text file with a list of modules to include in the model (default is "modules.txt")',
     )
     parser.add_argument(
-        "--include-modules", "--include-module", dest="include_exclude_modules", nargs='+',
-        action='include', default=[],
-        help="Module(s) to add to the model in addition to any specified with --module-list file"
+        "--include-modules",
+        "--include-module",
+        dest="include_exclude_modules",
+        nargs="+",
+        action="include",
+        default=[],
+        help="Module(s) to add to the model in addition to any specified with --module-list file",
     )
     parser.add_argument(
-        "--exclude-modules", "--exclude-module", dest="include_exclude_modules", nargs='+',
-        action='exclude', default=[],
+        "--exclude-modules",
+        "--exclude-module",
+        dest="include_exclude_modules",
+        nargs="+",
+        action="exclude",
+        default=[],
         help="Module(s) to remove from the model after processing "
-             "--module-list file and prior --include-modules arguments"
+        "--module-list file and prior --include-modules arguments",
     )
     # note: we define --inputs-dir here because it may be used to specify the location of
     # the module list, which is needed before it is loaded.
-    parser.add_argument("--inputs-dir", default="inputs",
-        help='Directory containing input files (default is "inputs")')
+    parser.add_argument(
+        "--inputs-dir",
+        default="inputs",
+        help='Directory containing input files (default is "inputs")',
+    )
 
 
 def add_pre_module_args(parser):
@@ -686,11 +835,18 @@ def add_pre_module_args(parser):
     Add arguments needed before any modules are loaded.
     """
     parser.add_argument(
-        "--log-run", dest="log_run_to_file", default=False, action="store_true",
-        help="Log output to a file.")
+        "--log-run",
+        dest="log_run_to_file",
+        default=False,
+        action="store_true",
+        help="Log output to a file.",
+    )
     parser.add_argument(
-        "--logs-dir", dest="logs_dir", default="logs",
-        help='Directory containing log files (default is "logs"')
+        "--logs-dir",
+        dest="logs_dir",
+        default="logs",
+        help='Directory containing log files (default is "logs"',
+    )
 
     # Standard logging levels from
     # https://docs.python.org/3/library/logging.html#levels
@@ -700,24 +856,38 @@ def add_pre_module_args(parser):
     # logger.error() should be used to explain an error in more detail if
     # needed at the same time as the code raises an exception.
     parser.add_argument(
-        '--log-level', dest='log_level', default='warning',
-        choices = ['error', 'warning', 'info', 'debug'],
-        help='Amount of detail to include in on-screen logging and log files. '
-             'Default is "warning".')
+        "--log-level",
+        dest="log_level",
+        default="warning",
+        choices=["error", "warning", "info", "debug"],
+        help="Amount of detail to include in on-screen logging and log files. "
+        'Default is "warning".',
+    )
     # Deprecated logging flags are retained for now so we can warn users to
     # change their settings.
     parser.add_argument(
-        '--verbose', dest='log_level', action='store_const', const='info',
-        help='Obsolete logging flag; use --log-level info or '
-             '--log-level debug instead.')
+        "--verbose",
+        dest="log_level",
+        action="store_const",
+        const="info",
+        help="Obsolete logging flag; use --log-level info or "
+        "--log-level debug instead.",
+    )
     parser.add_argument(
-        '--quiet', dest='log_level', action='store_const', const='warning',
-        help='Obsolete logging flag; use --log-level warning or '
-             '--log-level error insead.')
+        "--quiet",
+        dest="log_level",
+        action="store_const",
+        const="warning",
+        help="Obsolete logging flag; use --log-level warning or "
+        "--log-level error insead.",
+    )
 
     parser.add_argument(
-        '--debug', action='store_true', default=False,
-        help='Automatically start pdb debugger on exceptions')
+        "--debug",
+        action="store_true",
+        default=False,
+        help="Automatically start pdb debugger on exceptions",
+    )
 
 
 def parse_pre_module_options(args):
@@ -732,13 +902,10 @@ def parse_pre_module_options(args):
 
 
 def parse_list_file(file):
-    """ Read all items from `file` into a list, removing white space at either
+    """Read all items from `file` into a list, removing white space at either
     end of line, blank lines and anything after "#" """
     with open(file) as f:
-        items = [
-            r.split('#', 1)[0].strip()
-            for r in f.read().splitlines()
-        ]
+        items = [r.split("#", 1)[0].strip() for r in f.read().splitlines()]
     items = [i for i in items if i]
     return items
 
@@ -763,7 +930,9 @@ def get_module_list(args):
     if module_list_file is None:
         # note: this could be a RuntimeError, but then users can't do "switch solve --help" in a random directory
         # (alternatively, we could provide no warning at all, since the user can specify --include-modules in the arguments)
-        print("WARNING: No module list found. Please create a modules.txt file with a list of modules to use for the model.")
+        print(
+            "WARNING: No module list found. Please create a modules.txt file with a list of modules to use for the model."
+        )
         modules = []
     else:
         # if it exists, the module list contains one module name per row (no .py extension)
@@ -775,18 +944,20 @@ def get_module_list(args):
     # adjust modules as requested by the user
     # include_exclude_modules format: [('include', [mod1, mod2]), ('exclude', [mod3])]
     for action, mods in module_options.include_exclude_modules:
-        if action == 'include':
+        if action == "include":
             for module_name in mods:
-                if module_name not in modules:  # maybe we should raise an error if already present?
+                if (
+                    module_name not in modules
+                ):  # maybe we should raise an error if already present?
                     modules.append(module_name)
-        if action == 'exclude':
+        if action == "exclude":
             for module_name in mods:
                 try:
                     modules.remove(module_name)
                 except ValueError:
-                    raise ValueError(            # maybe we should just pass?
-                        'Unable to exclude module {} because it was not '
-                        'previously included.'.format(module_name)
+                    raise ValueError(  # maybe we should just pass?
+                        "Unable to exclude module {} because it was not "
+                        "previously included.".format(module_name)
                     )
 
     # add this module, since it has callbacks, e.g. define_arguments for
@@ -810,7 +981,7 @@ def get_iteration_list(m):
     return iterate_modules
 
 
-def get_option_file_args(dir='.', extra_args=[]):
+def get_option_file_args(dir=".", extra_args=[]):
     """
     Retrieve base arguments from options.txt (if present). These can be on
     multiple lines to ease editing, and comments starting with "#" (possibly
@@ -827,8 +998,10 @@ def get_option_file_args(dir='.', extra_args=[]):
     args.extend(extra_args)
     return args
 
+
 # Generic argument-related code; could potentially be moved to utilities.py
 # if we want to make these standard parts of Switch.
+
 
 def add_extra_suffixes(model):
     """
@@ -850,14 +1023,20 @@ def solve(model):
         # with its own solver object (e.g., with runph or a parallel solver server).
         # In those cases, we don't want to go through the expense of creating an
         # unused solver object, or get errors if the solver options are invalid.
-        model.solver = SolverFactory(model.options.solver, solver_io=model.options.solver_io)
+        model.solver = SolverFactory(
+            model.options.solver, solver_io=model.options.solver_io
+        )
 
         # patch for Pyomo < 4.2
         # note: Pyomo added an options_string argument to solver.solve() in Pyomo 4.2 rev 10587.
         # (See https://software.sandia.gov/trac/pyomo/browser/pyomo/trunk/pyomo/opt/base/solvers.py?rev=10587 )
         # This is misreported in the documentation as options=, but options= actually accepts a dictionary.
-        if model.options.solver_options_string and not hasattr(model.solver, "_options_string_to_dict"):
-            for k, v in _options_string_to_dict(model.options.solver_options_string).items():
+        if model.options.solver_options_string and not hasattr(
+            model.solver, "_options_string_to_dict"
+        ):
+            for k, v in _options_string_to_dict(
+                model.options.solver_options_string
+            ).items():
                 model.solver.options[k] = v
 
         # import pdb; pdb.set_trace()
@@ -868,15 +1047,13 @@ def solve(model):
         options_string=model.options.solver_options_string,
         keepfiles=model.options.keepfiles,
         tee=model.options.tee,
-        symbolic_solver_labels=model.options.symbolic_solver_labels
+        symbolic_solver_labels=model.options.symbolic_solver_labels,
     )
     # drop all the unspecified options
     solver_args = {k: v for (k, v) in solver_args.items() if v is not None}
 
     # Automatically send all defined suffixes to the solver
-    solver_args["suffixes"] = [
-        c.name for c in model.component_objects(ctype=Suffix)
-    ]
+    solver_args["suffixes"] = [c.name for c in model.component_objects(ctype=Suffix)]
 
     # note: the next few lines are faster than the line above, but seem risky:
     # i = m._ctypes.get(Suffix, [None])[0]
@@ -901,6 +1078,7 @@ def solve(model):
     if model.options.tempdir is not None:
         # from https://software.sandia.gov/downloads/pub/pyomo/PyomoOnlineDocs.html#_changing_the_temporary_directory
         from pyutilib.services import TempfileManager
+
         TempfileManager.tempdir = model.options.tempdir
 
     try:
@@ -909,26 +1087,38 @@ def solve(model):
         # show the solver status for obscure errors if possible
         print("\nError during solve:\n")
         try:
-            print(err.__traceback__.tb_frame.f_locals['results'])
+            print(err.__traceback__.tb_frame.f_locals["results"])
         except:
             pass
         raise
-    #import pdb; pdb.set_trace()
+    # import pdb; pdb.set_trace()
 
     if model.options.verbose:
-        print("Solved model. Total time spent in solver: {:2f} s.".format(timer.step_time()))
+        print(
+            "Solved model. Total time spent in solver: {:2f} s.".format(
+                timer.step_time()
+            )
+        )
 
     # Treat infeasibility as an error, rather than trying to load and save the results
     # (note: in this case, results.solver.status may be SolverStatus.warning instead of
     # SolverStatus.error)
-    if (results.solver.termination_condition == TerminationCondition.infeasible):
+    if results.solver.termination_condition == TerminationCondition.infeasible:
         if hasattr(model, "iis"):
-            print("Model was infeasible; irreducibly inconsistent set (IIS) returned by solver:")
+            print(
+                "Model was infeasible; irreducibly inconsistent set (IIS) returned by solver:"
+            )
             print("\n".join(sorted(c.name for c in model.iis)))
         else:
-            print("Model was infeasible; if the solver can generate an irreducibly inconsistent set (IIS),")
-            print("more information may be available by setting the appropriate flags in the ")
-            print('--solver-options-string and calling this script with "--suffixes iis".')
+            print(
+                "Model was infeasible; if the solver can generate an irreducibly inconsistent set (IIS),"
+            )
+            print(
+                "more information may be available by setting the appropriate flags in the "
+            )
+            print(
+                '--solver-options-string and calling this script with "--suffixes iis".'
+            )
         # This infeasibility logging module could be nice, but it doesn't work
         # for my solvers and produces extraneous messages.
         # import pyomo.util.infeasible
@@ -949,14 +1139,19 @@ def solve(model):
     # result.solution.status, but also cleared) is in
     # pyomo.opt.SolutionStatus.['optimal', 'bestSoFar', 'feasible', 'globallyOptimal', 'locallyOptimal'],
     # but this seems pretty foolproof (if undocumented).
-    if len(model.solutions[-1]._entry['variable']) == 0:
+    if len(model.solutions[-1]._entry["variable"]) == 0:
         # no solution returned
         print("Solver terminated without a solution.")
         print("  Solver Status: ", results.solver.status)
         print("  Solution Status: ", model.solutions[-1].status)
         print("  Termination Condition: ", results.solver.termination_condition)
-        if model.options.solver == 'glpk' and results.solver.termination_condition == TerminationCondition.other:
-            print("Hint: glpk has been known to classify infeasible problems as 'other'.")
+        if (
+            model.options.solver == "glpk"
+            and results.solver.termination_condition == TerminationCondition.other
+        ):
+            print(
+                "Hint: glpk has been known to classify infeasible problems as 'other'."
+            )
         raise RuntimeError("Solver failed to find an optimal solution.")
 
     # Report any warnings; these are written to stderr so users can find them in
@@ -979,6 +1174,8 @@ def solve(model):
 
 instance_number = 0
 instance_number_lock = threading.Lock()
+
+
 def make_logger(parsed_args):
     """
     Create a unique logger to attach to a model instance.
@@ -1014,34 +1211,39 @@ def retrieve_cplex_mip_duals():
     from cplex lp solver. (This could be made permanent in
     pyomo.solvers.plugins.solvers.CPLEX.create_command_line)."""
     from pyomo.solvers.plugins.solvers.CPLEX import CPLEXSHELL
+
     old_create_command_line = CPLEXSHELL.create_command_line
+
     def new_create_command_line(*args, **kwargs):
         # call original command
         command = old_create_command_line(*args, **kwargs)
         # alter script
-        if hasattr(command, 'script') and 'optimize\n' in command.script:
+        if hasattr(command, "script") and "optimize\n" in command.script:
             command.script = command.script.replace(
-                'optimize\n',
-                'optimize\nchange problem fix\noptimize\n'
+                "optimize\n",
+                "optimize\nchange problem fix\noptimize\n"
                 # see http://www-01.ibm.com/support/docview.wss?uid=swg21399941
                 # and http://www-01.ibm.com/support/docview.wss?uid=swg21400009
             )
             print("changed CPLEX solve script to the following:")
             print(command.script)
         else:
-            print (
+            print(
                 "Unable to patch CPLEX solver script to retrieve duals "
                 "for MIP problems"
             )
         return command
+
     new_create_command_line.is_patched = True
-    if not getattr(CPLEXSHELL.create_command_line, 'is_patched', False):
+    if not getattr(CPLEXSHELL.create_command_line, "is_patched", False):
         CPLEXSHELL.create_command_line = new_create_command_line
 
 
 # taken from https://software.sandia.gov/trac/pyomo/browser/pyomo/trunk/pyomo/opt/base/solvers.py?rev=10784
 # This can be removed when all users are on Pyomo 4.2
 import pyutilib
+
+
 def _options_string_to_dict(istr):
     ans = {}
     istr = istr.strip()
@@ -1049,18 +1251,20 @@ def _options_string_to_dict(istr):
         return ans
     if istr[0] == "'" or istr[0] == '"':
         istr = eval(istr)
-    tokens = pyutilib.misc.quote_split('[ ]+',istr)
+    tokens = pyutilib.misc.quote_split("[ ]+", istr)
     for token in tokens:
-        index = token.find('=')
+        index = token.find("=")
         if index is -1:
             raise ValueError(
-                "Solver options must have the form option=value: '{}'".format(istr))
+                "Solver options must have the form option=value: '{}'".format(istr)
+            )
         try:
-            val = eval(token[(index+1):])
+            val = eval(token[(index + 1) :])
         except:
-            val = token[(index+1):]
+            val = token[(index + 1) :]
         ans[token[:index]] = val
     return ans
+
 
 def save_results(instance, outdir):
     """
@@ -1073,11 +1277,10 @@ def save_results(instance, outdir):
     # First, save the full solution data to the results object, because recent
     # versions of Pyomo only store execution metadata there by default.
     instance.solutions.store_to(instance.last_results)
-    with open(os.path.join(outdir, 'results.pickle'), 'wb') as fh:
+    with open(os.path.join(outdir, "results.pickle"), "wb") as fh:
         pickle.dump(instance.last_results, fh, protocol=-1)
     # remove the solution from the results object, to minimize long-term memory use
     instance.last_results.solution.clear()
-
 
 
 def query_yes_no(question, default="yes"):
@@ -1090,8 +1293,7 @@ def query_yes_no(question, default="yes"):
 
     The "answer" return value is True for "yes" or False for "no".
     """
-    valid = {"yes": True, "y": True, "ye": True,
-             "no": False, "n": False}
+    valid = {"yes": True, "y": True, "ye": True, "no": False, "n": False}
     if default is None:
         prompt = " [y/n] "
     elif default == "yes":
@@ -1104,43 +1306,43 @@ def query_yes_no(question, default="yes"):
     while True:
         sys.stdout.write(question + prompt)
         choice = input().lower()
-        if default is not None and choice == '':
+        if default is not None and choice == "":
             return valid[default]
         elif choice in valid:
             return valid[choice]
         else:
-            sys.stdout.write("Please respond with 'yes' or 'no' "
-                             "(or 'y' or 'n').\n")
+            sys.stdout.write("Please respond with 'yes' or 'no' " "(or 'y' or 'n').\n")
+
 
 def report_model_in_traceback(tb):
     """
     Report on location of model in current traceback, if one can be found easily.
     """
     import traceback
+
     for level, (frame, line) in enumerate(reversed(list(traceback.walk_tb(tb)))):
-        file_loc = '{}, line {}'.format(frame.f_code.co_filename, line)
+        file_loc = "{}, line {}".format(frame.f_code.co_filename, line)
         if level == 0:
-            location = 'in the current frame'
+            location = "in the current frame"
         elif level == 1:
-            location = 'in\n{}\n(1 level up)'.format(file_loc)
+            location = "in\n{}\n(1 level up)".format(file_loc)
         else:
-            location = 'in\n{}\n({} levels up)'.format(file_loc, level)
+            location = "in\n{}\n({} levels up)".format(file_loc, level)
         vars = frame.f_locals
         for name, v in vars.items():
             if isinstance(v, Model):
                 print(
-                    "\nA model can be found in variable '{}' {}"
-                    .format(name, location)
+                    "\nA model can be found in variable '{}' {}".format(name, location)
                 )
                 return
         for name, v in vars.items():
-            if isinstance(v, Component) and hasattr(v, 'model'):
+            if isinstance(v, Component) and hasattr(v, "model"):
                 print(
-                    "\nA model can be found in '{}.model()' {}"
-                    .format(name, location)
+                    "\nA model can be found in '{}.model()' {}".format(name, location)
                 )
                 return
     print("\nNo Pyomo model was found in the current stack trace.")
+
 
 ###############
 

--- a/switch_model/solve_scenarios.py
+++ b/switch_model/solve_scenarios.py
@@ -36,11 +36,15 @@ cmd_line_args = sys.argv[1:]
 # Other command-line arguments will be passed through to solve.py via
 # scenario_cmd_line_args
 parser = _ArgumentParser(
-    allow_abbrev=False, description='Solve one or more Switch scenarios.'
+    allow_abbrev=False, description="Solve one or more Switch scenarios."
 )
 parser.add_argument(
-    '--scenario', '--scenarios', nargs='+', dest='scenarios',
-    default=[], action='extend'
+    "--scenario",
+    "--scenarios",
+    nargs="+",
+    dest="scenarios",
+    default=[],
+    action="extend",
 )
 parser.add_argument("--scenario-list", default="scenarios.txt")
 parser.add_argument("--scenario-queue", default="scenario_queue")
@@ -48,15 +52,17 @@ parser.add_argument("--job-id", default=None)
 
 # import pdb; pdb.set_trace()
 # get a namespace object with successfully parsed scenario manager arguments
-scenario_manager_args = parser.parse_known_args(args=option_file_args + cmd_line_args)[0]
+scenario_manager_args = parser.parse_known_args(args=option_file_args + cmd_line_args)[
+    0
+]
 # get lists of other arguments to pass through to standard solve routine
 scenario_option_file_args = parser.parse_known_args(args=option_file_args)[1]
 scenario_cmd_line_args = parser.parse_known_args(args=cmd_line_args)[1]
 
 # create a logger for this module's output based on default arguments
-logger = solve.make_logger(solve.parse_pre_module_options(
-    scenario_option_file_args + scenario_cmd_line_args
-))
+logger = solve.make_logger(
+    solve.parse_pre_module_options(scenario_option_file_args + scenario_cmd_line_args)
+)
 
 requested_scenarios = scenario_manager_args.scenarios
 scenario_list_file = scenario_manager_args.scenario_list
@@ -77,11 +83,11 @@ scenario_queue_dir = scenario_manager_args.scenario_queue
 # If a job id is not specified, interrupted jobs will not be restarted.
 job_id = scenario_manager_args.job_id
 if job_id is None:
-    job_id = os.environ.get('SWITCH_JOB_ID')
+    job_id = os.environ.get("SWITCH_JOB_ID")
 if job_id is None:
     # this cannot be running in parallel with another task with the same pid on
     # the same host, so it's safe to requeue any jobs with this id
-    job_id = socket.gethostname() + '_' + str(os.getpid())
+    job_id = socket.gethostname() + "_" + str(os.getpid())
 
 # TODO: other options for requeueing jobs:
 # - use file locks on lockfiles: lock a
@@ -132,12 +138,13 @@ if job_id is None:
 # the DB), so users can restart scenarios by deleting the 'done' file.
 # But this requires synchronized clocks across workers...
 
-running_scenarios_file = os.path.join(scenario_queue_dir, job_id+"_running.txt")
+running_scenarios_file = os.path.join(scenario_queue_dir, job_id + "_running.txt")
 
 # list of scenarios currently being run by this job (always just one with the current code)
 running_scenarios = []
 
-#import pdb; pdb.set_trace()
+# import pdb; pdb.set_trace()
+
 
 def main(args=None):
     # make sure the scenario_queue_dir exists (marginally better to do this once
@@ -145,7 +152,7 @@ def main(args=None):
     try:
         os.makedirs(scenario_queue_dir)
     except OSError:
-        pass    # directory probably exists already
+        pass  # directory probably exists already
 
     # remove lock directories for any scenarios that were
     # previously being solved by this job but were interrupted
@@ -177,6 +184,7 @@ def main(args=None):
 
         mark_completed(scenario_name)
 
+
 def scenarios_to_run():
     """Generator function which returns argument lists for each scenario that should be run.
 
@@ -193,13 +201,17 @@ def scenarios_to_run():
         # just run them in the order specified, with no queue-management
         for scenario_name in requested_scenarios:
             completed = False
-            scenario_args = scenario_option_file_args + get_scenario_dict()[scenario_name] + scenario_cmd_line_args
+            scenario_args = (
+                scenario_option_file_args
+                + get_scenario_dict()[scenario_name]
+                + scenario_cmd_line_args
+            )
             # flag the scenario as being run; then run it whether or not it was previously run
             checkout(scenario_name, force=True)
             yield (scenario_name, scenario_args)
         # no more scenarios to run
         return
-    else:   # no specific scenarios requested
+    else:  # no specific scenarios requested
         # Run every scenario in the list, with queue management
         # This is done by repeatedly scanning the scenario list and choosing
         # the first scenario that hasn't been run. This way, users can edit the
@@ -212,7 +224,9 @@ def scenarios_to_run():
             # This list is found by retrieving the names of the lock-directories.
             already_run = {f for f in os.listdir(".") if os.path.isdir(f)}
             for scenario_name, base_args in get_scenario_dict().items():
-                scenario_args = scenario_option_file_args + base_args + scenario_cmd_line_args
+                scenario_args = (
+                    scenario_option_file_args + base_args + scenario_cmd_line_args
+                )
                 if scenario_name not in already_run and checkout(scenario_name):
                     # run this scenario, then start again at the top of the list
                     ran.append(scenario_name)
@@ -222,15 +236,20 @@ def scenarios_to_run():
                 else:
                     if scenario_name not in skipped and scenario_name not in ran:
                         skipped.append(scenario_name)
-                        logger.info("Skipping {} because it was already run.".format(scenario_name))
+                        logger.info(
+                            "Skipping {} because it was already run.".format(
+                                scenario_name
+                            )
+                        )
                 # move on to the next candidate
         # no more scenarios to run
         if skipped and not ran:
             logger.warn(
                 "Skipping all scenarios because they have already been solved. "
                 "If you would like to run these scenarios again, "
-                "please remove the {sq} directory or its contents. (rm -rf {sq})"
-                .format(sq=scenario_queue_dir)
+                "please remove the {sq} directory or its contents. (rm -rf {sq})".format(
+                    sq=scenario_queue_dir
+                )
             )
         return
 
@@ -243,13 +262,15 @@ def parse_arg(arg, args=sys.argv[1:], **parse_kw):
     # (They have no reason to set the destination anyway.)
     # note: we use the term "option" so that parsing errors will make a little more
     # sense, e.g., if users call with "--suffixes <blank>" (instead of just omitting it)
-    parse_kw["dest"]="option"
+    parse_kw["dest"] = "option"
     parser.add_argument(arg, **parse_kw)
     return parser.parse_known_args(args)[0].option
+
 
 def get_scenario_name(scenario_args):
     # use ad-hoc parsing to extract the scenario name from a scenario-definition string
     return parse_arg("--scenario-name", default=None, args=scenario_args)
+
 
 def last_index(lst, val):
     try:
@@ -257,18 +278,18 @@ def last_index(lst, val):
     except ValueError:
         return -1
 
+
 def get_scenario_dict():
     # note: we read the list from the disk each time so that we get a fresher
     # version if the standard list is changed during a long solution effort.
     # This ignores comments in the scenario list (possibly starting mid-line),
     # just like switch solve does in options.txt.
-    with open(scenario_list_file, 'r') as f:
-        scenario_list = [
-            shlex.split(r, comments=True) for r in f.read().splitlines()
-        ]
+    with open(scenario_list_file, "r") as f:
+        scenario_list = [shlex.split(r, comments=True) for r in f.read().splitlines()]
     # drop any empty lines
     scenario_list = [s for s in scenario_list if s]
     return OrderedDict((get_scenario_name(s), s) for s in scenario_list)
+
 
 def checkout(scenario_name, force=False):
     # write a flag that we are solving this scenario, before actually trying to lock it
@@ -283,7 +304,7 @@ def checkout(scenario_name, force=False):
         os.mkdir(os.path.join(scenario_queue_dir, scenario_name))
         locked = True
     except OSError as e:
-        if e.errno != 17:     # File exists
+        if e.errno != 17:  # File exists
             raise
         locked = False
     if locked or force:
@@ -294,12 +315,14 @@ def checkout(scenario_name, force=False):
         write_running_scenarios_file()
         return False
 
+
 def mark_completed(scenario_name):
     # remove the scenario from the list of running scenarios (since it's been completed now)
     running_scenarios.remove(scenario_name)
     write_running_scenarios_file()
     # note: the scenario lock directory is left in place so the scenario won't get checked
     # out again
+
 
 def write_running_scenarios_file():
     # write the list of scenarios currently being run by this job to disk
@@ -313,15 +336,16 @@ def write_running_scenarios_file():
         # done that actually haven't.)
         flags = "r+" if os.path.exists(running_scenarios_file) else "w"
         with open(running_scenarios_file, flags) as f:
-            f.write("\n".join(running_scenarios)+"\n")
+            f.write("\n".join(running_scenarios) + "\n")
             f.truncate()
     else:
         # remove the running_scenarios_file entirely if it would be empty
         try:
             os.remove(running_scenarios_file)
         except OSError as e:
-            if e.errno != 2:    # no such file
+            if e.errno != 2:  # no such file
                 raise
+
 
 def unlock_running_scenarios():
     # called during startup to remove lockfiles for any scenarios that were still running
@@ -333,8 +357,9 @@ def unlock_running_scenarios():
             try:
                 os.rmdir(os.path.join(scenario_queue_dir, scenario_name))
             except OSError as e:
-                if e.errno != 2:    # no such file
+                if e.errno != 2:  # no such file
                     raise
+
 
 # run the main function if called as a script
 if __name__ == "__main__":

--- a/switch_model/test.py
+++ b/switch_model/test.py
@@ -1,13 +1,15 @@
 from __future__ import print_function
+
 # Copyright (c) 2015-2020 The Switch Authors. All rights reserved.
 # Licensed under the Apache License, Version 2.0, which is in the LICENSE file.
 import sys
+
 
 def main():
     print("running {} as {}.".format(__file__, __name__))
     print("system path:")
     print("\n".join(sys.path))
 
+
 if __name__ == "__main__":
     main()
-

--- a/switch_model/timescales.py
+++ b/switch_model/timescales.py
@@ -230,7 +230,7 @@ def define_components(mod):
     mod.PERIODS = Set(ordered=True)
     mod.period_start = Param(mod.PERIODS, within=NonNegativeReals)
     mod.period_end = Param(mod.PERIODS, within=NonNegativeReals)
-    mod.min_data_check('PERIODS', 'period_start', 'period_end')
+    mod.min_data_check("PERIODS", "period_start", "period_end")
 
     mod.TIMESERIES = Set(ordered=True)
     mod.ts_period = Param(mod.TIMESERIES, within=mod.PERIODS)
@@ -238,12 +238,16 @@ def define_components(mod):
     mod.ts_num_tps = Param(mod.TIMESERIES, within=NonNegativeIntegers)
     mod.ts_scale_to_period = Param(mod.TIMESERIES, within=NonNegativeReals)
     mod.min_data_check(
-        'TIMESERIES', 'ts_period', 'ts_duration_of_tp', 'ts_num_tps',
-        'ts_scale_to_period')
+        "TIMESERIES",
+        "ts_period",
+        "ts_duration_of_tp",
+        "ts_num_tps",
+        "ts_scale_to_period",
+    )
 
     mod.TIMEPOINTS = Set(ordered=True)
     mod.tp_ts = Param(mod.TIMEPOINTS, within=mod.TIMESERIES)
-    mod.min_data_check('TIMEPOINTS', 'tp_ts')
+    mod.min_data_check("TIMEPOINTS", "tp_ts")
     mod.tp_timestamp = Param(mod.TIMEPOINTS, default=lambda m, t: t)
 
     # Derived sets and parameters
@@ -251,35 +255,38 @@ def define_components(mod):
     # can be used for the add_one_to_period_end_rule
 
     mod.tp_duration_hrs = Param(
-        mod.TIMEPOINTS,
-        initialize=lambda m, t: m.ts_duration_of_tp[m.tp_ts[t]])
+        mod.TIMEPOINTS, initialize=lambda m, t: m.ts_duration_of_tp[m.tp_ts[t]]
+    )
     mod.tp_weight = Param(
         mod.TIMEPOINTS,
         within=NonNegativeReals,
         initialize=lambda m, t: (
-            m.tp_duration_hrs[t] * m.ts_scale_to_period[m.tp_ts[t]]))
+            m.tp_duration_hrs[t] * m.ts_scale_to_period[m.tp_ts[t]]
+        ),
+    )
     mod.TPS_IN_TS = Set(
         mod.TIMESERIES,
         ordered=True,
         within=mod.TIMEPOINTS,
-        initialize=lambda m, ts: [
-            t for t in m.TIMEPOINTS if m.tp_ts[t] == ts])
+        initialize=lambda m, ts: [t for t in m.TIMEPOINTS if m.tp_ts[t] == ts],
+    )
     mod.tp_period = Param(
         mod.TIMEPOINTS,
         within=mod.PERIODS,
-        initialize=lambda m, t: m.ts_period[m.tp_ts[t]])
+        initialize=lambda m, t: m.ts_period[m.tp_ts[t]],
+    )
     mod.TS_IN_PERIOD = Set(
         mod.PERIODS,
         ordered=True,
         within=mod.TIMESERIES,
-        initialize=lambda m, p: [
-            ts for ts in m.TIMESERIES if m.ts_period[ts] == p])
+        initialize=lambda m, p: [ts for ts in m.TIMESERIES if m.ts_period[ts] == p],
+    )
     mod.TPS_IN_PERIOD = Set(
         mod.PERIODS,
         ordered=True,
         within=mod.TIMEPOINTS,
-        initialize=lambda m, p: [
-            t for t in m.TIMEPOINTS if m.tp_period[t] == p])
+        initialize=lambda m, p: [t for t in m.TIMEPOINTS if m.tp_period[t] == p],
+    )
 
     # Decide whether period_end values have been given as exact points in time
     # (e.g., 2020.0 means 2020-01-01 00:00:00), or as a label for a full
@@ -288,46 +295,63 @@ def define_components(mod):
     # NOTE: we can't just check whether period_end[p] + 1 = period_start[p+1],
     # because that is undefined for single-period models.
     def add_one_to_period_end_rule(m):
-        hours_in_period = {p: sum(m.tp_weight[t] for t in m.TPS_IN_PERIOD[p]) for p in m.PERIODS}
+        hours_in_period = {
+            p: sum(m.tp_weight[t] for t in m.TPS_IN_PERIOD[p]) for p in m.PERIODS
+        }
         err_plain = sum(
             (m.period_end[p] - m.period_start[p]) * hours_per_year - hours_in_period[p]
-                for p in m.PERIODS)
+            for p in m.PERIODS
+        )
         err_add_one = sum(
-            (m.period_end[p] + 1 - m.period_start[p]) * hours_per_year - hours_in_period[p]
-                for p in m.PERIODS)
-        add_one = (abs(err_add_one) < abs(err_plain))
+            (m.period_end[p] + 1 - m.period_start[p]) * hours_per_year
+            - hours_in_period[p]
+            for p in m.PERIODS
+        )
+        add_one = abs(err_add_one) < abs(err_plain)
         # print "add_one: {}".format(add_one)
         return add_one
-    mod.add_one_to_period_end = Param(within=Boolean, initialize=add_one_to_period_end_rule)
+
+    mod.add_one_to_period_end = Param(
+        within=Boolean, initialize=add_one_to_period_end_rule
+    )
 
     mod.period_length_years = Param(
         mod.PERIODS,
-        initialize=lambda m, p: m.period_end[p] - m.period_start[p] + (1 if m.add_one_to_period_end else 0))
+        initialize=lambda m, p: m.period_end[p]
+        - m.period_start[p]
+        + (1 if m.add_one_to_period_end else 0),
+    )
     mod.period_length_hours = Param(
-        mod.PERIODS,
-        initialize=lambda m, p: m.period_length_years[p] * hours_per_year)
+        mod.PERIODS, initialize=lambda m, p: m.period_length_years[p] * hours_per_year
+    )
 
     mod.CURRENT_AND_PRIOR_PERIODS_FOR_PERIOD = Set(
-        mod.PERIODS, ordered=True,
-        initialize=lambda m, p:
-            [p2 for p2 in m.PERIODS if m.PERIODS.ord(p2) <= m.PERIODS.ord(p)]
+        mod.PERIODS,
+        ordered=True,
+        initialize=lambda m, p: [
+            p2 for p2 in m.PERIODS if m.PERIODS.ord(p2) <= m.PERIODS.ord(p)
+        ],
     )
 
     mod.ts_scale_to_year = Param(
         mod.TIMESERIES,
         initialize=lambda m, ts: (
-            m.ts_scale_to_period[ts] / m.period_length_years[m.ts_period[ts]]))
+            m.ts_scale_to_period[ts] / m.period_length_years[m.ts_period[ts]]
+        ),
+    )
     mod.ts_duration_hrs = Param(
         mod.TIMESERIES,
-        initialize=lambda m, ts: (
-            m.ts_num_tps[ts] * m.ts_duration_of_tp[ts]))
+        initialize=lambda m, ts: (m.ts_num_tps[ts] * m.ts_duration_of_tp[ts]),
+    )
 
     mod.tp_weight_in_year = Param(
         mod.TIMEPOINTS,
         within=NonNegativeReals,
         initialize=lambda m, t: (
-            m.tp_weight[t] / m.period_length_years[m.tp_period[t]]),
-        doc="This weight scales a timepoint to an annual average.")
+            m.tp_weight[t] / m.period_length_years[m.tp_period[t]]
+        ),
+        doc="This weight scales a timepoint to an annual average.",
+    )
     # Identify previous step for each timepoint, for use in tracking
     # unit commitment or storage. We use circular indexing (.prevw() method)
     # for the timepoints within a timeseries to give consistency between the
@@ -336,24 +360,30 @@ def define_components(mod):
     mod.tp_previous = Param(
         mod.TIMEPOINTS,
         within=mod.TIMEPOINTS,
-        initialize=lambda m, t: m.TPS_IN_TS[m.tp_ts[t]].prevw(t))
+        initialize=lambda m, t: m.TPS_IN_TS[m.tp_ts[t]].prevw(t),
+    )
 
     def validate_time_weights_rule(m, p):
         hours_in_period = sum(m.tp_weight[t] for t in m.TPS_IN_PERIOD[p])
         tol = 0.01
-        if(hours_in_period > (1 + tol) * m.period_length_hours[p] or
-           hours_in_period < (1 - tol) * m.period_length_hours[p]):
-            print(("validate_time_weights_rule failed for period " +
-                   "'{period:.0f}'. Expected {period_h:0.2f}, based on " +
-                   "length in years, but the sum of timepoint weights " +
-                   "is {ds_h:0.2f}.\n"
-                   ).format(period=p, period_h=m.period_length_hours[p],
-                            ds_h=hours_in_period))
+        if (
+            hours_in_period > (1 + tol) * m.period_length_hours[p]
+            or hours_in_period < (1 - tol) * m.period_length_hours[p]
+        ):
+            print(
+                (
+                    "validate_time_weights_rule failed for period "
+                    + "'{period:.0f}'. Expected {period_h:0.2f}, based on "
+                    + "length in years, but the sum of timepoint weights "
+                    + "is {ds_h:0.2f}.\n"
+                ).format(
+                    period=p, period_h=m.period_length_hours[p], ds_h=hours_in_period
+                )
+            )
             return 0
         return 1
-    mod.validate_time_weights = BuildCheck(
-        mod.PERIODS,
-        rule=validate_time_weights_rule)
+
+    mod.validate_time_weights = BuildCheck(mod.PERIODS, rule=validate_time_weights_rule)
 
     def validate_period_lengths_rule(m, p):
         tol = 0.01
@@ -361,16 +391,19 @@ def define_components(mod):
             p_end = m.period_start[p] + m.period_length_years[p]
             p_next = m.period_start[m.PERIODS.next(p)]
             if abs(p_next - p_end) > tol:
-                print((
-                    "validate_period_lengths_rule failed for period"
-                    + "'{p:.0f}'. Period ends at {p_end}, but next period"
-                    + "begins at {p_next}."
-                ).format(p=p, p_end=p_end, p_next=p_next))
+                print(
+                    (
+                        "validate_period_lengths_rule failed for period"
+                        + "'{p:.0f}'. Period ends at {p_end}, but next period"
+                        + "begins at {p_next}."
+                    ).format(p=p, p_end=p_end, p_next=p_next)
+                )
                 return False
         return True
+
     mod.validate_period_lengths = BuildCheck(
-        mod.PERIODS,
-        rule=validate_period_lengths_rule)
+        mod.PERIODS, rule=validate_period_lengths_rule
+    )
 
 
 def load_inputs(mod, switch_data, inputs_dir):
@@ -400,16 +433,23 @@ def load_inputs(mod, switch_data, inputs_dir):
     # names, be indifferent to column order, and throw an error message if
     # some columns are not found.
     switch_data.load_aug(
-        filename=os.path.join(inputs_dir, 'periods.csv'),
+        filename=os.path.join(inputs_dir, "periods.csv"),
         index=mod.PERIODS,
-        param=(mod.period_start, mod.period_end))
+        param=(mod.period_start, mod.period_end),
+    )
     switch_data.load_aug(
-        filename=os.path.join(inputs_dir, 'timeseries.csv'),
+        filename=os.path.join(inputs_dir, "timeseries.csv"),
         index=mod.TIMESERIES,
-        param=(mod.ts_period, mod.ts_duration_of_tp,
-               mod.ts_num_tps, mod.ts_scale_to_period))
+        param=(
+            mod.ts_period,
+            mod.ts_duration_of_tp,
+            mod.ts_num_tps,
+            mod.ts_scale_to_period,
+        ),
+    )
     switch_data.load_aug(
-        filename=os.path.join(inputs_dir, 'timepoints.csv'),
-        select=('timepoint_id', 'timestamp', 'timeseries'),
+        filename=os.path.join(inputs_dir, "timepoints.csv"),
+        select=("timepoint_id", "timestamp", "timeseries"),
         index=mod.TIMEPOINTS,
-        param=(mod.tp_timestamp, mod.tp_ts))
+        param=(mod.tp_timestamp, mod.tp_ts),
+    )

--- a/switch_model/transmission/copperplate.py
+++ b/switch_model/transmission/copperplate.py
@@ -3,11 +3,12 @@ Allow unlimited transfer of power between zones at no cost.
 """
 from pyomo.environ import *
 
+
 def define_components(m):
     m.TXPowerNet = Var(m.LOAD_ZONES, m.TIMEPOINTS, within=Reals)
     # net imports into each zone from all other zones
     m.TX_Energy_Balance = Constraint(
         m.TIMEPOINTS,
-        rule=lambda m, t: sum(m.TXPowerNet[z, t] for z in m.LOAD_ZONES) == 0.0
+        rule=lambda m, t: sum(m.TXPowerNet[z, t] for z in m.LOAD_ZONES) == 0.0,
     )
-    m.Zone_Power_Injections.append('TXPowerNet')
+    m.Zone_Power_Injections.append("TXPowerNet")

--- a/switch_model/transmission/local_td.py
+++ b/switch_model/transmission/local_td.py
@@ -16,8 +16,12 @@ import os
 import pandas as pd
 from pyomo.environ import *
 
-dependencies = 'switch_model.timescales', 'switch_model.balancing.load_zones',\
-    'switch_model.financials'
+dependencies = (
+    "switch_model.timescales",
+    "switch_model.balancing.load_zones",
+    "switch_model.financials",
+)
+
 
 def define_dynamic_lists(mod):
     """
@@ -122,59 +126,59 @@ def define_components(mod):
 
     # Local T&D
     mod.existing_local_td = Param(mod.LOAD_ZONES, within=NonNegativeReals)
-    mod.min_data_check('existing_local_td')
+    mod.min_data_check("existing_local_td")
 
-    mod.BuildLocalTD = Var(
-        mod.LOAD_ZONES, mod.PERIODS,
-        within=NonNegativeReals)
+    mod.BuildLocalTD = Var(mod.LOAD_ZONES, mod.PERIODS, within=NonNegativeReals)
     mod.LocalTDCapacity = Expression(
-        mod.LOAD_ZONES, mod.PERIODS,
-        rule=lambda m, z, period:
-            m.existing_local_td[z]
-            + sum(
-                m.BuildLocalTD[z, bld_yr]
-                for bld_yr in m.CURRENT_AND_PRIOR_PERIODS_FOR_PERIOD[period]
-        )
+        mod.LOAD_ZONES,
+        mod.PERIODS,
+        rule=lambda m, z, period: m.existing_local_td[z]
+        + sum(
+            m.BuildLocalTD[z, bld_yr]
+            for bld_yr in m.CURRENT_AND_PRIOR_PERIODS_FOR_PERIOD[period]
+        ),
     )
     mod.distribution_loss_rate = Param(default=0.053)
 
     mod.Meet_Local_TD = Constraint(
         mod.EXTERNAL_COINCIDENT_PEAK_DEMAND_ZONE_PERIODS,
-        rule=lambda m, z, period:
-            m.LocalTDCapacity[z, period] * (1-m.distribution_loss_rate)
-            >=
-            m.zone_expected_coincident_peak_demand[z, period]
+        rule=lambda m, z, period: m.LocalTDCapacity[z, period]
+        * (1 - m.distribution_loss_rate)
+        >= m.zone_expected_coincident_peak_demand[z, period],
     )
-    mod.local_td_annual_cost_per_mw = Param(
-        mod.LOAD_ZONES,
-        within=NonNegativeReals)
-    mod.min_data_check('local_td_annual_cost_per_mw')
+    mod.local_td_annual_cost_per_mw = Param(mod.LOAD_ZONES, within=NonNegativeReals)
+    mod.min_data_check("local_td_annual_cost_per_mw")
     mod.LocalTDFixedCosts = Expression(
         mod.PERIODS,
         doc="Summarize annual local T&D costs for the objective function.",
         rule=lambda m, p: sum(
             m.LocalTDCapacity[z, p] * m.local_td_annual_cost_per_mw[z]
-            for z in m.LOAD_ZONES))
-    mod.Cost_Components_Per_Period.append('LocalTDFixedCosts')
-
+            for z in m.LOAD_ZONES
+        ),
+    )
+    mod.Cost_Components_Per_Period.append("LocalTDFixedCosts")
 
     # DISTRIBUTED NODE
     mod.WithdrawFromCentralGrid = Var(
         mod.ZONE_TIMEPOINTS,
         within=NonNegativeReals,
-        doc="Power withdrawn from a zone's central node sent over local T&D.")
+        doc="Power withdrawn from a zone's central node sent over local T&D.",
+    )
     mod.Enforce_Local_TD_Capacity_Limit = Constraint(
         mod.ZONE_TIMEPOINTS,
-        rule=lambda m, z, t:
-            m.WithdrawFromCentralGrid[z,t] <= m.LocalTDCapacity[z,m.tp_period[t]])
+        rule=lambda m, z, t: m.WithdrawFromCentralGrid[z, t]
+        <= m.LocalTDCapacity[z, m.tp_period[t]],
+    )
     mod.InjectIntoDistributedGrid = Expression(
         mod.ZONE_TIMEPOINTS,
         doc="Describes WithdrawFromCentralGrid after line losses.",
-        rule=lambda m, z, t: m.WithdrawFromCentralGrid[z,t] * (1-m.distribution_loss_rate))
+        rule=lambda m, z, t: m.WithdrawFromCentralGrid[z, t]
+        * (1 - m.distribution_loss_rate),
+    )
 
     # Register energy injections & withdrawals
-    mod.Zone_Power_Withdrawals.append('WithdrawFromCentralGrid')
-    mod.Distributed_Power_Injections.append('InjectIntoDistributedGrid')
+    mod.Zone_Power_Withdrawals.append("WithdrawFromCentralGrid")
+    mod.Distributed_Power_Injections.append("InjectIntoDistributedGrid")
 
 
 def define_dynamic_components(mod):
@@ -198,9 +202,13 @@ def define_dynamic_components(mod):
             sum(
                 getattr(m, component)[z, t]
                 for component in m.Distributed_Power_Injections
-            ) == sum(
+            )
+            == sum(
                 getattr(m, component)[z, t]
-                for component in m.Distributed_Power_Withdrawals)))
+                for component in m.Distributed_Power_Withdrawals
+            )
+        ),
+    )
 
 
 def load_inputs(mod, switch_data, inputs_dir):
@@ -224,14 +232,16 @@ def load_inputs(mod, switch_data, inputs_dir):
     """
 
     switch_data.load_aug(
-        filename=os.path.join(inputs_dir, 'load_zones.csv'),
-        param=(mod.existing_local_td, mod.local_td_annual_cost_per_mw))
-    switch_data.load_aug(
-        filename=os.path.join(inputs_dir, 'trans_params.csv'),
-        optional=True,
-        optional_params=['distribution_loss_rate'],
-        param=[mod.distribution_loss_rate]
+        filename=os.path.join(inputs_dir, "load_zones.csv"),
+        param=(mod.existing_local_td, mod.local_td_annual_cost_per_mw),
     )
+    switch_data.load_aug(
+        filename=os.path.join(inputs_dir, "trans_params.csv"),
+        optional=True,
+        optional_params=["distribution_loss_rate"],
+        param=[mod.distribution_loss_rate],
+    )
+
 
 def post_solve(instance, outdir):
     """
@@ -249,7 +259,7 @@ def post_solve(instance, outdir):
 
     """
     wide_dat = []
-    for z,t in instance.ZONE_TIMEPOINTS:
+    for z, t in instance.ZONE_TIMEPOINTS:
         record = {"load_zone": z, "timestamp": t}
         for component in instance.Distributed_Power_Injections:
             record[component] = value(getattr(instance, component)[z, t])
@@ -261,14 +271,14 @@ def post_solve(instance, outdir):
     wide_df.to_csv(os.path.join(outdir, "local_td_energy_balance_wide.csv"))
 
     normalized_dat = []
-    for z,t in instance.ZONE_TIMEPOINTS:
+    for z, t in instance.ZONE_TIMEPOINTS:
         for component in instance.Distributed_Power_Injections:
             record = {
                 "load_zone": z,
                 "timestamp": t,
                 "component": component,
                 "injects_or_withdraws": "injects",
-                "value": value(getattr(instance, component)[z, t])
+                "value": value(getattr(instance, component)[z, t]),
             }
             normalized_dat.append(record)
         for component in instance.Distributed_Power_Withdrawals:
@@ -277,7 +287,7 @@ def post_solve(instance, outdir):
                 "timestamp": t,
                 "component": component,
                 "injects_or_withdraws": "withdraws",
-                "value": value(-1.0 * getattr(instance, component)[z, t])
+                "value": value(-1.0 * getattr(instance, component)[z, t]),
             }
             normalized_dat.append(record)
     df = pd.DataFrame(normalized_dat)

--- a/switch_model/transmission/transport/__init__.py
+++ b/switch_model/transmission/transport/__init__.py
@@ -9,5 +9,6 @@ The core modules in the package are build and dispatch.
 
 """
 core_modules = [
-    'switch_model.transmission.transport.build',
-    'switch_model.transmission.transport.dispatch']
+    "switch_model.transmission.transport.build",
+    "switch_model.transmission.transport.dispatch",
+]

--- a/switch_model/transmission/transport/build.py
+++ b/switch_model/transmission/transport/build.py
@@ -13,8 +13,12 @@ from pyomo.environ import *
 
 from switch_model.financials import capital_recovery_factor as crf
 
-dependencies = 'switch_model.timescales', 'switch_model.balancing.load_zones',\
-    'switch_model.financials'
+dependencies = (
+    "switch_model.timescales",
+    "switch_model.balancing.load_zones",
+    "switch_model.financials",
+)
+
 
 def define_components(mod):
     """
@@ -160,15 +164,15 @@ def define_components(mod):
     # configurations that are sometimes run with interzonal transmission and sometimes not
     # (e.g., island interconnect scenarios). However, presence of this column will still be
     # checked by load_data_aug.
-    mod.min_data_check('trans_lz1', 'trans_lz2')
+    mod.min_data_check("trans_lz1", "trans_lz2")
 
     def _check_tx_duplicate_paths(m):
-        forward_paths = set([
-            (m.trans_lz1[tx], m.trans_lz2[tx]) for tx in m.TRANSMISSION_LINES
-        ])
-        reverse_paths = set([
-            (m.trans_lz2[tx], m.trans_lz1[tx]) for tx in m.TRANSMISSION_LINES
-        ])
+        forward_paths = set(
+            [(m.trans_lz1[tx], m.trans_lz2[tx]) for tx in m.TRANSMISSION_LINES]
+        )
+        reverse_paths = set(
+            [(m.trans_lz2[tx], m.trans_lz1[tx]) for tx in m.TRANSMISSION_LINES]
+        )
         overlap = forward_paths.intersection(reverse_paths)
         if overlap:
             logging.error(
@@ -176,57 +180,54 @@ def define_components(mod):
                 "in input files. They are expected to specify a single path "
                 "per pair of connected load zones. "
                 "(Ex: either A->B or B->A, but not both). "
-                "Over-specified lines: {}".format(overlap))
-            return(False)
+                "Over-specified lines: {}".format(overlap)
+            )
+            return False
         else:
-            return(True)
+            return True
+
     mod.check_tx_duplicate_paths = BuildCheck(rule=_check_tx_duplicate_paths)
 
     mod.trans_dbid = Param(mod.TRANSMISSION_LINES, default=lambda m, tx: tx)
     mod.trans_length_km = Param(mod.TRANSMISSION_LINES, within=NonNegativeReals)
-    mod.trans_efficiency = Param(
-        mod.TRANSMISSION_LINES,
-        within=PercentFraction)
-    mod.existing_trans_cap = Param(
-        mod.TRANSMISSION_LINES,
-        within=NonNegativeReals)
-    mod.min_data_check(
-        'trans_length_km', 'trans_efficiency', 'existing_trans_cap')
+    mod.trans_efficiency = Param(mod.TRANSMISSION_LINES, within=PercentFraction)
+    mod.existing_trans_cap = Param(mod.TRANSMISSION_LINES, within=NonNegativeReals)
+    mod.min_data_check("trans_length_km", "trans_efficiency", "existing_trans_cap")
     mod.trans_new_build_allowed = Param(
-        mod.TRANSMISSION_LINES, within=Boolean, default=True)
+        mod.TRANSMISSION_LINES, within=Boolean, default=True
+    )
     mod.TRANS_BLD_YRS = Set(
         dimen=2,
         initialize=mod.TRANSMISSION_LINES * mod.PERIODS,
-        filter=lambda m, tx, p: m.trans_new_build_allowed[tx])
+        filter=lambda m, tx, p: m.trans_new_build_allowed[tx],
+    )
     mod.BuildTx = Var(mod.TRANS_BLD_YRS, within=NonNegativeReals)
     mod.TxCapacityNameplate = Expression(
-        mod.TRANSMISSION_LINES, mod.PERIODS,
+        mod.TRANSMISSION_LINES,
+        mod.PERIODS,
         rule=lambda m, tx, period: sum(
             m.BuildTx[tx, bld_yr]
             for bld_yr in m.PERIODS
             if bld_yr <= period and (tx, bld_yr) in m.TRANS_BLD_YRS
-        ) + m.existing_trans_cap[tx])
+        )
+        + m.existing_trans_cap[tx],
+    )
     mod.trans_derating_factor = Param(
-        mod.TRANSMISSION_LINES,
-        within=PercentFraction,
-        default=1)
+        mod.TRANSMISSION_LINES, within=PercentFraction, default=1
+    )
     mod.TxCapacityNameplateAvailable = Expression(
-        mod.TRANSMISSION_LINES, mod.PERIODS,
-        rule=lambda m, tx, period: (
-            m.TxCapacityNameplate[tx, period] * m.trans_derating_factor[tx]))
-    mod.trans_terrain_multiplier = Param(
         mod.TRANSMISSION_LINES,
-        within=NonNegativeReals,
-        default=1)
-    mod.trans_capital_cost_per_mw_km = Param(
-        within=NonNegativeReals,
-        default=1000)
-    mod.trans_lifetime_yrs = Param(
-        within=NonNegativeReals,
-        default=20)
-    mod.trans_fixed_om_fraction = Param(
-        within=NonNegativeReals,
-        default=0.03)
+        mod.PERIODS,
+        rule=lambda m, tx, period: (
+            m.TxCapacityNameplate[tx, period] * m.trans_derating_factor[tx]
+        ),
+    )
+    mod.trans_terrain_multiplier = Param(
+        mod.TRANSMISSION_LINES, within=NonNegativeReals, default=1
+    )
+    mod.trans_capital_cost_per_mw_km = Param(within=NonNegativeReals, default=1000)
+    mod.trans_lifetime_yrs = Param(within=NonNegativeReals, default=20)
+    mod.trans_fixed_om_fraction = Param(within=NonNegativeReals, default=0.03)
     # Total annual fixed costs for building new transmission lines...
     # Multiply capital costs by capital recover factor to get annual
     # payments. Add annual fixed O&M that are expressed as a fraction of
@@ -235,9 +236,12 @@ def define_components(mod):
         mod.TRANSMISSION_LINES,
         within=NonNegativeReals,
         initialize=lambda m, tx: (
-            m.trans_capital_cost_per_mw_km * m.trans_terrain_multiplier[tx] *
-            m.trans_length_km[tx] * (crf(m.interest_rate, m.trans_lifetime_yrs) +
-                m.trans_fixed_om_fraction)))
+            m.trans_capital_cost_per_mw_km
+            * m.trans_terrain_multiplier[tx]
+            * m.trans_length_km[tx]
+            * (crf(m.interest_rate, m.trans_lifetime_yrs) + m.trans_fixed_om_fraction)
+        ),
+    )
     # An expression to summarize annual costs for the objective
     # function. Units should be total annual future costs in $base_year
     # real dollars. The objective function will convert these to
@@ -247,9 +251,9 @@ def define_components(mod):
         rule=lambda m, p: sum(
             m.TxCapacityNameplate[tx, p] * m.trans_cost_annual[tx]
             for tx in m.TRANSMISSION_LINES
-        )
+        ),
     )
-    mod.Cost_Components_Per_Period.append('TxFixedCosts')
+    mod.Cost_Components_Per_Period.append("TxFixedCosts")
 
     def init_DIRECTIONAL_TX(model):
         tx_dir = set()
@@ -257,23 +261,25 @@ def define_components(mod):
             tx_dir.add((model.trans_lz1[tx], model.trans_lz2[tx]))
             tx_dir.add((model.trans_lz2[tx], model.trans_lz1[tx]))
         return tx_dir
-    mod.DIRECTIONAL_TX = Set(
-        dimen=2,
-        initialize=init_DIRECTIONAL_TX)
+
+    mod.DIRECTIONAL_TX = Set(dimen=2, initialize=init_DIRECTIONAL_TX)
     mod.TX_CONNECTIONS_TO_ZONE = Set(
         mod.LOAD_ZONES,
         initialize=lambda m, lz: set(
-            z for z in m.LOAD_ZONES if (z,lz) in m.DIRECTIONAL_TX))
+            z for z in m.LOAD_ZONES if (z, lz) in m.DIRECTIONAL_TX
+        ),
+    )
 
     def init_trans_d_line(m, zone_from, zone_to):
         for tx in m.TRANSMISSION_LINES:
-            if((m.trans_lz1[tx] == zone_from and m.trans_lz2[tx] == zone_to) or
-               (m.trans_lz2[tx] == zone_from and m.trans_lz1[tx] == zone_to)):
+            if (m.trans_lz1[tx] == zone_from and m.trans_lz2[tx] == zone_to) or (
+                m.trans_lz2[tx] == zone_from and m.trans_lz1[tx] == zone_to
+            ):
                 return tx
+
     mod.trans_d_line = Param(
-        mod.DIRECTIONAL_TX,
-        within=mod.TRANSMISSION_LINES,
-        initialize=init_trans_d_line)
+        mod.DIRECTIONAL_TX, within=mod.TRANSMISSION_LINES, initialize=init_trans_d_line
+    )
 
 
 def load_inputs(mod, switch_data, inputs_dir):
@@ -299,27 +305,34 @@ def load_inputs(mod, switch_data, inputs_dir):
     # TODO: send issue / pull request to Pyomo to allow .csv files with
     # no rows after header (fix bugs in pyomo.core.plugins.data.text)
     switch_data.load_aug(
-        filename=os.path.join(inputs_dir, 'transmission_lines.csv'),
+        filename=os.path.join(inputs_dir, "transmission_lines.csv"),
         index=mod.TRANSMISSION_LINES,
         optional_params=(
-            'trans_dbid', 'trans_derating_factor',
-            'trans_terrain_multiplier', 'trans_new_build_allowed'
+            "trans_dbid",
+            "trans_derating_factor",
+            "trans_terrain_multiplier",
+            "trans_new_build_allowed",
         ),
         param=(
-            mod.trans_lz1, mod.trans_lz2,
-            mod.trans_length_km, mod.trans_efficiency, mod.existing_trans_cap,
-            mod.trans_dbid, mod.trans_derating_factor,
-            mod.trans_terrain_multiplier, mod.trans_new_build_allowed
-        )
+            mod.trans_lz1,
+            mod.trans_lz2,
+            mod.trans_length_km,
+            mod.trans_efficiency,
+            mod.existing_trans_cap,
+            mod.trans_dbid,
+            mod.trans_derating_factor,
+            mod.trans_terrain_multiplier,
+            mod.trans_new_build_allowed,
+        ),
     )
     switch_data.load_aug(
-        filename=os.path.join(inputs_dir, 'trans_params.csv'),
+        filename=os.path.join(inputs_dir, "trans_params.csv"),
         optional=True,
         param=(
             mod.trans_capital_cost_per_mw_km,
             mod.trans_lifetime_yrs,
-            mod.trans_fixed_om_fraction
-        )
+            mod.trans_fixed_om_fraction,
+        ),
     )
 
 
@@ -327,18 +340,23 @@ def post_solve(instance, outdir):
     mod = instance
     normalized_dat = [
         {
-        	"TRANSMISSION_LINE": tx,
-        	"PERIOD": p,
-        	"trans_lz1": mod.trans_lz1[tx],
-        	"trans_lz2": mod.trans_lz2[tx],
-        	"trans_dbid": mod.trans_dbid[tx],
-        	"trans_length_km": mod.trans_length_km[tx],
-        	"trans_efficiency": mod.trans_efficiency[tx],
-        	"trans_derating_factor": mod.trans_derating_factor[tx],
-        	"TxCapacityNameplate": value(mod.TxCapacityNameplate[tx,p]),
-        	"TxCapacityNameplateAvailable": value(mod.TxCapacityNameplateAvailable[tx,p]),
-        	"TotalAnnualCost": value(mod.TxCapacityNameplate[tx,p] * mod.trans_cost_annual[tx])
-        } for tx, p in mod.TRANSMISSION_LINES * mod.PERIODS
+            "TRANSMISSION_LINE": tx,
+            "PERIOD": p,
+            "trans_lz1": mod.trans_lz1[tx],
+            "trans_lz2": mod.trans_lz2[tx],
+            "trans_dbid": mod.trans_dbid[tx],
+            "trans_length_km": mod.trans_length_km[tx],
+            "trans_efficiency": mod.trans_efficiency[tx],
+            "trans_derating_factor": mod.trans_derating_factor[tx],
+            "TxCapacityNameplate": value(mod.TxCapacityNameplate[tx, p]),
+            "TxCapacityNameplateAvailable": value(
+                mod.TxCapacityNameplateAvailable[tx, p]
+            ),
+            "TotalAnnualCost": value(
+                mod.TxCapacityNameplate[tx, p] * mod.trans_cost_annual[tx]
+            ),
+        }
+        for tx, p in mod.TRANSMISSION_LINES * mod.PERIODS
     ]
     tx_build_df = pd.DataFrame(normalized_dat)
     tx_build_df.set_index(["TRANSMISSION_LINE", "PERIOD"], inplace=True)

--- a/switch_model/upgrade/__init__.py
+++ b/switch_model/upgrade/__init__.py
@@ -23,8 +23,12 @@ API Synopsis:
 """
 # Public interface
 from .manager import (
-    main, upgrade_inputs, scan_and_upgrade,
-    get_input_version, do_inputs_need_upgrade
+    main,
+    upgrade_inputs,
+    scan_and_upgrade,
+    get_input_version,
+    do_inputs_need_upgrade,
 )
+
 # Private utility functions for this upgrade sub-package
 from .manager import _backup, _write_input_version, print_verbose

--- a/switch_model/upgrade/manager.py
+++ b/switch_model/upgrade/manager.py
@@ -38,17 +38,22 @@ upgrade_plugins = [
 last_required_update = upgrade_plugins[-1][-1]
 
 code_version = parse_version(switch_model.__version__)
-version_file = 'switch_inputs_version.txt'
-#verbose = False
+version_file = "switch_inputs_version.txt"
+# verbose = False
 verbose = True
 
-def scan_and_upgrade(top_dir, inputs_dir_name='inputs', backup=True, assign_current_version=False):
+
+def scan_and_upgrade(
+    top_dir, inputs_dir_name="inputs", backup=True, assign_current_version=False
+):
     for dirpath, dirnames, filenames in os.walk(top_dir):
         for dirname in dirnames:
             path = os.path.join(dirpath, dirname)
-            if os.path.exists(os.path.join(path, inputs_dir_name, 'modules.txt')):
+            if os.path.exists(os.path.join(path, inputs_dir_name, "modules.txt")):
                 # print_verbose('upgrading {}'.format(os.path.join(path, inputs_dir_name)))
-                upgrade_inputs(os.path.join(path, inputs_dir_name), backup, assign_current_version)
+                upgrade_inputs(
+                    os.path.join(path, inputs_dir_name), backup, assign_current_version
+                )
 
 
 def get_input_version(inputs_dir):
@@ -63,26 +68,29 @@ def get_input_version(inputs_dir):
     """
     version_path = os.path.join(inputs_dir, version_file)
     if os.path.isfile(version_path):
-        with open(version_path, 'r') as f:
+        with open(version_path, "r") as f:
             version = f.readline().strip()
     # Before we started storing version numbers in the inputs directory, we
     # had an input file named generator_info.tab. If that file exists, we are
     # dealing with version 2.0.0b0.
-    elif os.path.isfile(os.path.join(inputs_dir, 'generator_info.tab')):
-        version = '2.0.0b0'
+    elif os.path.isfile(os.path.join(inputs_dir, "generator_info.tab")):
+        version = "2.0.0b0"
     else:
-        raise ValueError((
-            "Input directory {} is not recognized as a valid Switch input folder. "
-            "An input directory needs to contain a file named '{}' that stores the "
-            "version number of Switch that it was intended for. ").format(
-                inputs_dir, version_file))
+        raise ValueError(
+            (
+                "Input directory {} is not recognized as a valid Switch input folder. "
+                "An input directory needs to contain a file named '{}' that stores the "
+                "version number of Switch that it was intended for. "
+            ).format(inputs_dir, version_file)
+        )
     return version
 
 
 def _write_input_version(inputs_dir, new_version):
     version_path = os.path.join(inputs_dir, version_file)
-    with open(version_path, 'w') as f:
+    with open(version_path, "w") as f:
         f.write(new_version + "\n")
+
 
 def do_inputs_need_upgrade(inputs_dir):
     """
@@ -102,10 +110,10 @@ def _backup(inputs_dir):
     """
     Make a backup of the inputs_dir into a zip file, unless it already exists
     """
-    inputs_backup = inputs_dir + '_v' + get_input_version(inputs_dir)
+    inputs_backup = inputs_dir + "_v" + get_input_version(inputs_dir)
     inputs_backup_path = inputs_backup + ".zip"
     if not os.path.isfile(inputs_backup_path):
-        shutil.make_archive(inputs_backup, 'zip', inputs_dir)
+        shutil.make_archive(inputs_backup, "zip", inputs_dir)
 
 
 def print_verbose(*args):
@@ -118,9 +126,9 @@ def upgrade_inputs(inputs_dir, backup=True, assign_current_version=False):
     # This logic will grow over time as complexity evolves.. Don't overengineer
     upgraded = False
     if do_inputs_need_upgrade(inputs_dir):
-        print_verbose('Upgrading ' + inputs_dir)
+        print_verbose("Upgrading " + inputs_dir)
         if backup:
-            print_verbose('\tBacked up original inputs')
+            print_verbose("\tBacked up original inputs")
             _backup(inputs_dir)
         # Successively apply the upgrade scripts as needed.
         for (upgrader, v_from, v_to) in upgrade_plugins:
@@ -128,21 +136,23 @@ def upgrade_inputs(inputs_dir, backup=True, assign_current_version=False):
             # note: the next line catches datasets created by/for versions of Switch that
             # didn't require input directory upgrades
             if parse_version(v_from) <= inputs_v < parse_version(v_to):
-                print_verbose('\tUpgrading from ' + v_from + ' to ' + v_to)
+                print_verbose("\tUpgrading from " + v_from + " to " + v_to)
                 upgrader.upgrade_input_dir(inputs_dir)
         upgraded = True
 
-    if (parse_version(last_required_update) < parse_version(switch_model.__version__)
-            and assign_current_version):
+    if (
+        parse_version(last_required_update) < parse_version(switch_model.__version__)
+        and assign_current_version
+    ):
         # user requested writing of current version number, even if no upgrade is needed
         # (useful for updating examples to track with new release of Switch)
         _write_input_version(inputs_dir, switch_model.__version__)
         upgraded = True
 
     if upgraded:
-        print_verbose('\tFinished upgrading ' + inputs_dir + '\n')
+        print_verbose("\tFinished upgrading " + inputs_dir + "\n")
     else:
-        print_verbose('Skipped ' + inputs_dir + '; it does not need upgrade.')
+        print_verbose("Skipped " + inputs_dir + "; it does not need upgrade.")
 
 
 def main(args=None):
@@ -154,33 +164,67 @@ def main(args=None):
         args = parser.parse_args()
     set_verbose(args.verbose)
     if args.recursive:
-        scan_and_upgrade('.', args.inputs_dir_name, args.backup, args.assign_current_version)
+        scan_and_upgrade(
+            ".", args.inputs_dir_name, args.backup, args.assign_current_version
+        )
     else:
         if not os.path.isdir(args.inputs_dir_name):
-            print("Error: Input directory {} does not exist.".format(args.inputs_dir_name))
+            print(
+                "Error: Input directory {} does not exist.".format(args.inputs_dir_name)
+            )
             return -1
-        upgrade_inputs(os.path.normpath(args.inputs_dir_name), args.backup, args.assign_current_version)
+        upgrade_inputs(
+            os.path.normpath(args.inputs_dir_name),
+            args.backup,
+            args.assign_current_version,
+        )
+
 
 def set_verbose(verbosity):
     global verbose
     verbose = verbosity
 
+
 def add_parser_args(parser):
-    parser.add_argument("--inputs-dir-name", type=str, default="inputs",
-        help='Input directory name (default is "inputs")')
-    parser.add_argument("--backup", action='store_true', default=True,
-        help='Make backup of inputs directory before upgrading (set true by default)')
-    parser.add_argument("--no-backup", action='store_false', dest='backup',
-        help='Do not make backup of inputs directory before upgrading')
-    parser.add_argument("--assign-current-version", dest='assign_current_version',
-        action='store_true', default=False,
-        help=('Update version number in inputs directory to match current version'
-              'of Switch, even if data does not require an upgrade.'))
-    parser.add_argument("--recursive", dest="recursive",
-        default=False, action='store_true',
-        help=('Recursively scan the provided path for inputs directories '
-              'named "inputs", and upgrade each directory found. Note, this '
-              'requires each inputs directory to include modules.txt. This '
-              'will not work if modules.txt is in the parent directory.'))
-    parser.add_argument("--verbose", action='store_true', default=verbose)
-    parser.add_argument("--quiet", dest="verbose", action='store_false')
+    parser.add_argument(
+        "--inputs-dir-name",
+        type=str,
+        default="inputs",
+        help='Input directory name (default is "inputs")',
+    )
+    parser.add_argument(
+        "--backup",
+        action="store_true",
+        default=True,
+        help="Make backup of inputs directory before upgrading (set true by default)",
+    )
+    parser.add_argument(
+        "--no-backup",
+        action="store_false",
+        dest="backup",
+        help="Do not make backup of inputs directory before upgrading",
+    )
+    parser.add_argument(
+        "--assign-current-version",
+        dest="assign_current_version",
+        action="store_true",
+        default=False,
+        help=(
+            "Update version number in inputs directory to match current version"
+            "of Switch, even if data does not require an upgrade."
+        ),
+    )
+    parser.add_argument(
+        "--recursive",
+        dest="recursive",
+        default=False,
+        action="store_true",
+        help=(
+            "Recursively scan the provided path for inputs directories "
+            'named "inputs", and upgrade each directory found. Note, this '
+            "requires each inputs directory to include modules.txt. This "
+            "will not work if modules.txt is in the parent directory."
+        ),
+    )
+    parser.add_argument("--verbose", action="store_true", default=verbose)
+    parser.add_argument("--quiet", dest="verbose", action="store_false")

--- a/switch_model/upgrade/re_upgrade.py
+++ b/switch_model/upgrade/re_upgrade.py
@@ -2,15 +2,17 @@ from __future__ import print_function
 
 import os
 from switch_model.upgrade.manager import upgrade_plugins
+
 upgrade_module, upgrade_from, upgrade_to = upgrade_plugins[-1]
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     print(
-        "Re-running upgrade from {} to {} for all subdirectories of current directory"
-        .format(upgrade_from, upgrade_to)
+        "Re-running upgrade from {} to {} for all subdirectories of current directory".format(
+            upgrade_from, upgrade_to
+        )
     )
 
-    for dirpath, dirnames, filenames in os.walk('.'):
-        if 'switch_inputs_version.txt' in filenames:
-            print('upgrading {}'.format(dirpath))
+    for dirpath, dirnames, filenames in os.walk("."):
+        if "switch_inputs_version.txt" in filenames:
+            print("upgrading {}".format(dirpath))
             upgrade_module.upgrade_input_dir(dirpath)

--- a/switch_model/upgrade/upgrade_2_0_0b1.py
+++ b/switch_model/upgrade/upgrade_2_0_0b1.py
@@ -31,118 +31,115 @@ import pandas
 import argparse
 import switch_model.upgrade
 
-upgrades_from = '2.0.0b0'
-upgrades_to = '2.0.0b1'
+upgrades_from = "2.0.0b0"
+upgrades_to = "2.0.0b1"
 
 old_modules = {
-    'switch_mod.balancing_areas',
-    'switch_mod.export',
-    'switch_mod.export.__init__',
-    'switch_mod.export.dump',
-    'switch_mod.export.example_export',
-    'switch_mod.financials',
-    'switch_mod.fuel_cost',
-    'switch_mod.fuel_markets',
-    'switch_mod.fuels',
-    'switch_mod.gen_tech',
-    'switch_mod.generators.hydro_simple',
-    'switch_mod.generators.hydro_system',
-    'switch_mod.generators.storage',
-    'switch_mod.hawaii.batteries',
-    'switch_mod.hawaii.batteries_fixed_calendar_life',
-    'switch_mod.hawaii.constant_elasticity_demand_system',
-    'switch_mod.hawaii.demand_response',
-    'switch_mod.hawaii.demand_response_no_reserves',
-    'switch_mod.hawaii.demand_response_simple',
-    'switch_mod.hawaii.emission_rules',
-    'switch_mod.hawaii.ev',
-    'switch_mod.hawaii.fed_subsidies',
-    'switch_mod.hawaii.fuel_markets_expansion',
-    'switch_mod.hawaii.hydrogen',
-    'switch_mod.hawaii.kalaeloa',
-    'switch_mod.hawaii.lng_conversion',
-    'switch_mod.hawaii.no_central_pv',
-    'switch_mod.hawaii.no_onshore_wind',
-    'switch_mod.hawaii.no_renewables',
-    'switch_mod.hawaii.no_wind',
-    'switch_mod.hawaii.psip',
-    'switch_mod.hawaii.pumped_hydro',
-    'switch_mod.hawaii.r_demand_system',
-    'switch_mod.hawaii.reserves',
-    'switch_mod.hawaii.rps',
-    'switch_mod.hawaii.save_results',
-    'switch_mod.hawaii.scenario_data',
-    'switch_mod.hawaii.scenarios',
-    'switch_mod.hawaii.smooth_dispatch',
-    'switch_mod.hawaii.switch_patch',
-    'switch_mod.hawaii.unserved_load',
-    'switch_mod.hawaii.util',
-    'switch_mod.load_zones',
-    'switch_mod.local_td',
-    'switch_mod.main',
-    'switch_mod.project.build',
-    'switch_mod.project.discrete_build',
-    'switch_mod.project.dispatch',
-    'switch_mod.project.no_commit',
-    'switch_mod.project.unitcommit.commit',
-    'switch_mod.project.unitcommit.discrete',
-    'switch_mod.project.unitcommit.fuel_use',
-    'switch_mod.solve',
-    'switch_mod.solve_scenarios',
-    'switch_mod.test',
-    'switch_mod.timescales',
-    'switch_mod.trans_build',
-    'switch_mod.trans_dispatch',
-    'switch_mod.utilities',
-    'switch_mod.project',
-    'switch_mod.project.unitcommit',
+    "switch_mod.balancing_areas",
+    "switch_mod.export",
+    "switch_mod.export.__init__",
+    "switch_mod.export.dump",
+    "switch_mod.export.example_export",
+    "switch_mod.financials",
+    "switch_mod.fuel_cost",
+    "switch_mod.fuel_markets",
+    "switch_mod.fuels",
+    "switch_mod.gen_tech",
+    "switch_mod.generators.hydro_simple",
+    "switch_mod.generators.hydro_system",
+    "switch_mod.generators.storage",
+    "switch_mod.hawaii.batteries",
+    "switch_mod.hawaii.batteries_fixed_calendar_life",
+    "switch_mod.hawaii.constant_elasticity_demand_system",
+    "switch_mod.hawaii.demand_response",
+    "switch_mod.hawaii.demand_response_no_reserves",
+    "switch_mod.hawaii.demand_response_simple",
+    "switch_mod.hawaii.emission_rules",
+    "switch_mod.hawaii.ev",
+    "switch_mod.hawaii.fed_subsidies",
+    "switch_mod.hawaii.fuel_markets_expansion",
+    "switch_mod.hawaii.hydrogen",
+    "switch_mod.hawaii.kalaeloa",
+    "switch_mod.hawaii.lng_conversion",
+    "switch_mod.hawaii.no_central_pv",
+    "switch_mod.hawaii.no_onshore_wind",
+    "switch_mod.hawaii.no_renewables",
+    "switch_mod.hawaii.no_wind",
+    "switch_mod.hawaii.psip",
+    "switch_mod.hawaii.pumped_hydro",
+    "switch_mod.hawaii.r_demand_system",
+    "switch_mod.hawaii.reserves",
+    "switch_mod.hawaii.rps",
+    "switch_mod.hawaii.save_results",
+    "switch_mod.hawaii.scenario_data",
+    "switch_mod.hawaii.scenarios",
+    "switch_mod.hawaii.smooth_dispatch",
+    "switch_mod.hawaii.switch_patch",
+    "switch_mod.hawaii.unserved_load",
+    "switch_mod.hawaii.util",
+    "switch_mod.load_zones",
+    "switch_mod.local_td",
+    "switch_mod.main",
+    "switch_mod.project.build",
+    "switch_mod.project.discrete_build",
+    "switch_mod.project.dispatch",
+    "switch_mod.project.no_commit",
+    "switch_mod.project.unitcommit.commit",
+    "switch_mod.project.unitcommit.discrete",
+    "switch_mod.project.unitcommit.fuel_use",
+    "switch_mod.solve",
+    "switch_mod.solve_scenarios",
+    "switch_mod.test",
+    "switch_mod.timescales",
+    "switch_mod.trans_build",
+    "switch_mod.trans_dispatch",
+    "switch_mod.utilities",
+    "switch_mod.project",
+    "switch_mod.project.unitcommit",
 }
 rename_modules = {
-    'switch_mod.load_zones': 'switch_mod.balancing.load_zones',
-    'switch_mod.fuels': 'switch_mod.energy_sources.properties',
-    'switch_mod.trans_build': 'switch_mod.transmission.transport.build',
-    'switch_mod.trans_dispatch': 'switch_mod.transmission.transport.dispatch',
-    'switch_mod.project.build': 'switch_mod.generators.core.build',
-    'switch_mod.project.discrete_build': 'switch_mod.generators.core.gen_discrete_build',
-    'switch_mod.project.dispatch': 'switch_mod.generators.core.dispatch',
-    'switch_mod.project.no_commit': 'switch_mod.generators.core.no_commit',
-    'switch_mod.project.unitcommit.commit': 'switch_mod.generators.core.commit.operate',
-    'switch_mod.project.unitcommit.fuel_use': 'switch_mod.generators.core.commit.fuel_use',
-    'switch_mod.project.unitcommit.discrete': 'switch_mod.generators.core.commit.discrete',
-    'switch_mod.fuel_cost': 'switch_mod.energy_sources.fuel_costs.simple',
-    'switch_mod.fuel_markets': 'switch_mod.energy_sources.fuel_costs.markets',
-    'switch_mod.export': 'switch_mod.reporting',
-    'switch_mod.local_td': 'switch_mod.transmission.local_td',
-    'switch_mod.balancing_areas': 'switch_mod.balancing.operating_reserves.areas',
-    'switch_mod.export.dump': 'switch_mod.reporting.dump',
-    'switch_mod.generators.hydro_simple':
-        'switch_mod.generators.extensions.hydro_simple',
-    'switch_mod.generators.hydro_system':
-        'switch_mod.generators.extensions.hydro_system',
-    'switch_mod.generators.storage':
-        'switch_mod.generators.extensions.storage',
+    "switch_mod.load_zones": "switch_mod.balancing.load_zones",
+    "switch_mod.fuels": "switch_mod.energy_sources.properties",
+    "switch_mod.trans_build": "switch_mod.transmission.transport.build",
+    "switch_mod.trans_dispatch": "switch_mod.transmission.transport.dispatch",
+    "switch_mod.project.build": "switch_mod.generators.core.build",
+    "switch_mod.project.discrete_build": "switch_mod.generators.core.gen_discrete_build",
+    "switch_mod.project.dispatch": "switch_mod.generators.core.dispatch",
+    "switch_mod.project.no_commit": "switch_mod.generators.core.no_commit",
+    "switch_mod.project.unitcommit.commit": "switch_mod.generators.core.commit.operate",
+    "switch_mod.project.unitcommit.fuel_use": "switch_mod.generators.core.commit.fuel_use",
+    "switch_mod.project.unitcommit.discrete": "switch_mod.generators.core.commit.discrete",
+    "switch_mod.fuel_cost": "switch_mod.energy_sources.fuel_costs.simple",
+    "switch_mod.fuel_markets": "switch_mod.energy_sources.fuel_costs.markets",
+    "switch_mod.export": "switch_mod.reporting",
+    "switch_mod.local_td": "switch_mod.transmission.local_td",
+    "switch_mod.balancing_areas": "switch_mod.balancing.operating_reserves.areas",
+    "switch_mod.export.dump": "switch_mod.reporting.dump",
+    "switch_mod.generators.hydro_simple": "switch_mod.generators.extensions.hydro_simple",
+    "switch_mod.generators.hydro_system": "switch_mod.generators.extensions.hydro_system",
+    "switch_mod.generators.storage": "switch_mod.generators.extensions.storage",
 }
-module_prefix = 'switch_mod.'
-expand_modules = { # Old module name: [new module names]
-    'switch_mod': [
-        '### begin core modules ###',
-        'switch_mod',
-        'switch_mod.timescales',
-        'switch_mod.financials',
-        'switch_mod.balancing.load_zones',
-        'switch_mod.energy_sources.properties',
-        'switch_mod.generators.core.build',
-        'switch_mod.generators.core.dispatch',
-        'switch_mod.reporting',
-        '### end core modules ###'
+module_prefix = "switch_mod."
+expand_modules = {  # Old module name: [new module names]
+    "switch_mod": [
+        "### begin core modules ###",
+        "switch_mod",
+        "switch_mod.timescales",
+        "switch_mod.financials",
+        "switch_mod.balancing.load_zones",
+        "switch_mod.energy_sources.properties",
+        "switch_mod.generators.core.build",
+        "switch_mod.generators.core.dispatch",
+        "switch_mod.reporting",
+        "### end core modules ###",
     ],
-    'switch_mod.project': [
-        'switch_mod.generators.core.build',
-        'switch_mod.generators.core.dispatch'
+    "switch_mod.project": [
+        "switch_mod.generators.core.build",
+        "switch_mod.generators.core.dispatch",
     ],
-    'switch_mod.project.unitcommit': [
-        'switch_mod.generators.core.commit.operate',
-        'switch_mod.generators.core.commit.fuel_use'
+    "switch_mod.project.unitcommit": [
+        "switch_mod.generators.core.commit.operate",
+        "switch_mod.generators.core.commit.fuel_use",
     ],
 }
 
@@ -163,19 +160,20 @@ def upgrade_input_dir(inputs_dir):
         path = os.path.join(inputs_dir, file_name)
         if optional_file and not os.path.isfile(path):
             return
-        df = pandas.read_csv(path, na_values=['.'], sep=r"\s+", index_col=False)
+        df = pandas.read_csv(path, na_values=["."], sep=r"\s+", index_col=False)
         df.rename(columns={old_col_name: new_col_name}, inplace=True)
-        df.to_csv(path, sep='\t', na_rep='.', index=False)
+        df.to_csv(path, sep="\t", na_rep=".", index=False)
 
-    rename_file('modules', 'modules.txt')
-    modules_path = os.path.join(inputs_dir, 'modules.txt')
+    rename_file("modules", "modules.txt")
+    modules_path = os.path.join(inputs_dir, "modules.txt")
     if not os.path.isfile(modules_path):
-        modules_path = os.path.join(inputs_dir, '..', 'modules.txt')
+        modules_path = os.path.join(inputs_dir, "..", "modules.txt")
     if not os.path.isfile(modules_path):
         raise RuntimeError(
             "Unable to find modules or modules.txt file for input directory '{}'. "
-            "This file should be located in the input directory or its parent."
-            .format(inputs_dir)
+            "This file should be located in the input directory or its parent.".format(
+                inputs_dir
+            )
         )
 
     ###
@@ -186,12 +184,14 @@ def upgrade_input_dir(inputs_dir):
 
     # If the original file didn't specify either switch_mod or the list of
     # core modules, we need to insert switch_mod.
-    if not('switch_mod' in module_list or
-           'timescales' in module_list or
-           'switch_mod.timescales' in module_list):
-        module_list.insert(0, 'switch_mod')
+    if not (
+        "switch_mod" in module_list
+        or "timescales" in module_list
+        or "switch_mod.timescales" in module_list
+    ):
+        module_list.insert(0, "switch_mod")
 
-    new_module_list=[]
+    new_module_list = []
     for module in module_list:
         # add prefix if appropriate
         # (standardizes names for further processing)
@@ -211,66 +211,73 @@ def upgrade_input_dir(inputs_dir):
         if module not in final_module_list:
             final_module_list.append(module)
 
-    with open(modules_path, 'w') as f:
-       for module in final_module_list:
+    with open(modules_path, "w") as f:
+        for module in final_module_list:
             f.write(module + "\n")
 
     ###
     # Get load zone economic multipliers (if available), then drop that column.
-    load_zone_path = os.path.join(inputs_dir, 'load_zones.tab')
-    load_zone_df = pandas.read_csv(load_zone_path, na_values=['.'], sep=r'\s+')
-    if 'lz_cost_multipliers' in load_zone_df:
-        load_zone_df['lz_cost_multipliers'].fillna(1)
+    load_zone_path = os.path.join(inputs_dir, "load_zones.tab")
+    load_zone_df = pandas.read_csv(load_zone_path, na_values=["."], sep=r"\s+")
+    if "lz_cost_multipliers" in load_zone_df:
+        load_zone_df["lz_cost_multipliers"].fillna(1)
     else:
-        load_zone_df['lz_cost_multipliers'] = 1
-    load_zone_keep_cols = [c for c in load_zone_df if c != 'lz_cost_multipliers']
-    load_zone_df.to_csv(load_zone_path, sep='\t', na_rep='.',
-                        index=False, columns=load_zone_keep_cols)
+        load_zone_df["lz_cost_multipliers"] = 1
+    load_zone_keep_cols = [c for c in load_zone_df if c != "lz_cost_multipliers"]
+    load_zone_df.to_csv(
+        load_zone_path, sep="\t", na_rep=".", index=False, columns=load_zone_keep_cols
+    )
 
     ###
     # Merge generator_info with project_info
-    gen_info_path = os.path.join(inputs_dir, 'generator_info.tab')
-    gen_info_df = pandas.read_csv(gen_info_path, na_values=['.'], sep=r'\s+')
+    gen_info_path = os.path.join(inputs_dir, "generator_info.tab")
+    gen_info_df = pandas.read_csv(gen_info_path, na_values=["."], sep=r"\s+")
     gen_info_col_renames = {
-        'generation_technology': 'proj_gen_tech',
-        'g_energy_source': 'proj_energy_source',
-        'g_max_age': 'proj_max_age',
-        'g_scheduled_outage_rate': 'proj_scheduled_outage_rate.default',
-        'g_forced_outage_rate': 'proj_forced_outage_rate.default',
-        'g_variable_o_m': 'proj_variable_om.default',
-        'g_full_load_heat_rate': 'proj_full_load_heat_rate.default',
-        'g_is_variable': 'proj_is_variable',
-        'g_is_baseload': 'proj_is_baseload',
-        'g_min_build_capacity': 'proj_min_build_capacity',
-        'g_is_cogen': 'proj_is_cogen',
-        'g_storage_efficiency': 'proj_storage_efficiency.default',
-        'g_store_to_release_ratio': 'proj_store_to_release_ratio.default',
-        'g_unit_size': 'proj_unit_size.default',
-        'g_min_load_fraction': 'proj_min_load_fraction.default',
-        'g_startup_fuel': 'proj_startup_fuel.default',
-        'g_startup_om': 'proj_startup_om.default',
-        'g_ccs_capture_efficiency': 'proj_ccs_capture_efficiency.default',
-        'g_ccs_energy_load': 'proj_ccs_energy_load.default'
+        "generation_technology": "proj_gen_tech",
+        "g_energy_source": "proj_energy_source",
+        "g_max_age": "proj_max_age",
+        "g_scheduled_outage_rate": "proj_scheduled_outage_rate.default",
+        "g_forced_outage_rate": "proj_forced_outage_rate.default",
+        "g_variable_o_m": "proj_variable_om.default",
+        "g_full_load_heat_rate": "proj_full_load_heat_rate.default",
+        "g_is_variable": "proj_is_variable",
+        "g_is_baseload": "proj_is_baseload",
+        "g_min_build_capacity": "proj_min_build_capacity",
+        "g_is_cogen": "proj_is_cogen",
+        "g_storage_efficiency": "proj_storage_efficiency.default",
+        "g_store_to_release_ratio": "proj_store_to_release_ratio.default",
+        "g_unit_size": "proj_unit_size.default",
+        "g_min_load_fraction": "proj_min_load_fraction.default",
+        "g_startup_fuel": "proj_startup_fuel.default",
+        "g_startup_om": "proj_startup_om.default",
+        "g_ccs_capture_efficiency": "proj_ccs_capture_efficiency.default",
+        "g_ccs_energy_load": "proj_ccs_energy_load.default",
     }
     drop_cols = [c for c in gen_info_df if c not in gen_info_col_renames]
     for c in drop_cols:
         del gen_info_df[c]
     gen_info_df.rename(columns=gen_info_col_renames, inplace=True)
-    proj_info_path = os.path.join(inputs_dir, 'project_info.tab')
-    proj_info_df = pandas.read_csv(proj_info_path, na_values=['.'], sep=r'\s+')
-    proj_info_df = pandas.merge(proj_info_df, gen_info_df, on='proj_gen_tech', how='left')
+    proj_info_path = os.path.join(inputs_dir, "project_info.tab")
+    proj_info_df = pandas.read_csv(proj_info_path, na_values=["."], sep=r"\s+")
+    proj_info_df = pandas.merge(
+        proj_info_df, gen_info_df, on="proj_gen_tech", how="left"
+    )
     # Factor in the load zone cost multipliers
     proj_info_df = pandas.merge(
-        load_zone_df[['LOAD_ZONE', 'lz_cost_multipliers']], proj_info_df,
-        left_on='LOAD_ZONE', right_on='proj_load_zone', how='right')
-    proj_info_df['proj_variable_om.default'] *= proj_info_df['lz_cost_multipliers']
-    for c in ['LOAD_ZONE', 'lz_cost_multipliers']:
+        load_zone_df[["LOAD_ZONE", "lz_cost_multipliers"]],
+        proj_info_df,
+        left_on="LOAD_ZONE",
+        right_on="proj_load_zone",
+        how="right",
+    )
+    proj_info_df["proj_variable_om.default"] *= proj_info_df["lz_cost_multipliers"]
+    for c in ["LOAD_ZONE", "lz_cost_multipliers"]:
         del proj_info_df[c]
 
     # An internal function to apply a column of default values to the actual column
     def update_cols_with_defaults(df, col_list):
         for col in col_list:
-            default_col = col + '.default'
+            default_col = col + ".default"
             if default_col not in df:
                 continue
             if col not in df:
@@ -279,151 +286,191 @@ def upgrade_input_dir(inputs_dir):
                 df[col].fillna(df[default_col], inplace=True)
                 del df[default_col]
 
-    columns_with_defaults = ['proj_scheduled_outage_rate', 'proj_forced_outage_rate',
-                             'proj_variable_om', 'proj_full_load_heat_rate',
-                             'proj_storage_efficiency', 'proj_store_to_release_ratio',
-                             'proj_unit_size', 'proj_min_load_fraction',
-                             'proj_startup_fuel', 'proj_startup_om',
-                             'proj_ccs_capture_efficiency', 'proj_ccs_energy_load']
+    columns_with_defaults = [
+        "proj_scheduled_outage_rate",
+        "proj_forced_outage_rate",
+        "proj_variable_om",
+        "proj_full_load_heat_rate",
+        "proj_storage_efficiency",
+        "proj_store_to_release_ratio",
+        "proj_unit_size",
+        "proj_min_load_fraction",
+        "proj_startup_fuel",
+        "proj_startup_om",
+        "proj_ccs_capture_efficiency",
+        "proj_ccs_energy_load",
+    ]
     update_cols_with_defaults(proj_info_df, columns_with_defaults)
-    proj_info_df.to_csv(proj_info_path, sep='\t', na_rep='.', index=False)
+    proj_info_df.to_csv(proj_info_path, sep="\t", na_rep=".", index=False)
     os.remove(gen_info_path)
 
     ###
     # Merge gen_new_build_costs into proj_build_costs
 
     # Translate default generator costs into costs for each project
-    gen_build_path = os.path.join(inputs_dir, 'gen_new_build_costs.tab')
+    gen_build_path = os.path.join(inputs_dir, "gen_new_build_costs.tab")
     if os.path.isfile(gen_build_path):
-        gen_build_df = pandas.read_csv(gen_build_path, na_values=['.'], sep=r'\s+')
+        gen_build_df = pandas.read_csv(gen_build_path, na_values=["."], sep=r"\s+")
         new_col_names = {
-            'generation_technology': 'proj_gen_tech',
-            'investment_period': 'build_year',
-            'g_overnight_cost': 'proj_overnight_cost.default',
-            'g_storage_energy_overnight_cost': 'proj_storage_energy_overnight_cost.default',
-            'g_fixed_o_m': 'proj_fixed_om.default'}
+            "generation_technology": "proj_gen_tech",
+            "investment_period": "build_year",
+            "g_overnight_cost": "proj_overnight_cost.default",
+            "g_storage_energy_overnight_cost": "proj_storage_energy_overnight_cost.default",
+            "g_fixed_o_m": "proj_fixed_om.default",
+        }
         gen_build_df.rename(columns=new_col_names, inplace=True)
         new_g_builds = pandas.merge(
-            gen_build_df, proj_info_df[['PROJECT', 'proj_gen_tech', 'proj_load_zone']],
-            on='proj_gen_tech')
+            gen_build_df,
+            proj_info_df[["PROJECT", "proj_gen_tech", "proj_load_zone"]],
+            on="proj_gen_tech",
+        )
         # Factor in the load zone cost multipliers
         new_g_builds = pandas.merge(
-            load_zone_df[['LOAD_ZONE', 'lz_cost_multipliers']], new_g_builds,
-            left_on='LOAD_ZONE', right_on='proj_load_zone', how='right')
-        new_g_builds['proj_overnight_cost.default'] *= new_g_builds['lz_cost_multipliers']
-        new_g_builds['proj_fixed_om.default'] *= new_g_builds['lz_cost_multipliers']
+            load_zone_df[["LOAD_ZONE", "lz_cost_multipliers"]],
+            new_g_builds,
+            left_on="LOAD_ZONE",
+            right_on="proj_load_zone",
+            how="right",
+        )
+        new_g_builds["proj_overnight_cost.default"] *= new_g_builds[
+            "lz_cost_multipliers"
+        ]
+        new_g_builds["proj_fixed_om.default"] *= new_g_builds["lz_cost_multipliers"]
         # Clean up
-        for drop_col in ['LOAD_ZONE', 'proj_gen_tech', 'proj_load_zone',
-                         'lz_cost_multipliers']:
+        for drop_col in [
+            "LOAD_ZONE",
+            "proj_gen_tech",
+            "proj_load_zone",
+            "lz_cost_multipliers",
+        ]:
             del new_g_builds[drop_col]
 
         # Merge the expanded gen_new_build_costs data into proj_build_costs
-        project_build_path = os.path.join(inputs_dir, 'proj_build_costs.tab')
+        project_build_path = os.path.join(inputs_dir, "proj_build_costs.tab")
         if os.path.isfile(project_build_path):
-            project_build_df = pandas.read_csv(project_build_path, na_values=['.'], sep=r'\s+')
-            project_build_df = pandas.merge(project_build_df, new_g_builds,
-                                             on=['PROJECT', 'build_year'], how='outer')
+            project_build_df = pandas.read_csv(
+                project_build_path, na_values=["."], sep=r"\s+"
+            )
+            project_build_df = pandas.merge(
+                project_build_df,
+                new_g_builds,
+                on=["PROJECT", "build_year"],
+                how="outer",
+            )
         else:
             # Make sure the order of the columns is ok since merge won't ensuring that.
-            idx_cols = ['PROJECT', 'build_year']
+            idx_cols = ["PROJECT", "build_year"]
             dat_cols = [c for c in new_g_builds if c not in idx_cols]
             col_order = idx_cols + dat_cols
             project_build_df = new_g_builds[col_order]
-        columns_with_defaults = ['proj_overnight_cost', 'proj_fixed_om',
-                                 'proj_storage_energy_overnight_cost']
+        columns_with_defaults = [
+            "proj_overnight_cost",
+            "proj_fixed_om",
+            "proj_storage_energy_overnight_cost",
+        ]
         update_cols_with_defaults(project_build_df, columns_with_defaults)
-        project_build_df.to_csv(project_build_path, sep='\t', na_rep='.', index=False)
+        project_build_df.to_csv(project_build_path, sep="\t", na_rep=".", index=False)
         os.remove(gen_build_path)
 
     # Merge gen_inc_heat_rates.tab into proj_inc_heat_rates.tab
-    g_hr_path = os.path.join(inputs_dir, 'gen_inc_heat_rates.tab')
+    g_hr_path = os.path.join(inputs_dir, "gen_inc_heat_rates.tab")
     if os.path.isfile(g_hr_path):
-        g_hr_df = pandas.read_csv(g_hr_path, na_values=['.'], sep=r'\s+')
-        proj_hr_default = pandas.merge(g_hr_df, proj_info_df[['PROJECT', 'proj_gen_tech']],
-                                       left_on='generation_technology',
-                                       right_on='proj_gen_tech')
+        g_hr_df = pandas.read_csv(g_hr_path, na_values=["."], sep=r"\s+")
+        proj_hr_default = pandas.merge(
+            g_hr_df,
+            proj_info_df[["PROJECT", "proj_gen_tech"]],
+            left_on="generation_technology",
+            right_on="proj_gen_tech",
+        )
         col_renames = {
-            'PROJECT': 'project',
-            'power_start_mw': 'power_start_mw.default',
-            'power_end_mw': 'power_end_mw.default',
-            'incremental_heat_rate_mbtu_per_mwhr': 'incremental_heat_rate_mbtu_per_mwhr.default',
-            'fuel_use_rate_mmbtu_per_h': 'fuel_use_rate_mmbtu_per_h.default'
+            "PROJECT": "project",
+            "power_start_mw": "power_start_mw.default",
+            "power_end_mw": "power_end_mw.default",
+            "incremental_heat_rate_mbtu_per_mwhr": "incremental_heat_rate_mbtu_per_mwhr.default",
+            "fuel_use_rate_mmbtu_per_h": "fuel_use_rate_mmbtu_per_h.default",
         }
         proj_hr_default.rename(columns=col_renames, inplace=True)
-        proj_hr_path = os.path.join(inputs_dir, 'proj_inc_heat_rates.tab')
+        proj_hr_path = os.path.join(inputs_dir, "proj_inc_heat_rates.tab")
         if os.path.isfile(proj_hr_path):
-            proj_hr_df = pandas.read_csv(proj_hr_path, na_values=['.'], sep=r'\s+')
-            proj_hr_df = pandas.merge(proj_hr_df, proj_hr_default, on='proj_gen_tech', how='left')
+            proj_hr_df = pandas.read_csv(proj_hr_path, na_values=["."], sep=r"\s+")
+            proj_hr_df = pandas.merge(
+                proj_hr_df, proj_hr_default, on="proj_gen_tech", how="left"
+            )
         else:
             proj_hr_df = proj_hr_default
-        columns_with_defaults = ['power_start_mw', 'power_end_mw',
-                                 'incremental_heat_rate_mbtu_per_mwhr',
-                                 'fuel_use_rate_mmbtu_per_h']
+        columns_with_defaults = [
+            "power_start_mw",
+            "power_end_mw",
+            "incremental_heat_rate_mbtu_per_mwhr",
+            "fuel_use_rate_mmbtu_per_h",
+        ]
         update_cols_with_defaults(proj_hr_df, columns_with_defaults)
-        cols = ['project', 'power_start_mw', 'power_end_mw',
-                'incremental_heat_rate_mbtu_per_mwhr', 'fuel_use_rate_mmbtu_per_h']
-        proj_hr_df.to_csv(proj_hr_path, sep='\t', na_rep='.', index=False, columns=cols)
+        cols = [
+            "project",
+            "power_start_mw",
+            "power_end_mw",
+            "incremental_heat_rate_mbtu_per_mwhr",
+            "fuel_use_rate_mmbtu_per_h",
+        ]
+        proj_hr_df.to_csv(proj_hr_path, sep="\t", na_rep=".", index=False, columns=cols)
         os.remove(g_hr_path)
 
     # Done with restructuring. Now apply component renaming.
 
     old_new_file_names = {
-        'proj_existing_builds.tab':'gen_build_predetermined.tab',
-        'project_info.tab':'generation_projects_info.tab',
-        'proj_build_costs.tab':'gen_build_costs.tab',
-        'proj_inc_heat_rates.tab':'gen_inc_heat_rates.tab',
-        'hydro_projects.tab':'hydro_generation_projects.tab',
-        'lz_peak_loads.tab':'zone_coincident_peak_demand.tab',
-        'lz_to_regional_fuel_market.tab':'zone_to_regional_fuel_market.tab'
+        "proj_existing_builds.tab": "gen_build_predetermined.tab",
+        "project_info.tab": "generation_projects_info.tab",
+        "proj_build_costs.tab": "gen_build_costs.tab",
+        "proj_inc_heat_rates.tab": "gen_inc_heat_rates.tab",
+        "hydro_projects.tab": "hydro_generation_projects.tab",
+        "lz_peak_loads.tab": "zone_coincident_peak_demand.tab",
+        "lz_to_regional_fuel_market.tab": "zone_to_regional_fuel_market.tab",
     }
 
     for old, new in old_new_file_names.items():
         rename_file(old, new)
 
     old_new_column_names_in_file = {
-        'gen_build_predetermined.tab':[
-        ('proj_existing_cap','gen_predetermined_cap')
+        "gen_build_predetermined.tab": [("proj_existing_cap", "gen_predetermined_cap")],
+        "gen_build_costs.tab": [
+            ("proj_overnight_cost", "gen_overnight_cost"),
+            ("proj_fixed_om", "gen_fixed_om"),
+            ("proj_storage_energy_overnight_cost", "gen_storage_energy_overnight_cost"),
         ],
-        'gen_build_costs.tab':[
-        ('proj_overnight_cost','gen_overnight_cost'),
-        ('proj_fixed_om','gen_fixed_om'),
-        ('proj_storage_energy_overnight_cost','gen_storage_energy_overnight_cost')
+        "generation_projects_info.tab": [
+            ("proj_dbid", "gen_dbid"),
+            ("proj_gen_tech", "gen_tech"),
+            ("proj_load_zone", "gen_load_zone"),
+            ("proj_connect_cost_per_mw", "gen_connect_cost_per_mw"),
+            ("proj_capacity_limit_mw", "gen_capacity_limit_mw"),
+            ("proj_variable_om", "gen_variable_om"),
+            ("proj_max_age", "gen_max_age"),
+            ("proj_min_build_capacity", "gen_min_build_capacity"),
+            ("proj_scheduled_outage_rate", "gen_scheduled_outage_rate"),
+            ("proj_forced_outage_rate", "gen_forced_outage_rate"),
+            ("proj_is_variable", "gen_is_variable"),
+            ("proj_is_baseload", "gen_is_baseload"),
+            ("proj_is_cogen", "gen_is_cogen"),
+            ("proj_energy_source", "gen_energy_source"),
+            ("proj_full_load_heat_rate", "gen_full_load_heat_rate"),
+            ("proj_storage_efficiency", "gen_storage_efficiency"),
+            ("proj_min_load_fraction", "gen_min_load_fraction"),
+            ("proj_startup_fuel", "gen_startup_fuel"),
+            ("proj_startup_om", "gen_startup_om"),
+            ("proj_min_uptime", "gen_min_uptime"),
+            ("proj_min_downtime", "gen_min_downtime"),
+            ("proj_min_commit_fraction", "gen_min_commit_fraction"),
+            ("proj_max_commit_fraction", "gen_max_commit_fraction"),
+            ("proj_min_load_fraction_TP", "gen_min_load_fraction_TP"),
+            ("proj_unit_size", "gen_unit_size"),
         ],
-        'generation_projects_info.tab':[
-        ('proj_dbid','gen_dbid'),('proj_gen_tech','gen_tech'),
-        ('proj_load_zone','gen_load_zone'),
-        ('proj_connect_cost_per_mw','gen_connect_cost_per_mw'),
-        ('proj_capacity_limit_mw','gen_capacity_limit_mw'),
-        ('proj_variable_om','gen_variable_om'),
-        ('proj_max_age','gen_max_age'),
-        ('proj_min_build_capacity','gen_min_build_capacity'),
-        ('proj_scheduled_outage_rate','gen_scheduled_outage_rate'),
-        ('proj_forced_outage_rate','gen_forced_outage_rate'),
-        ('proj_is_variable','gen_is_variable'),
-        ('proj_is_baseload','gen_is_baseload'),
-        ('proj_is_cogen','gen_is_cogen'),
-        ('proj_energy_source','gen_energy_source'),
-        ('proj_full_load_heat_rate','gen_full_load_heat_rate'),
-        ('proj_storage_efficiency','gen_storage_efficiency'),
-        ('proj_min_load_fraction','gen_min_load_fraction'),
-        ('proj_startup_fuel','gen_startup_fuel'),
-        ('proj_startup_om','gen_startup_om'),
-        ('proj_min_uptime','gen_min_uptime'),
-        ('proj_min_downtime','gen_min_downtime'),
-        ('proj_min_commit_fraction','gen_min_commit_fraction'),
-        ('proj_max_commit_fraction','gen_max_commit_fraction'),
-        ('proj_min_load_fraction_TP','gen_min_load_fraction_TP'),
-        ('proj_unit_size','gen_unit_size')
+        "loads.tab": [("lz_demand_mw", "zone_demand_mw")],
+        "zone_coincident_peak_demand.tab": [
+            ("peak_demand_mw", "zone_expected_coincident_peak_demand")
         ],
-        'loads.tab':[
-        ('lz_demand_mw','zone_demand_mw')
+        "variable_capacity_factors.tab": [
+            ("proj_max_capacity_factor", "gen_max_capacity_factor")
         ],
-        'zone_coincident_peak_demand.tab':[
-        ('peak_demand_mw','zone_expected_coincident_peak_demand')
-        ],
-        'variable_capacity_factors.tab':[
-        ('proj_max_capacity_factor','gen_max_capacity_factor')
-        ]
     }
 
     for fname, old_new_pairs in old_new_column_names_in_file.items():

--- a/switch_model/upgrade/upgrade_2_0_0b2.py
+++ b/switch_model/upgrade/upgrade_2_0_0b2.py
@@ -11,8 +11,9 @@ Changes are:
 import os
 import switch_model.upgrade
 
-upgrades_from = '2.0.0b1'
-upgrades_to = '2.0.0b2'
+upgrades_from = "2.0.0b1"
+upgrades_to = "2.0.0b2"
+
 
 def upgrade_input_dir(inputs_dir):
     """
@@ -21,14 +22,15 @@ def upgrade_input_dir(inputs_dir):
     """
     # Find modules.txt; it should be either in the inputs directory or in its
     # parent directory.
-    modules_path = os.path.join(inputs_dir, 'modules.txt')
+    modules_path = os.path.join(inputs_dir, "modules.txt")
     if not os.path.isfile(modules_path):
-        modules_path = os.path.join(inputs_dir, '..', 'modules.txt')
+        modules_path = os.path.join(inputs_dir, "..", "modules.txt")
     if not os.path.isfile(modules_path):
         raise RuntimeError(
             "Unable to find modules or modules.txt file for input directory '{}'. "
-            "This file should be located in the input directory or its parent."
-            .format(inputs_dir)
+            "This file should be located in the input directory or its parent.".format(
+                inputs_dir
+            )
         )
 
     # Replace switch_mod with switch_model in modules.txt
@@ -41,13 +43,14 @@ def upgrade_input_dir(inputs_dir):
     with open(modules_path) as f:
         module_list = [line.strip() for line in f.read().splitlines()]
         final_module_list = [
-            'switch_model' + line[10:] if line.startswith('switch_mod.') or line == 'switch_mod'
+            "switch_model" + line[10:]
+            if line.startswith("switch_mod.") or line == "switch_mod"
             else line
             for line in module_list
         ]
 
-    with open(modules_path, 'w') as f:
-       for module in final_module_list:
+    with open(modules_path, "w") as f:
+        for module in final_module_list:
             f.write(module + "\n")
 
     # Write a new version text file.

--- a/switch_model/upgrade/upgrade_2_0_0b4.py
+++ b/switch_model/upgrade/upgrade_2_0_0b4.py
@@ -11,8 +11,9 @@ import os, shutil, argparse
 import pandas
 import switch_model.upgrade
 
-upgrades_from = '2.0.0b2'
-upgrades_to = '2.0.0b4'
+upgrades_from = "2.0.0b2"
+upgrades_to = "2.0.0b4"
+
 
 def upgrade_input_dir(inputs_dir):
     """
@@ -30,12 +31,12 @@ def upgrade_input_dir(inputs_dir):
         path = os.path.join(inputs_dir, file_name)
         if optional_file and not os.path.isfile(path):
             return
-        df = pandas.read_csv(path, na_values=['.'], sep=r"\s+", index_col=False)
+        df = pandas.read_csv(path, na_values=["."], sep=r"\s+", index_col=False)
         df.rename(columns={old_col_name: new_col_name}, inplace=True)
-        df.to_csv(path, sep='\t', na_rep='.', index=False)
+        df.to_csv(path, sep="\t", na_rep=".", index=False)
 
     old_new_column_names_in_file = {
-        'gen_inc_heat_rates.tab': [('project', 'GENERATION_PROJECT')]
+        "gen_inc_heat_rates.tab": [("project", "GENERATION_PROJECT")]
     }
 
     for fname, old_new_pairs in old_new_column_names_in_file.items():
@@ -43,14 +44,16 @@ def upgrade_input_dir(inputs_dir):
             rename_column(fname, old_col_name=old, new_col_name=new)
 
     # merge trans_optional_params.tab with transmission_lines.tab
-    trans_lines_path = os.path.join(inputs_dir, 'transmission_lines.tab')
-    trans_opt_path = os.path.join(inputs_dir, 'trans_optional_params.tab')
+    trans_lines_path = os.path.join(inputs_dir, "transmission_lines.tab")
+    trans_opt_path = os.path.join(inputs_dir, "trans_optional_params.tab")
     if os.path.isfile(trans_lines_path) and os.path.isfile(trans_lines_path):
-        trans_lines = pandas.read_csv(trans_lines_path, na_values=['.'], sep=r'\s+')
+        trans_lines = pandas.read_csv(trans_lines_path, na_values=["."], sep=r"\s+")
         if os.path.isfile(trans_opt_path):
-            trans_opt = pandas.read_csv(trans_opt_path, na_values=['.'], sep=r'\s+')
-            trans_lines = trans_lines.merge(trans_opt, on='TRANSMISSION_LINE', how='left')
-        trans_lines.to_csv(trans_lines_path, sep='\t', na_rep='.', index=False)
+            trans_opt = pandas.read_csv(trans_opt_path, na_values=["."], sep=r"\s+")
+            trans_lines = trans_lines.merge(
+                trans_opt, on="TRANSMISSION_LINE", how="left"
+            )
+        trans_lines.to_csv(trans_lines_path, sep="\t", na_rep=".", index=False)
         if os.path.isfile(trans_opt_path):
             os.remove(trans_opt_path)
 

--- a/switch_model/upgrade/upgrade_2_0_1.py
+++ b/switch_model/upgrade/upgrade_2_0_1.py
@@ -11,36 +11,36 @@ import os, shutil, argparse
 import pandas
 import switch_model.upgrade
 
-upgrades_from = '2.0.0b4'
-upgrades_to = '2.0.1'
+upgrades_from = "2.0.0b4"
+upgrades_to = "2.0.1"
 
 # note: we could keep switch_model.hawaii.reserves active, but then we would need special code to switch
 # the model to the main reserves module if and only if they are using the iterative demand response system
 # which seems unnecessarily complicated
 replace_modules = {
-    'switch_model.hawaii.demand_response':
-        ['switch_model.balancing.demand_response.iterative'],
-    'switch_model.hawaii.r_demand_system':
-        ['switch_model.balancing.demand_response.iterative.r_demand_system'],
-    'switch_model.hawaii.reserves': [
-        'switch_model.balancing.operating_reserves.areas',
-        'switch_model.balancing.operating_reserves.spinning_reserves',
-    ]
+    "switch_model.hawaii.demand_response": [
+        "switch_model.balancing.demand_response.iterative"
+    ],
+    "switch_model.hawaii.r_demand_system": [
+        "switch_model.balancing.demand_response.iterative.r_demand_system"
+    ],
+    "switch_model.hawaii.reserves": [
+        "switch_model.balancing.operating_reserves.areas",
+        "switch_model.balancing.operating_reserves.spinning_reserves",
+    ],
 }
 module_messages = {
     # description of significant changes to particular modules (other than moving)
     # old_module: message
-    'switch_model.hawaii.r_demand_system':
-        'The switch_model.hawaii.r_demand_system module has been moved. Please update '
-        'the --dr-demand-module flag to point to the new location.',
-    'switch_model.hawaii.demand_response':
-        'The switch_model.hawaii.demand_response module has been moved. Please update '
-        'iterate.txt to refer to the new location.',
-    'switch_model.hawaii.switch_patch':
-        'The switch_model.hawaii.switch_patch module no longer patches '
-        'the cplex solver to generate dual values for mixed-integer programs. '
-        'Use the new --retrieve-cplex-mip-duals flag if you need this behavior.'
+    "switch_model.hawaii.r_demand_system": "The switch_model.hawaii.r_demand_system module has been moved. Please update "
+    "the --dr-demand-module flag to point to the new location.",
+    "switch_model.hawaii.demand_response": "The switch_model.hawaii.demand_response module has been moved. Please update "
+    "iterate.txt to refer to the new location.",
+    "switch_model.hawaii.switch_patch": "The switch_model.hawaii.switch_patch module no longer patches "
+    "the cplex solver to generate dual values for mixed-integer programs. "
+    "Use the new --retrieve-cplex-mip-duals flag if you need this behavior.",
 }
+
 
 def upgrade_input_dir(inputs_dir):
     """
@@ -60,32 +60,36 @@ def rename_file(old_name, new_name, optional_file=True):
         return
     shutil.move(old_path, new_path)
 
+
 def rename_column(file_name, old_col_name, new_col_name, optional_file=True):
     path = os.path.join(inputs_dir, file_name)
     if optional_file and not os.path.isfile(path):
         return
-    df = pandas.read_csv(path, na_values=['.'], sep=r"\s+", index_col=False)
+    df = pandas.read_csv(path, na_values=["."], sep=r"\s+", index_col=False)
     df.rename(columns={old_col_name: new_col_name}, inplace=True)
-    df.to_csv(path, sep='\t', na_rep='.', index=False)
+    df.to_csv(path, sep="\t", na_rep=".", index=False)
+
 
 def item_list(items):
     """Generate normal-text version of list of items, with commas and "and" as needed."""
-    return ' and '.join(', '.join(items).rsplit(', ', 1))
+    return " and ".join(", ".join(items).rsplit(", ", 1))
+
 
 def update_modules(inputs_dir):
     """Rename modules in the module list if needed (list is sought in
     standard locations) and return list of alerts for user."""
 
-    modules_path = os.path.join(inputs_dir, 'modules.txt')
+    modules_path = os.path.join(inputs_dir, "modules.txt")
     if not os.path.isfile(modules_path):
-        modules_path = os.path.join(inputs_dir, '..', 'modules.txt')
+        modules_path = os.path.join(inputs_dir, "..", "modules.txt")
     if not os.path.isfile(modules_path):
         raise RuntimeError(
             "Unable to find modules or modules.txt file for input directory '{}'. "
-            "This file should be located in the input directory or its parent."
-            .format(inputs_dir)
+            "This file should be located in the input directory or its parent.".format(
+                inputs_dir
+            )
         )
-    modules_path = os.path.normpath(modules_path) # tidy up for display later
+    modules_path = os.path.normpath(modules_path)  # tidy up for display later
 
     # Upgrade module listings
     # Each line of the original file is either a module identifier or a comment
@@ -93,13 +97,14 @@ def update_modules(inputs_dir):
         old_module_list = [line.strip() for line in f.read().splitlines()]
 
     # rename modules as needed
-    new_module_list=[]
+    new_module_list = []
     for module in old_module_list:
         try:
             new_modules = replace_modules[module]
-            print (
-                "Module {old} has been replaced by {new} in {file}."
-                .format(old=module, new=item_list(new_modules), file=modules_path)
+            print(
+                "Module {old} has been replaced by {new} in {file}.".format(
+                    old=module, new=item_list(new_modules), file=modules_path
+                )
             )
         except KeyError:
             new_modules = [module]
@@ -112,10 +117,10 @@ def update_modules(inputs_dir):
     # components defined by other modules, but
     # switch_model.balancing.operating_reserves.spinning_reserves should
     # load early so other modules can register reserves with it.
-    if 'switch_model.hawaii.reserves' in old_module_list:
-        new_spin = 'switch_model.balancing.operating_reserves.areas'
+    if "switch_model.hawaii.reserves" in old_module_list:
+        new_spin = "switch_model.balancing.operating_reserves.areas"
         try:
-            insert_pos = new_module_list.index('switch_model.balancing.load_zones') + 1
+            insert_pos = new_module_list.index("switch_model.balancing.load_zones") + 1
             if insert_pos < new_module_list.index(new_spin):
                 new_module_list.remove(new_spin)
                 new_module_list.insert(insert_pos, new_spin)
@@ -126,17 +131,16 @@ def update_modules(inputs_dir):
                 # )
         except ValueError:
             # couldn't find the location to insert spinning reserves module
-            print (
-                '{} module should be moved early in the module list, '
-                'before any modules that define reserve elements.'
-                .format(new_spin)
+            print(
+                "{} module should be moved early in the module list, "
+                "before any modules that define reserve elements.".format(new_spin)
             )
 
-    #import pdb; pdb.set_trace()
+    # import pdb; pdb.set_trace()
 
     # write new modules list
-    with open(modules_path, 'w') as f:
-       for module in new_module_list:
+    with open(modules_path, "w") as f:
+        for module in new_module_list:
             f.write(module + "\n")
 
     # report any significant changes in the previously active modules

--- a/switch_model/upgrade/upgrade_2_0_4.py
+++ b/switch_model/upgrade/upgrade_2_0_4.py
@@ -11,8 +11,8 @@ import os, shutil, argparse
 import pandas
 import switch_model.upgrade
 
-upgrades_from = '2.0.1'
-upgrades_to = '2.0.4'
+upgrades_from = "2.0.1"
+upgrades_to = "2.0.4"
 
 replace_modules = {
     # no renames in this version
@@ -21,25 +21,22 @@ replace_modules = {
 module_messages = {
     # description of significant changes to particular modules (other than moving)
     # old_module: message
-    'switch_model.transmission.local_td':
-        'Switch 2.0.4 makes two changes to the local_td module. '
-        '1. The carrying cost of pre-existing local transmission and '
-        'distribution is now included in the total system costs. '
-        '2. The legacy transmission is no longer reported in the '
-        'BuildLocalTD.tab output file.',
-    'switch_model.reporting':
-        'Output files (*.tab) now use native line endings instead of '
-        'always using Unix-style line endings. On Windows systems, these '
-        'files will now use "\\r\\n" instead of "\\n".',
-    'switch_model.reporting.basic_exports':
-        'Output files (*.csv) now use native line endings instead of '
-        'always using Unix-style line endings. On Windows systems, these '
-        'files will now use "\\r\\n" instead of "\\n".',
-    'switch_model.hawaii.save_results':
-        'Output files (*.tsv) now use native line endings instead of '
-        'always using Unix-style line endings. On Windows systems, these '
-        'files will now use "\\r\\n" instead of "\\n".',
+    "switch_model.transmission.local_td": "Switch 2.0.4 makes two changes to the local_td module. "
+    "1. The carrying cost of pre-existing local transmission and "
+    "distribution is now included in the total system costs. "
+    "2. The legacy transmission is no longer reported in the "
+    "BuildLocalTD.tab output file.",
+    "switch_model.reporting": "Output files (*.tab) now use native line endings instead of "
+    "always using Unix-style line endings. On Windows systems, these "
+    'files will now use "\\r\\n" instead of "\\n".',
+    "switch_model.reporting.basic_exports": "Output files (*.csv) now use native line endings instead of "
+    "always using Unix-style line endings. On Windows systems, these "
+    'files will now use "\\r\\n" instead of "\\n".',
+    "switch_model.hawaii.save_results": "Output files (*.tsv) now use native line endings instead of "
+    "always using Unix-style line endings. On Windows systems, these "
+    'files will now use "\\r\\n" instead of "\\n".',
 }
+
 
 def upgrade_input_dir(inputs_dir):
     """
@@ -59,35 +56,37 @@ def rename_file(old_name, new_name, optional_file=True):
         return
     shutil.move(old_path, new_path)
 
+
 def rename_column(file_name, old_col_name, new_col_name, optional_file=True):
     path = os.path.join(inputs_dir, file_name)
     if optional_file and not os.path.isfile(path):
         return
-    df = pandas.read_csv(path, na_values=['.'], sep=r"\s+", index_col=False)
+    df = pandas.read_csv(path, na_values=["."], sep=r"\s+", index_col=False)
     df.rename(columns={old_col_name: new_col_name}, inplace=True)
-    df.to_csv(path, sep='\t', na_rep='.', index=False)
+    df.to_csv(path, sep="\t", na_rep=".", index=False)
+
 
 def item_list(items):
     """Generate normal-text version of list of items, with commas and "and" as needed."""
-    return ' and '.join(', '.join(items).rsplit(', ', 1))
+    return " and ".join(", ".join(items).rsplit(", ", 1))
+
 
 def update_modules(inputs_dir):
     """Rename modules in the module list if needed (list is sought in
     standard locations) and return list of alerts for user."""
 
-    modules_path = os.path.join(inputs_dir, 'modules.txt')
+    modules_path = os.path.join(inputs_dir, "modules.txt")
     if not os.path.isfile(modules_path):
-        modules_path = os.path.join(inputs_dir, '..', 'modules.txt')
+        modules_path = os.path.join(inputs_dir, "..", "modules.txt")
     if not os.path.isfile(modules_path):
-        modules_path = 'modules.txt'
+        modules_path = "modules.txt"
     if not os.path.isfile(modules_path):
         raise RuntimeError(
             "Unable to find modules or modules.txt file for input directory '{}'. "
             "This file should be located in the input directory, its parent, or "
-            "the current working directory."
-            .format(inputs_dir)
+            "the current working directory.".format(inputs_dir)
         )
-    modules_path = os.path.normpath(modules_path) # tidy up for display later
+    modules_path = os.path.normpath(modules_path)  # tidy up for display later
 
     # Upgrade module listings
     # Each line of the original file is either a module identifier or a comment
@@ -95,13 +94,14 @@ def update_modules(inputs_dir):
         old_module_list = [line.strip() for line in f.read().splitlines()]
 
     # rename modules as needed
-    new_module_list=[]
+    new_module_list = []
     for module in old_module_list:
         try:
             new_modules = replace_modules[module]
             switch_model.upgrade.print_verbose(
-                "Module {old} has been replaced by {new} in {file}."
-                .format(old=module, new=item_list(new_modules), file=modules_path)
+                "Module {old} has been replaced by {new} in {file}.".format(
+                    old=module, new=item_list(new_modules), file=modules_path
+                )
             )
         except KeyError:
             new_modules = [module]
@@ -109,8 +109,8 @@ def update_modules(inputs_dir):
 
     if new_module_list != old_module_list:
         # write new modules list
-        with open(modules_path, 'w') as f:
-           for module in new_module_list:
+        with open(modules_path, "w") as f:
+            for module in new_module_list:
                 f.write(module + "\n")
 
     # report any significant changes in the previously active modules

--- a/switch_model/upgrade/upgrade_2_0_5.py
+++ b/switch_model/upgrade/upgrade_2_0_5.py
@@ -13,8 +13,8 @@ import switch_model.upgrade
 from pyomo.environ import DataPortal
 
 
-upgrades_from = '2.0.4'
-upgrades_to = '2.0.5'
+upgrades_from = "2.0.4"
+upgrades_to = "2.0.5"
 
 replace_modules = {
     # no renames in this version
@@ -23,10 +23,10 @@ replace_modules = {
 module_messages = {
     # description of significant changes to particular modules (other than moving)
     # old_module: message
-    'switch_model':
-        'Beginning with Switch 2.0.5, all inputs must be in .csv files and all '
-        'outputs will be written to .csv files.',
+    "switch_model": "Beginning with Switch 2.0.5, all inputs must be in .csv files and all "
+    "outputs will be written to .csv files.",
 }
+
 
 def upgrade_input_dir(inputs_dir):
     """
@@ -40,19 +40,24 @@ def upgrade_input_dir(inputs_dir):
 
     # Convert all .tab input files to .csv (maybe it should
     # work with a list of specific files instead?)
-    for old_path in glob.glob(os.path.join(inputs_dir, '*.tab')):
-        new_path = old_path[:-4] + '.csv'
+    for old_path in glob.glob(os.path.join(inputs_dir, "*.tab")):
+        new_path = old_path[:-4] + ".csv"
         convert_tab_to_csv(old_path, new_path)
     # Convert certain .tab input files to .csv
     # These are all simple ampl/pyomo files with only un-indexed parameters
     for f in [
-            'financials.dat', 'trans_params.dat', 'spillage_penalty.dat',
-            'spinning_reserve_params.dat', 'lost_load_cost.dat', 'hydrogen.dat'
-        ]:
+        "financials.dat",
+        "trans_params.dat",
+        "spillage_penalty.dat",
+        "spinning_reserve_params.dat",
+        "lost_load_cost.dat",
+        "hydrogen.dat",
+    ]:
         old_path = os.path.join(inputs_dir, f)
-        new_path = old_path[:-4] + '.csv'
+        new_path = old_path[:-4] + ".csv"
         if os.path.exists(old_path):
             convert_dat_to_csv(old_path, new_path)
+
 
 def convert_tab_to_csv(old_path, new_path):
     # Note: we assume the old file is a simple ampl/pyomo dat file, with only
@@ -61,23 +66,22 @@ def convert_tab_to_csv(old_path, new_path):
         # Allow any whitespace as a delimiter because that is how ampl/pyomo .tab
         # files work, and some of our older examples use spaces instead of tabs
         # (e.g., tests/upgrade_dat/copperplate1/inputs/variable_capacity_factors.tab).
-        df = pandas.read_csv(old_path, na_values=['.'], sep=r'\s+')
-        df.to_csv(new_path, sep=',', na_rep='.', index=False)
+        df = pandas.read_csv(old_path, na_values=["."], sep=r"\s+")
+        df.to_csv(new_path, sep=",", na_rep=".", index=False)
         os.remove(old_path)
     except Exception as e:
-        print(
-            '\nERROR converting {} to {}:\n{}'
-            .format(old_path, new_path, e.message)
-        )
+        print("\nERROR converting {} to {}:\n{}".format(old_path, new_path, e.message))
         raise
+
 
 def convert_dat_to_csv(old_path, new_path):
     # define a dummy "model" where every "parameter" reports a dimension of 0.
     # otherwise Pyomo assumes they have dim=1 and looks for index values.
-    class DummyModel():
+    class DummyModel:
         def __getattr__(self, pname):
             return DummyParam()
-    class DummyParam():
+
+    class DummyParam:
         def dim(self):
             return 0
 
@@ -86,14 +90,12 @@ def convert_dat_to_csv(old_path, new_path):
         data.load(filename=old_path)
         # this happens to be in a pandas-friendly format
         df = pandas.DataFrame(data.data())
-        df.to_csv(new_path, sep=',', na_rep='.', index=False)
+        df.to_csv(new_path, sep=",", na_rep=".", index=False)
         os.remove(old_path)
     except Exception as e:
-        print(
-            '\nERROR converting {} to {}:\n{}'
-            .format(old_path, new_path, e.message)
-        )
+        print("\nERROR converting {} to {}:\n{}".format(old_path, new_path, e.message))
         raise
+
 
 # These functions are not used in the 2.0.5 upgrade, but kept here for the future
 def rename_file(old_name, new_name, optional_file=True):
@@ -103,35 +105,37 @@ def rename_file(old_name, new_name, optional_file=True):
         return
     shutil.move(old_path, new_path)
 
+
 def rename_column(file_name, old_col_name, new_col_name, optional_file=True):
     path = os.path.join(inputs_dir, file_name)
     if optional_file and not os.path.isfile(path):
         return
-    df = pandas.read_csv(path, na_values=['.'], sep=',')  # for 2.0.5+
+    df = pandas.read_csv(path, na_values=["."], sep=",")  # for 2.0.5+
     df.rename(columns={old_col_name: new_col_name}, inplace=True)
-    df.to_csv(path, sep=',', na_rep='.', index=False)
+    df.to_csv(path, sep=",", na_rep=".", index=False)
+
 
 def item_list(items):
     """Generate normal-text version of list of items, with commas and "and" as needed."""
-    return ' and '.join(', '.join(items).rsplit(', ', 1))
+    return " and ".join(", ".join(items).rsplit(", ", 1))
+
 
 def update_modules(inputs_dir):
     """Rename modules in the module list if needed (list is sought in
     standard locations) and return list of alerts for user."""
 
-    modules_path = os.path.join(inputs_dir, 'modules.txt')
+    modules_path = os.path.join(inputs_dir, "modules.txt")
     if not os.path.isfile(modules_path):
-        modules_path = os.path.join(inputs_dir, '..', 'modules.txt')
+        modules_path = os.path.join(inputs_dir, "..", "modules.txt")
     if not os.path.isfile(modules_path):
-        modules_path = 'modules.txt'
+        modules_path = "modules.txt"
     if not os.path.isfile(modules_path):
         raise RuntimeError(
             "Unable to find modules or modules.txt file for input directory '{}'. "
             "This file should be located in the input directory, its parent, or "
-            "the current working directory."
-            .format(inputs_dir)
+            "the current working directory.".format(inputs_dir)
         )
-    modules_path = os.path.normpath(modules_path) # tidy up for display later
+    modules_path = os.path.normpath(modules_path)  # tidy up for display later
 
     # Upgrade module listings
     # Each line of the original file is either a module identifier or a comment
@@ -139,13 +143,14 @@ def update_modules(inputs_dir):
         old_module_list = [line.strip() for line in f.read().splitlines()]
 
     # rename modules as needed
-    new_module_list=[]
+    new_module_list = []
     for module in old_module_list:
         try:
             new_modules = replace_modules[module]
             switch_model.upgrade.print_verbose(
-                "Module {old} has been replaced by {new} in {file}."
-                .format(old=module, new=item_list(new_modules), file=modules_path)
+                "Module {old} has been replaced by {new} in {file}.".format(
+                    old=module, new=item_list(new_modules), file=modules_path
+                )
             )
         except KeyError:
             new_modules = [module]
@@ -153,8 +158,8 @@ def update_modules(inputs_dir):
 
     if new_module_list != old_module_list:
         # write new modules list
-        with open(modules_path, 'w') as f:
-           for module in new_module_list:
+        with open(modules_path, "w") as f:
+            for module in new_module_list:
                 f.write(module + "\n")
 
     # report any significant changes in the previously active modules

--- a/switch_model/upgrade/upgrade_2_0_6.py
+++ b/switch_model/upgrade/upgrade_2_0_6.py
@@ -5,28 +5,26 @@ import pandas as pd
 import switch_model.upgrade
 from pyomo.environ import DataPortal
 
-upgrades_from = '2.0.5'
-upgrades_to = '2.0.6'
+upgrades_from = "2.0.5"
+upgrades_to = "2.0.6"
 
 replace_modules = {
     # modules to be replaced in the module list
     # old_module: [new_module1, new_module2, ...],
-    'switch_model.hawaii.psip_2016_12':
-        ['switch_model.hawaii.heco_outlook_2020_06'],
-    'switch_model.hawaii.kalaeloa':
-        ['switch_model.hawaii.oahu_plants'],
+    "switch_model.hawaii.psip_2016_12": ["switch_model.hawaii.heco_outlook_2020_06"],
+    "switch_model.hawaii.kalaeloa": ["switch_model.hawaii.oahu_plants"],
 }
 
 module_messages = {
     # description of significant changes to particular modules other than
     # moving/renaming
     # old_module: message
-    'switch_model.generators.core.build':
-        'Beginning with Switch 2.0.6, gen_multiple_fuels.dat should '
-        'be replaced with gen_multiple_fuels.csv. The .csv file should have '
-        'two columns: GENERATION_PROJECT and fuel. It should have one row for '
-        'each allowed fuel for each multi-fuel generator.',
+    "switch_model.generators.core.build": "Beginning with Switch 2.0.6, gen_multiple_fuels.dat should "
+    "be replaced with gen_multiple_fuels.csv. The .csv file should have "
+    "two columns: GENERATION_PROJECT and fuel. It should have one row for "
+    "each allowed fuel for each multi-fuel generator.",
 }
+
 
 def upgrade_input_dir(inputs_dir):
     """
@@ -54,35 +52,37 @@ def rename_file(old_name, new_name, optional_file=True):
         return
     shutil.move(old_path, new_path)
 
+
 def rename_column(file_name, old_col_name, new_col_name, optional_file=True):
     path = os.path.join(inputs_dir, file_name)
     if optional_file and not os.path.isfile(path):
         return
-    df = pd.read_csv(path, na_values=['.'], sep=',')  # for 2.0.5+
+    df = pd.read_csv(path, na_values=["."], sep=",")  # for 2.0.5+
     df.rename(columns={old_col_name: new_col_name}, inplace=True)
-    df.to_csv(path, sep=',', na_rep='.', index=False)
+    df.to_csv(path, sep=",", na_rep=".", index=False)
+
 
 def item_list(items):
     """Generate normal-text version of list of items, with commas and "and" as needed."""
-    return ' and '.join(', '.join(items).rsplit(', ', 1))
+    return " and ".join(", ".join(items).rsplit(", ", 1))
+
 
 def update_modules(inputs_dir):
     """Rename modules in the module list if needed (list is sought in
     standard locations) and return list of alerts for user."""
 
-    modules_path = os.path.join(inputs_dir, 'modules.txt')
+    modules_path = os.path.join(inputs_dir, "modules.txt")
     if not os.path.isfile(modules_path):
-        modules_path = os.path.join(inputs_dir, '..', 'modules.txt')
+        modules_path = os.path.join(inputs_dir, "..", "modules.txt")
     if not os.path.isfile(modules_path):
-        modules_path = 'modules.txt'
+        modules_path = "modules.txt"
     if not os.path.isfile(modules_path):
         raise RuntimeError(
             "Unable to find modules or modules.txt file for input directory '{}'. "
             "This file should be located in the input directory, its parent, or "
-            "the current working directory."
-            .format(inputs_dir)
+            "the current working directory.".format(inputs_dir)
         )
-    modules_path = os.path.normpath(modules_path) # tidy up for display later
+    modules_path = os.path.normpath(modules_path)  # tidy up for display later
 
     # Upgrade module listings
     # Each line of the original file is either a module identifier or a comment
@@ -90,13 +90,14 @@ def update_modules(inputs_dir):
         old_module_list = [line.strip() for line in f.read().splitlines()]
 
     # rename modules as needed
-    new_module_list=[]
+    new_module_list = []
     for module in old_module_list:
         try:
             new_modules = replace_modules[module]
             switch_model.upgrade.print_verbose(
-                "Module {old} has been replaced by {new} in {file}."
-                .format(old=module, new=item_list(new_modules), file=modules_path)
+                "Module {old} has been replaced by {new} in {file}.".format(
+                    old=module, new=item_list(new_modules), file=modules_path
+                )
             )
         except KeyError:
             new_modules = [module]
@@ -104,8 +105,8 @@ def update_modules(inputs_dir):
 
     if new_module_list != old_module_list:
         # write new modules list
-        with open(modules_path, 'w') as f:
-           for module in new_module_list:
+        with open(modules_path, "w") as f:
+            for module in new_module_list:
                 f.write(module + "\n")
 
     # report any significant changes in the previously active modules
@@ -119,43 +120,41 @@ def update_modules(inputs_dir):
 
 
 def convert_gen_multiple_fuels_to_csv(inputs_dir):
-    old_path = os.path.join(inputs_dir, 'gen_multiple_fuels.dat')
-    new_path = os.path.join(inputs_dir, 'gen_multiple_fuels.csv')
+    old_path = os.path.join(inputs_dir, "gen_multiple_fuels.dat")
+    new_path = os.path.join(inputs_dir, "gen_multiple_fuels.csv")
 
     if os.path.exists(old_path):
         old_df = read_dat_file(old_path)
         # df has one row for each gen; gen is the index and a list of fuels is the value
         # unpack list of allowed fuels for each generator
         gen_fuels = [
-            (gen, fuel)
-            for gen, fuels in old_df.itertuples()
-            for fuel in fuels
+            (gen, fuel) for gen, fuels in old_df.itertuples() for fuel in fuels
         ]
         new_df = pd.DataFrame.from_records(
-            gen_fuels, columns=['GENERATION_PROJECT', 'fuel']
+            gen_fuels, columns=["GENERATION_PROJECT", "fuel"]
         )
-        new_df.to_csv(new_path, sep=',', na_rep='.', index=False)
+        new_df.to_csv(new_path, sep=",", na_rep=".", index=False)
         os.remove(old_path)
+
 
 def read_dat_file(path):
     # define a dummy "model" where every "parameter" reports a dimension of 0.
     # otherwise Pyomo assumes they have dim=1 and looks for index values.
-    class DummyModel():
+    class DummyModel:
         def __getattr__(self, pname):
             return DummyParam()
-    class DummyParam():
+
+    class DummyParam:
         def dim(self):
             return 0
+
     try:
         data = DataPortal(model=DummyModel())
         data.load(filename=path)
         # this happens to be in a pd-friendly format
         df = pd.DataFrame(data.data())
     except Exception as e:
-        print(
-            '\nERROR reading {}:\n{}'
-            .format(path, e.message)
-        )
+        print("\nERROR reading {}:\n{}".format(path, e.message))
         raise
     else:
         return df

--- a/switch_model/utilities.py
+++ b/switch_model/utilities.py
@@ -35,10 +35,12 @@ except NameError:
     # Python 3
     string_types = (str,)
 
+
 def define_AbstractModel(*module_list, **kwargs):
     # stub to provide old functionality as we move to a simpler calling convention
     args = kwargs.get("args", sys.argv[1:])
     return create_model(module_list, args)
+
 
 def create_model(module_list=None, args=sys.argv[1:], logger=None):
     """
@@ -80,6 +82,7 @@ def create_model(module_list=None, args=sys.argv[1:], logger=None):
     # Load modules
     if module_list is None:
         import switch_model.solve
+
         module_list = switch_model.solve.get_module_list(args)
     model.module_list = module_list
     for m in module_list:
@@ -105,7 +108,7 @@ def create_model(module_list=None, args=sys.argv[1:], logger=None):
     # Define and parse model configuration options
     argparser = _ArgumentParser(allow_abbrev=False)
     for module in model.get_modules():
-        if hasattr(module, 'define_arguments'):
+        if hasattr(module, "define_arguments"):
             module.define_arguments(argparser)
     model.options = argparser.parse_args(args)
 
@@ -115,13 +118,13 @@ def create_model(module_list=None, args=sys.argv[1:], logger=None):
 
     # Define model components
     for module in model.get_modules():
-        if hasattr(module, 'define_dynamic_lists'):
+        if hasattr(module, "define_dynamic_lists"):
             module.define_dynamic_lists(model)
     for module in model.get_modules():
-        if hasattr(module, 'define_components'):
+        if hasattr(module, "define_components"):
             module.define_components(model)
     for module in model.get_modules():
-        if hasattr(module, 'define_dynamic_components'):
+        if hasattr(module, "define_dynamic_components"):
             module.define_dynamic_components(model)
 
     return model
@@ -145,14 +148,17 @@ def make_iterable(item):
             i = iter([item])
     return i
 
+
 class StepTimer(object):
     """
     Keep track of elapsed time for steps of a process.
     Use timer = StepTimer() to create a timer, then retrieve elapsed time and/or
     reset the timer at each step by calling timer.step_time()
     """
+
     def __init__(self):
         self.start_time = time.time()
+
     def step_time(self):
         """
         Reset timer to current time and return time elapsed since last step.
@@ -160,6 +166,7 @@ class StepTimer(object):
         last_start = self.start_time
         self.start_time = now = time.time()
         return now - last_start
+
 
 def load_inputs(model, inputs_dir=None, attach_data_portal=True):
     """
@@ -175,7 +182,7 @@ def load_inputs(model, inputs_dir=None, attach_data_portal=True):
     data = DataPortal(model=model)
     data.load_aug = types.MethodType(load_aug, data)
     for module in model.get_modules():
-        if hasattr(module, 'load_inputs'):
+        if hasattr(module, "load_inputs"):
             module.load_inputs(model, data, inputs_dir)
     if model.options.verbose:
         print("Data read in {:.2f} s.\n".format(timer.step_time()))
@@ -209,8 +216,13 @@ def load_inputs(model, inputs_dir=None, attach_data_portal=True):
     return instance
 
 
-def save_inputs_as_dat(model, instance, save_path="inputs/complete_inputs.dat",
-    exclude=[], sorted_output=False):
+def save_inputs_as_dat(
+    model,
+    instance,
+    save_path="inputs/complete_inputs.dat",
+    exclude=[],
+    sorted_output=False,
+):
     """
     Save input data to a .dat file for use with PySP or other command line
     tools that have not been fully integrated with DataPortal.
@@ -219,26 +231,34 @@ def save_inputs_as_dat(model, instance, save_path="inputs/complete_inputs.dat",
     """
     # helper function to convert values to strings,
     # putting quotes around values that start as strings
-    quote_str = lambda v: '"{}"'.format(v) if isinstance(v, string_types) else '{}'.format(str(v))
+    quote_str = (
+        lambda v: '"{}"'.format(v)
+        if isinstance(v, string_types)
+        else "{}".format(str(v))
+    )
     # helper function to create delimited lists from single items or iterables of any data type
     from switch_model.reporting import make_iterable
-    join_space = lambda items: ' '.join(map(str, make_iterable(items)))  # space-separated list
-    join_comma = lambda items: ','.join(map(str, make_iterable(items)))  # comma-separated list
+
+    join_space = lambda items: " ".join(
+        map(str, make_iterable(items))
+    )  # space-separated list
+    join_comma = lambda items: ",".join(
+        map(str, make_iterable(items))
+    )  # comma-separated list
 
     with open(save_path, "w") as f:
         for component_name in instance.DataPortal.data():
             if component_name in exclude:
-                continue    # don't write data for components in exclude list
-                            # (they're in scenario-specific files)
+                continue  # don't write data for components in exclude list
+                # (they're in scenario-specific files)
             component = getattr(model, component_name)
             comp_class = type(component).__name__
             component_data = instance.DataPortal.data(name=component_name)
-            if comp_class == 'SimpleSet' or comp_class == 'OrderedSimpleSet':
+            if comp_class == "SimpleSet" or comp_class == "OrderedSimpleSet":
                 f.write(
-                    "set {} := {};\n"
-                    .format(component_name, join_space(component_data))
+                    "set {} := {};\n".format(component_name, join_space(component_data))
                 )
-            elif comp_class == 'IndexedParam':
+            elif comp_class == "IndexedParam":
                 if component_data:  # omit components for which no data were provided
                     f.write("param {} := \n".format(component_name))
                     for key, value in (
@@ -248,18 +268,22 @@ def save_inputs_as_dat(model, instance, save_path="inputs/complete_inputs.dat",
                     ):
                         f.write(" {} {}\n".format(join_space(key), quote_str(value)))
                     f.write(";\n")
-            elif comp_class == 'SimpleParam':
+            elif comp_class == "SimpleParam":
                 f.write("param {} := {};\n".format(component_name, component_data))
-            elif comp_class == 'IndexedSet':
+            elif comp_class == "IndexedSet":
                 for key, vals in iteritems(component_data):
                     f.write(
-                        "set {}[{}] := {};\n"
-                        .format(component_name, join_comma(key), join_space(vals))
+                        "set {}[{}] := {};\n".format(
+                            component_name, join_comma(key), join_space(vals)
+                        )
                     )
             else:
                 raise ValueError(
-                    "Error! Component type {} not recognized for model element '{}'.".
-                    format(comp_class, component_name))
+                    "Error! Component type {} not recognized for model element '{}'.".format(
+                        comp_class, component_name
+                    )
+                )
+
 
 def pre_solve(instance, outputs_dir=None):
     """
@@ -267,8 +291,9 @@ def pre_solve(instance, outputs_dir=None):
     This function can be used to adjust the instance after it is created and before it is solved.
     """
     for module in instance.get_modules():
-        if hasattr(module, 'pre_solve'):
+        if hasattr(module, "pre_solve"):
             module.pre_solve(instance)
+
 
 def post_solve(instance, outputs_dir=None):
     """
@@ -285,16 +310,13 @@ def post_solve(instance, outputs_dir=None):
     # (the latter may occur when there are problems with licenses, etc)
 
     for module in instance.get_modules():
-        if hasattr(module, 'post_solve'):
+        if hasattr(module, "post_solve"):
             module.post_solve(instance, outputs_dir)
 
+
 def unwrap(message):
-    return (
-        textwrap.dedent(message)
-        .replace(' \n', ' ')
-        .replace('\n', ' ')
-        .strip()
-    )
+    return textwrap.dedent(message).replace(" \n", " ").replace("\n", " ").strip()
+
 
 def min_data_check(model, *mandatory_model_components):
     """
@@ -328,9 +350,13 @@ def min_data_check(model, *mandatory_model_components):
     """
     model.__num_min_data_checks += 1
     new_data_check_name = "min_data_check_" + str(model.__num_min_data_checks)
-    setattr(model, new_data_check_name, BuildCheck(
-        rule=lambda m: check_mandatory_components(
-            m, *mandatory_model_components)))
+    setattr(
+        model,
+        new_data_check_name,
+        BuildCheck(
+            rule=lambda m: check_mandatory_components(m, *mandatory_model_components)
+        ),
+    )
 
 
 def _add_min_data_check(model):
@@ -339,7 +365,7 @@ def _add_min_data_check(model):
     object if it has not already been added. Also add a counter to keep
     track of what to name the next check that is added.
     """
-    if getattr(model, 'min_data_check', None) is None:
+    if getattr(model, "min_data_check", None) is None:
         model.__num_min_data_checks = 0
         model.min_data_check = types.MethodType(min_data_check, model)
 
@@ -351,6 +377,7 @@ def has_discrete_variables(model):
         for variable in model.component_objects(Var, active=True)
         for v in all_elements(variable)
     )
+
 
 def check_mandatory_components(model, *mandatory_model_components):
     """
@@ -377,39 +404,46 @@ def check_mandatory_components(model, *mandatory_model_components):
     for component_name in mandatory_model_components:
         obj = getattr(model, component_name)
         o_class = type(obj).__name__
-        if o_class == 'SimpleSet' or o_class == 'OrderedSimpleSet':
+        if o_class == "SimpleSet" or o_class == "OrderedSimpleSet":
             if len(obj) == 0:
                 raise ValueError(
-                    "No data is defined for the mandatory set '{}'.".
-                    format(component_name))
-        elif o_class == 'IndexedParam':
+                    "No data is defined for the mandatory set '{}'.".format(
+                        component_name
+                    )
+                )
+        elif o_class == "IndexedParam":
             if len(obj) != len(obj.index_set()):
-                missing_index_elements = [
-                    k for k in obj.index_set() if k not in obj
-                ]
+                missing_index_elements = [k for k in obj.index_set() if k not in obj]
                 raise ValueError(
                     "Values are not provided for every element of the "
                     "mandatory parameter '{}'. "
-                    "Missing data for {} values, including: {}"
-                    .format(
-                        component_name, len(missing_index_elements),
-                        missing_index_elements[:10]
+                    "Missing data for {} values, including: {}".format(
+                        component_name,
+                        len(missing_index_elements),
+                        missing_index_elements[:10],
                     )
                 )
-        elif o_class == 'IndexedSet':
+        elif o_class == "IndexedSet":
             if len(obj) != len(obj.index_set()):
                 raise ValueError(
-                    ("Sets are not defined for every index of " +
-                     "the mandatory indexed set '{}'").format(component_name))
-        elif o_class == 'SimpleParam':
+                    (
+                        "Sets are not defined for every index of "
+                        + "the mandatory indexed set '{}'"
+                    ).format(component_name)
+                )
+        elif o_class == "SimpleParam":
             if obj.value is None:
                 raise ValueError(
-                    "Value not provided for mandatory parameter '{}'".
-                    format(component_name))
+                    "Value not provided for mandatory parameter '{}'".format(
+                        component_name
+                    )
+                )
         else:
             raise ValueError(
-                "Error! Object type {} not recognized for model element '{}'.".
-                format(o_class, component_name))
+                "Error! Object type {} not recognized for model element '{}'.".format(
+                    o_class, component_name
+                )
+            )
     return True
 
 
@@ -426,6 +460,7 @@ class InputError(Exception):
 
     def __str__(self):
         return repr(self.value)
+
 
 def apply_input_aliases(switch_data, path):
     """
@@ -445,15 +480,15 @@ def apply_input_aliases(switch_data, path):
         file_aliases = switch_data.file_aliases = {
             standard: alternative
             for standard, alternative in (
-                pair.split('=') for pair in switch_data._model.options.input_aliases
+                pair.split("=") for pair in switch_data._model.options.input_aliases
             )
         }
 
     root, filename = os.path.split(path)
     if filename in file_aliases:
         old_path = path
-        if file_aliases[filename].lower() == 'none':
-            path = ''
+        if file_aliases[filename].lower() == "none":
+            path = ""
         else:
             # Note: We could use os.path.normpath() to clean up paths like
             # 'inputs/../inputs_alt', but leaving them as-is may make it more
@@ -463,12 +498,14 @@ def apply_input_aliases(switch_data, path):
                 # catch alias naming errors (should always point to a real file)
                 raise ValueError(
                     'Alias "{}" specified for file "{}" does not exist. '
-                    'Specify {}=none if you want to supply no data.'
-                    .format(path, old_path, filename)
+                    "Specify {}=none if you want to supply no data.".format(
+                        path, old_path, filename
+                    )
                 )
-        switch_data._model.logger.info('Applying alias {}={}'.format(old_path, path))
+        switch_data._model.logger.info("Applying alias {}={}".format(old_path, path))
 
     return path
+
 
 def load_aug(switch_data, optional=False, optional_params=[], **kwargs):
     """
@@ -515,20 +552,21 @@ def load_aug(switch_data, optional=False, optional_params=[], **kwargs):
     # also support auto-documenting of parameters and input files.
 
     # convert filename if needed
-    kwargs['filename'] = apply_input_aliases(switch_data, kwargs['filename'])
+    kwargs["filename"] = apply_input_aliases(switch_data, kwargs["filename"])
     # store filename in local variable for easier access
-    path = kwargs['filename']
+    path = kwargs["filename"]
 
     # catch obsolete auto_select argument (not used in 2.0.6 and later)
-    for a in ['auto_select', 'autoselect']:
+    for a in ["auto_select", "autoselect"]:
         if a in kwargs:
             del kwargs[a]
             # TODO: receive a reference to the model and use the logger for this
             print(
                 "WARNING: obsolete argument {} ignored while reading {}. "
                 "Please remove this from your code. Columns are always "
-                "auto-selected now unless a 'select' argument is passed."
-                .format(a, path)
+                "auto-selected now unless a 'select' argument is passed.".format(
+                    a, path
+                )
             )
 
     # Skip if an optional file is unavailable
@@ -538,26 +576,27 @@ def load_aug(switch_data, optional=False, optional_params=[], **kwargs):
     # If this is a .dat file, then skip the rest of this fancy business; we'll
     # only check if the file is missing and optional for .csv files.
     filename, extension = os.path.splitext(path)
-    if extension == '.dat':
+    if extension == ".dat":
         switch_data.load(**kwargs)
         return
 
     # copy optional_params to avoid side-effects when the list is altered below
-    optional_params=list(optional_params)
+    optional_params = list(optional_params)
     # Parse header and first row
     with open(path) as infile:
         headers_line = infile.readline()
         second_line = infile.readline()
-    file_is_empty = (headers_line == '')
-    file_has_no_data_rows = (second_line == '')
-    suffix = path.split('.')[-1]
-    if suffix in {'tab', 'tsv'}:
-        separator = '\t'
-    elif suffix == 'csv':
-        separator = ','
+    file_is_empty = headers_line == ""
+    file_has_no_data_rows = second_line == ""
+    suffix = path.split(".")[-1]
+    if suffix in {"tab", "tsv"}:
+        separator = "\t"
+    elif suffix == "csv":
+        separator = ","
     else:
         raise switch_model.utilities.InputError(
-            'Unrecognized file type for input file {}'.format(path))
+            "Unrecognized file type for input file {}".format(path)
+        )
     # TODO: parse this more formally, e.g. using csv module
     headers = headers_line.strip().split(separator)
     # Skip if the file is empty.
@@ -566,14 +605,14 @@ def load_aug(switch_data, optional=False, optional_params=[], **kwargs):
     # Try to get a list of parameters. If param was given as a
     # singleton or a tuple, make it into a list that can be edited.
     params = []
-    if 'param' in kwargs:
+    if "param" in kwargs:
         # Tuple -> list
-        if isinstance(kwargs['param'], tuple):
-            kwargs['param'] = list(kwargs['param'])
+        if isinstance(kwargs["param"], tuple):
+            kwargs["param"] = list(kwargs["param"])
         # Singleton -> list
-        elif not isinstance(kwargs['param'], list):
-            kwargs['param'] = [kwargs['param']]
-        params = kwargs['param']
+        elif not isinstance(kwargs["param"], list):
+            kwargs["param"] = [kwargs["param"]]
+        params = kwargs["param"]
     # optional_params may include Param objects instead of names. In
     # those cases, convert objects to names.
     for (i, p) in enumerate(optional_params):
@@ -589,8 +628,8 @@ def load_aug(switch_data, optional=False, optional_params=[], **kwargs):
             optional_params.append(p.name)
     # How many index columns do we expect?
     # Grab the dimensionality of the index param if it was provided.
-    if 'index' in kwargs:
-        num_indexes = kwargs['index'].dimen
+    if "index" in kwargs:
+        num_indexes = kwargs["index"].dimen
     # Next try the first parameter's index.
     elif len(params) > 0:
         try:
@@ -614,30 +653,27 @@ def load_aug(switch_data, optional=False, optional_params=[], **kwargs):
     # could all get the prefix "rfm_supply_tier_". Then they could get shorter names
     # within the file (e.g., "cost" and "limit"). We could also require the data file
     # to be called "rfm_supply_tier.csv" for greater consistency/predictability.
-    if 'select' not in kwargs:
-        kwargs['select'] = headers[0:num_indexes] + [p.name for p in params]
+    if "select" not in kwargs:
+        kwargs["select"] = headers[0:num_indexes] + [p.name for p in params]
     # Check to see if expected column names are in the file. If a column
     # name is missing and its parameter is optional, then drop it from
     # the select & param lists.
-    if isinstance(kwargs['select'], tuple):
-        kwargs['select'] = list(kwargs['select'])
+    if isinstance(kwargs["select"], tuple):
+        kwargs["select"] = list(kwargs["select"])
     del_items = []
-    for (i, col) in enumerate(kwargs['select']):
+    for (i, col) in enumerate(kwargs["select"]):
         p_i = i - num_indexes
         if col not in headers:
-            if(len(params) > p_i >= 0 and
-               params[p_i].name in optional_params):
+            if len(params) > p_i >= 0 and params[p_i].name in optional_params:
                 del_items.append((i, p_i))
             else:
-                raise InputError(
-                    'Column {} not found in file {}.'
-                    .format(col, path))
+                raise InputError("Column {} not found in file {}.".format(col, path))
     # When deleting entries from select & param lists, go from last
     # to first so that the indexes won't get messed up as we go.
     del_items.sort(reverse=True)
     for (i, p_i) in del_items:
-        del kwargs['select'][i]
-        del kwargs['param'][p_i]
+        del kwargs["select"][i]
+        del kwargs["param"][p_i]
 
     if optional and file_has_no_data_rows:
         # Skip the file.  Note that we are only doing this after having
@@ -671,7 +707,10 @@ else:
                     # see https://bugs.python.org/issue14910#msg204678
                     def new_get_option_tuples(self, option_string):
                         return []
-                    self._get_option_tuples = types.MethodType(new_get_option_tuples, self)
+
+                    self._get_option_tuples = types.MethodType(
+                        new_get_option_tuples, self
+                    )
                 else:
                     raise RuntimeError(
                         "Incompatible argparse module detected. This software requires "
@@ -682,36 +721,43 @@ else:
             kwargs.pop("allow_abbrev", None)
             return argparse.ArgumentParser.__init__(self, *args, **kwargs)
 
+
 class ExtendAction(argparse.Action):
     """Create or extend list with the provided items"""
+
     # from https://stackoverflow.com/a/41153081/3830997
     def __call__(self, parser, namespace, values, option_string=None):
         items = getattr(namespace, self.dest) or []
         items.extend(values)
         setattr(namespace, self.dest, items)
 
+
 class IncludeAction(argparse.Action):
     """Flag the specified items for inclusion in the model"""
+
     def __call__(self, parser, namespace, values, option_string=None):
         items = getattr(namespace, self.dest) or []
-        items.append(('include', values))
+        items.append(("include", values))
         setattr(namespace, self.dest, items)
+
+
 class ExcludeAction(argparse.Action):
     """Flag the specified items for exclusion from the model"""
+
     def __call__(self, parser, namespace, values, option_string=None):
         items = getattr(namespace, self.dest) or []
-        items.append(('exclude', values))
+        items.append(("exclude", values))
         setattr(namespace, self.dest, items)
+
 
 # Test whether we need to issue warnings about the Python parsing bug.
 # (applies to at least Python 2.7.11 and 3.6.2)
 # This bug messes up solve-scenarios if the user specifies
 # --scenario x --solver-options-string="a=b c=d"
 test_parser = argparse.ArgumentParser()
-test_parser.add_argument('--arg1', nargs='+', default=[])
+test_parser.add_argument("--arg1", nargs="+", default=[])
 bad_equal_parser = (
-    len(test_parser.parse_known_args(['--arg1', 'a', '--arg2=a=1 b=2'])[1])
-    == 0
+    len(test_parser.parse_known_args(["--arg1", "a", "--arg2=a=1 b=2"])[1]) == 0
 )
 
 # TODO: merge the _ArgumentParserAllowAbbrev code into this class
@@ -722,11 +768,12 @@ class _ArgumentParser(_ArgumentParserAllowAbbrev):
     - allows use of 'extend', 'include' and 'exclude' actions to accumulate lists
       with multiple calls
     """
+
     def __init__(self, *args, **kwargs):
         super(_ArgumentParser, self).__init__(*args, **kwargs)
-        self.register('action', 'extend', ExtendAction)
-        self.register('action', 'include', IncludeAction)
-        self.register('action', 'exclude', ExcludeAction)
+        self.register("action", "extend", ExtendAction)
+        self.register("action", "include", IncludeAction)
+        self.register("action", "exclude", ExcludeAction)
 
     def parse_known_args(self, args=None, namespace=None):
         # parse_known_args parses arguments like --list-arg a b --other-arg="something with space"
@@ -735,29 +782,30 @@ class _ArgumentParser(_ArgumentParserAllowAbbrev):
         # We issue a warning to avoid this.
         if bad_equal_parser and args is not None:
             for a in args:
-                if a.startswith('--') and '=' in a:
+                if a.startswith("--") and "=" in a:
                     print(
                         "Warning: argument '{}' may be parsed incorrectly. It is "
-                        "safer to use ' ' instead of '=' as a separator."
-                        .format(a)
+                        "safer to use ' ' instead of '=' as a separator.".format(a)
                     )
                     time.sleep(2)  # give users a chance to see it
         return super(_ArgumentParser, self).parse_known_args(args, namespace)
 
 
 def approx_equal(a, b, tolerance=0.01):
-    return abs(a-b) <= (abs(a) + abs(b)) / 2.0 * tolerance
+    return abs(a - b) <= (abs(a) + abs(b)) / 2.0 * tolerance
 
 
 def default_solver():
-    return pyomo.opt.SolverFactory('glpk')
+    return pyomo.opt.SolverFactory("glpk")
+
 
 def warn(message):
     """
     Send warning message to sys.stderr.
     Unlike warnings.warn, this does not add the current line of code to the message.
     """
-    sys.stderr.write("WARNING: " + message + '\n')
+    sys.stderr.write("WARNING: " + message + "\n")
+
 
 class TeeStream(object):
     """
@@ -766,9 +814,11 @@ class TeeStream(object):
     `sys.stdout=TeeStream(sys.stdout, log_file_handle)` will copy
     output destined for sys.stdout to log_file_handle as well.
     """
+
     def __init__(self, stream1, stream2):
         self.stream1 = stream1
         self.stream2 = stream2
+
     def __getattr__(self, *args, **kwargs):
         """
         Provide stream1 attributes when attributes are requested for this class.
@@ -776,24 +826,27 @@ class TeeStream(object):
         methods, etc.
         """
         return getattr(self.stream1, *args, **kwargs)
+
     def write(self, text):
         for f in [self.stream1, self.stream2]:
-            if f.isatty() or '\b' not in text:
+            if f.isatty() or "\b" not in text:
                 # normal processing
                 f.write(text)
             else:
                 for c in text:
-                    if c == '\b':
+                    if c == "\b":
                         # move one character before current position, to
                         # overwrite current character like a terminal
                         # (Python can't do f.seek(-1, 1) for some reason.)
-                        f.seek(f.tell()-1)
+                        f.seek(f.tell() - 1)
                     else:
                         f.write(c)
         return len(text)
+
     def flush(self):
         self.stream1.flush()
         self.stream2.flush()
+
 
 class LogOutput(object):
     """
@@ -803,24 +856,28 @@ class LogOutput(object):
     will have microseconds added to the name if needed to avoid overwriting
     existing any existing file.
     """
+
     def __init__(self, logs_dir):
         self.logs_dir = logs_dir
+
     def __enter__(self):
         """ start copying output to log file """
         if self.logs_dir is not None:
             log_file_path = self.make_file_path()
-            self.log_file = open(log_file_path, 'w', buffering=1)
+            self.log_file = open(log_file_path, "w", buffering=1)
             self.stdout = sys.stdout
             self.stderr = sys.stderr
             sys.stdout = TeeStream(sys.stdout, self.log_file)
             # sys.stderr = TeeStream(sys.stderr, self.log_file)
             print("logging output to " + str(log_file_path))
+
     def __exit__(self, type, value, traceback):
         """ restore original output streams and close log file """
         if self.logs_dir is not None:
             sys.stdout = self.stdout
             sys.stderr = self.stderr
             self.log_file.close()
+
     def make_file_path(self):
         """
         Create a log file on disk and return the file name (guaranteed unique).
@@ -832,7 +889,7 @@ class LogOutput(object):
         # make sure logs directory exists
         if not os.path.exists(self.logs_dir):
             os.makedirs(self.logs_dir)
-        file_path = path('%Y-%m-%d_%H-%M-%S')
+        file_path = path("%Y-%m-%d_%H-%M-%S")
         while True:
             try:
                 f = os.open(file_path, os.O_CREAT | os.O_EXCL)
@@ -841,8 +898,9 @@ class LogOutput(object):
                 break
             except FileExistsError:
                 # try again with microseconds in name and a little delay
-                file_path = path('%Y-%m-%d_%H-%M-%S.%f')
+                file_path = path("%Y-%m-%d_%H-%M-%S.%f")
         return file_path
+
 
 class TimingLineCounterStream(object):
     """
@@ -851,13 +909,15 @@ class TimingLineCounterStream(object):
     count of constructed components. Designed for use with
     model.create_instance(report_timing=True)
     """
-    match_line = re.compile(r'^[ ]*[0-9.]+ seconds to construct .* total\n$')
+
+    match_line = re.compile(r"^[ ]*[0-9.]+ seconds to construct .* total\n$")
 
     def __init__(self, orig_stream, model):
         self.orig_stream = orig_stream
         self.model = model
-        self.last_message = ''
+        self.last_message = ""
         self.components_completed = 0
+
     def __getattr__(self, *args, **kwargs):
         """
         Provide orig_stream attributes when attributes are requested for this class.
@@ -865,14 +925,13 @@ class TimingLineCounterStream(object):
         methods, etc.
         """
         return getattr(self.orig_stream, *args, **kwargs)
+
     def write(self, text):
         if self.last_message and self.orig_stream.isatty():
-                # Remove previous progress message; also overwrite with spaces
-                # in case it's at end of a line. We skip this when not in a
-                # terminal, e.g., in an IPython kernel.
-                self.orig_stream.write(''.join(
-                    c * len(self.last_message) for c in '\b \b'
-                ))
+            # Remove previous progress message; also overwrite with spaces
+            # in case it's at end of a line. We skip this when not in a
+            # terminal, e.g., in an IPython kernel.
+            self.orig_stream.write("".join(c * len(self.last_message) for c in "\b \b"))
         if self.match_line.match(text):
             self.components_completed += 1
 
@@ -881,10 +940,10 @@ class TimingLineCounterStream(object):
             # instance currently being constructed, so we have no way to know
             # if components are added or deleted during construction. So we just
             # use the original component count and update if we overshoot.
-            self.last_message = '{} of {} components constructed{}'.format(
+            self.last_message = "{} of {} components constructed{}".format(
                 self.components_completed,
                 max(self.components_completed, len(self.model._decl_order)),
-                '' if self.orig_stream.isatty() else '\n'
+                "" if self.orig_stream.isatty() else "\n",
             )
         else:
             # normal text, not a timing report
@@ -894,23 +953,28 @@ class TimingLineCounterStream(object):
 
         return len(text)
 
+
 class TimingLineCounter(object):
     """
     Intercept lines like '0 seconds to construct Set PERIODS; 1 index total'
     sent to stdout and turn them into a percentage count, relative to size of
     the passed model. Designed for use with model.create_instance(report_timing=True)
     """
+
     def __init__(self, model):
         self.model = model
+
     def __enter__(self):
         self.stdout = sys.stdout
         sys.stdout = TimingLineCounterStream(sys.stdout, self.model)
+
     def __exit__(self, type, value, traceback):
-        if getattr(sys.stdout, 'last_message', ''):
+        if getattr(sys.stdout, "last_message", ""):
             # add newline after last status message
-            sys.stdout.last_message = ''
+            sys.stdout.last_message = ""
             print("")
         sys.stdout = self.stdout
+
 
 # test_model = lambda: None
 # test_model._decl_order = [1, 2, 3]
@@ -925,10 +989,11 @@ class TimingLineCounter(object):
 #         print(line)
 #         time.sleep(0.5)
 
+
 def iteritems(obj):
-    """ Iterator of key, value pairs for obj;
-    equivalent to obj.items() on Python 3+ and obj.iteritems() on Python 2 """
+    """Iterator of key, value pairs for obj;
+    equivalent to obj.items() on Python 3+ and obj.iteritems() on Python 2"""
     try:
         return obj.iteritems()
-    except AttributeError: # Python 3+
+    except AttributeError:  # Python 3+
         return obj.items()

--- a/switch_model/version.py
+++ b/switch_model/version.py
@@ -5,4 +5,4 @@ This file should not contain anything that is not part of a minimal python
 distribution because it needs to be executed before Switch (and its
 dependencies) are installed.
 """
-__version__='2.0.6'
+__version__ = "2.0.6"

--- a/tests/examples_test.py
+++ b/tests/examples_test.py
@@ -18,6 +18,7 @@ TOP_DIR = os.path.dirname(os.path.dirname(__file__))
 
 UPDATE_EXPECTATIONS = False
 
+
 def _remove_temp_dir(path):
     for retry in range(100):
         try:
@@ -25,6 +26,7 @@ def _remove_temp_dir(path):
             break
         except:
             pass
+
 
 def read_file(filename):
     with open(filename, "r") as fh:
@@ -37,18 +39,17 @@ def write_file(filename, data):
 
 
 def find_example_dirs():
-    examples_dir = os.path.join(TOP_DIR, 'examples')
+    examples_dir = os.path.join(TOP_DIR, "examples")
     for dirpath, dirnames, filenames in os.walk(examples_dir):
         for dirname in dirnames:
             path = os.path.join(dirpath, dirname)
-            if os.path.exists(os.path.join(path, 'inputs', 'modules.txt')):
+            if os.path.exists(os.path.join(path, "inputs", "modules.txt")):
                 yield path
 
 
 def get_expectation_path(example_dir):
-    expectation_file = os.path.join(example_dir, 'outputs',
-                                        'total_cost.txt')
-    if not os.path.isfile( expectation_file ):
+    expectation_file = os.path.join(example_dir, "outputs", "total_cost.txt")
+    if not os.path.isfile(expectation_file):
         return False
     else:
         return expectation_file
@@ -56,16 +57,21 @@ def get_expectation_path(example_dir):
 
 def make_test(example_dir):
     def test_example():
-        temp_dir = tempfile.mkdtemp(prefix='switch_test_')
+        temp_dir = tempfile.mkdtemp(prefix="switch_test_")
         try:
             # Custom python modules may be in the example's working directory
             sys.path.append(example_dir)
-            args = switch_model.solve.get_option_file_args(dir=example_dir,
+            args = switch_model.solve.get_option_file_args(
+                dir=example_dir,
                 extra_args=[
-                    '--inputs-dir', os.path.join(example_dir, 'inputs'),
-                    '--outputs-dir', temp_dir])
+                    "--inputs-dir",
+                    os.path.join(example_dir, "inputs"),
+                    "--outputs-dir",
+                    temp_dir,
+                ],
+            )
             switch_model.solve.main(args)
-            total_cost = read_file(os.path.join(temp_dir, 'total_cost.txt'))
+            total_cost = read_file(os.path.join(temp_dir, "total_cost.txt"))
         finally:
             sys.path.remove(example_dir)
             _remove_temp_dir(temp_dir)
@@ -75,19 +81,21 @@ def make_test(example_dir):
         else:
             expected = float(read_file(expectation_file))
             actual = float(total_cost)
-            if not switch_model.utilities.approx_equal(expected, actual,
-                                                     tolerance=0.0001):
+            if not switch_model.utilities.approx_equal(
+                expected, actual, tolerance=0.0001
+            ):
                 raise AssertionError(
-                    'Mismatch for total_cost (the objective function value):\n'
-                    'Expected value:  {}\n'
-                    'Actual value:    {}\n'
+                    "Mismatch for total_cost (the objective function value):\n"
+                    "Expected value:  {}\n"
+                    "Actual value:    {}\n"
                     'Run "python -m tests.examples_test --update" to '
-                    'update the expectations if this change is expected.'
-                    .format(expected, actual))
+                    "update the expectations if this change is expected.".format(
+                        expected, actual
+                    )
+                )
 
     name = os.path.relpath(example_dir, TOP_DIR)
-    return unittest.FunctionTestCase(
-        test_example, description='Example: %s' % name)
+    return unittest.FunctionTestCase(test_example, description="Example: %s" % name)
 
 
 def load_tests(loader, tests, pattern):
@@ -98,8 +106,8 @@ def load_tests(loader, tests, pattern):
     return suite
 
 
-if __name__ == '__main__':
-    if sys.argv[1:2] == ['--update']:
+if __name__ == "__main__":
+    if sys.argv[1:2] == ["--update"]:
         UPDATE_EXPECTATIONS = True
         sys.argv.pop(1)
     unittest.main()

--- a/tests/upgrade_dat/custom_extension/sunk_costs.py
+++ b/tests/upgrade_dat/custom_extension/sunk_costs.py
@@ -27,7 +27,5 @@ from pyomo.environ import *
 
 
 def define_components(mod):
-    mod.administration_fees = Param(
-        mod.PERIODS,
-        initialize=lambda m, p: 1000000)
-    mod.Cost_Components_Per_Period.append('administration_fees')
+    mod.administration_fees = Param(mod.PERIODS, initialize=lambda m, p: 1000000)
+    mod.Cost_Components_Per_Period.append("administration_fees")

--- a/tests/utilities_test.py
+++ b/tests/utilities_test.py
@@ -12,8 +12,8 @@ import switch_model.solve
 from pyomo.environ import DataPortal
 from testfixtures import compare
 
-class UtilitiesTest(unittest.TestCase):
 
+class UtilitiesTest(unittest.TestCase):
     def test_approx_equal(self):
         assert not utilities.approx_equal(1, 2)
         assert not utilities.approx_equal(1, 1.02)
@@ -22,8 +22,9 @@ class UtilitiesTest(unittest.TestCase):
 
     def test_save_inputs_as_dat(self):
         (model, instance) = switch_model.solve.main(
-            args=["--inputs-dir", os.path.join('examples', '3zone_toy', 'inputs')],
-            return_model=True, return_instance=True
+            args=["--inputs-dir", os.path.join("examples", "3zone_toy", "inputs")],
+            return_model=True,
+            return_instance=True,
         )
         temp_dir = tempfile.mkdtemp(prefix="switch_test_")
         try:
@@ -38,38 +39,39 @@ class UtilitiesTest(unittest.TestCase):
     def test_check_mandatory_components(self):
         from pyomo.environ import ConcreteModel, Param, Set
         from switch_model.utilities import check_mandatory_components
+
         mod = ConcreteModel()
-        mod.set_A = Set(initialize=[1,2])
-        mod.paramA_full = Param(mod.set_A, initialize={1:'a',2:'b'})
+        mod.set_A = Set(initialize=[1, 2])
+        mod.paramA_full = Param(mod.set_A, initialize={1: "a", 2: "b"})
         mod.paramA_empty = Param(mod.set_A)
         mod.set_B = Set()
         mod.paramB_empty = Param(mod.set_B)
         mod.paramC = Param(initialize=1)
         mod.paramD = Param()
-        check_mandatory_components(mod, 'set_A', 'paramA_full')
-        check_mandatory_components(mod, 'paramB_empty')
-        check_mandatory_components(mod, 'paramC')
+        check_mandatory_components(mod, "set_A", "paramA_full")
+        check_mandatory_components(mod, "paramB_empty")
+        check_mandatory_components(mod, "paramC")
         with self.assertRaises(ValueError):
-            check_mandatory_components(mod, 'set_A', 'paramA_empty')
+            check_mandatory_components(mod, "set_A", "paramA_empty")
         with self.assertRaises(ValueError):
-            check_mandatory_components(mod, 'set_A', 'set_B')
+            check_mandatory_components(mod, "set_A", "set_B")
         with self.assertRaises(ValueError):
-            check_mandatory_components(mod, 'paramC', 'paramD')
-
+            check_mandatory_components(mod, "paramC", "paramD")
 
     def test_min_data_check(self):
         from switch_model.utilities import _add_min_data_check
         from pyomo.environ import AbstractModel, Param, Set
+
         mod = AbstractModel()
         _add_min_data_check(mod)
-        mod.set_A = Set(initialize=[1,2])
-        mod.paramA_full = Param(mod.set_A, initialize={1:'a',2:'b'})
+        mod.set_A = Set(initialize=[1, 2])
+        mod.paramA_full = Param(mod.set_A, initialize={1: "a", 2: "b"})
         mod.paramA_empty = Param(mod.set_A)
-        mod.min_data_check('set_A', 'paramA_full')
+        mod.min_data_check("set_A", "paramA_full")
         self.assertIsNotNone(mod.create_instance())
-        mod.min_data_check('set_A', 'paramA_empty')
+        mod.min_data_check("set_A", "paramA_empty")
         # Fiddle with the pyomo logger to suppress its error message
-        logger = logging.getLogger('pyomo.core')
+        logger = logging.getLogger("pyomo.core")
         orig_log_level = logger.level
         logger.setLevel(logging.FATAL)
         with self.assertRaises(ValueError):
@@ -77,5 +79,5 @@ class UtilitiesTest(unittest.TestCase):
         logger.setLevel(orig_log_level)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Hello there!

Through this pull request, I'm proposing that SWITCH use [Black](https://github.com/psf/black), the most used Python code formatter. Here's a description from the Black documentation.

> By using Black, you agree to cede control over minutiae of hand-formatting. In return, Black gives you speed, determinism, and freedom from pycodestyle nagging about formatting. You will save time and mental energy for more important matters.
<br> Black makes code review faster by producing the smallest diffs possible. Blackened code looks the same regardless of the project you’re reading. Formatting becomes transparent after a while and you can focus on the content instead.

Black is managed by the Python Software Foundation, has +20k stars on GitHub and is used by many large projects including the pandas library!

For Switch specifically, it would be great to use Black so that merging changes from downstream forks (e.g. RAEL-Berkley) is easier since formatting would be consistent across both repositories.

This pull request adds black to the dev dependencies and reformats all the Python files according to Black.

