### PR TITLE
fix reporting for carbon_policies.py

### DIFF
--- a/switch_model/policies/carbon_policies.py
+++ b/switch_model/policies/carbon_policies.py
@@ -79,7 +79,7 @@ def post_solve(model, outdir):
                model.carbon_cap_tco2_per_yr[period]]
         # Only print the carbon cap dual value if it exists and if the problem
         # is purely linear.
-        if not model.has_discrete_variables() and model.Enforce_Carbon_Cap[period] in model.dual:
+        if not model.has_discrete_variables() and period in model.Enforce_Carbon_Cap and model.Enforce_Carbon_Cap[period] in model.dual:
             row.append(model.dual[model.Enforce_Carbon_Cap[period]] /
                        model.bring_annual_costs_to_base_year[period])
         else:


### PR DESCRIPTION
Added test for existence of key in get_row in carbon_policies.py to avoid error message when key did not exist and using a social cost of carbon.  Fix suggested by Josiah Johnston.