### PR TITLE
Fix negative maximum contingency in spinning reserves

### DIFF
--- a/switch_model/balancing/operating_reserves/spinning_reserves.py
+++ b/switch_model/balancing/operating_reserves/spinning_reserves.py
@@ -551,6 +551,7 @@ def define_dynamic_components(m):
     """
     m.MaximumContingency = Var(
         m.BALANCING_AREA_TIMEPOINTS,
+        within=NonNegativeReals,
         doc=(
             "Maximum of the registered Spinning_Reserve_Contingencies, after "
             "multiplying by contingency_safety_factor."


### PR DESCRIPTION
Constrains `MaximumContingency` to be non-negative in the spinning reserves module.

When no unit or project contingencies are enabled, `Spinning_Reserve_Contingencies` is empty, but `MaximumContingency` is still included in `Spinning_Reserve_Up_Requirements`. Without a lower bound, solvers can assign a negative value to `MaximumContingency`, which can offset other positive upward reserve requirements.

Tested with `conda run -n switch-env python run_tests.py`.